### PR TITLE
Make TileLayer Implement ITileLayer

### DIFF
--- a/Mapsui/Layers/TileLayer.cs
+++ b/Mapsui/Layers/TileLayer.cs
@@ -36,7 +36,7 @@ namespace Mapsui.Layers
         MemoryCache<Feature> MemoryCache { get; }
     }
 
-    public class TileLayer : BaseLayer
+    public class TileLayer : BaseLayer, ITileLayer
     {
         private TileFetcher _tileFetcher;
         private ITileSource _tileSource;


### PR DESCRIPTION
Corrects issue of Map.Resolutions not returning an empty list when there is only a single item of type TileLayer.
