### PR TITLE
Cleared some parts of Map.CRS and its usage

### DIFF
--- a/Mapsui/Layers/ImageLayer.cs
+++ b/Mapsui/Layers/ImageLayer.cs
@@ -139,8 +139,15 @@ namespace Mapsui.Layers
             _needsUpdate = false;
 
             var newExtent = new BoundingBox(extent);
-            
-            if (Transformation != null && !string.IsNullOrWhiteSpace(CRS)) DataSource.CRS = CRS;
+
+            // TODO: It seems, that this isn't correct. 
+            // Why should DataSource.CRS set to CRS and later (next line) start 
+            // a transformation from DataSource.CRS to CRS?
+            // Perhaps this line should check, if DataSource isn't empty and if 
+            // still, than set it to CRS.
+            // if (Transformation != null && !string.IsNullOrWhiteSpace(CRS)) DataSource.CRS = CRS;
+            if (Transformation != null && string.IsNullOrWhiteSpace(DataSource.CRS) && !string.IsNullOrWhiteSpace(CRS))
+                DataSource.CRS = CRS;
 
             if (ProjectionHelper.NeedsTransform(Transformation, CRS, DataSource.CRS))
                 if (Transformation != null && Transformation.IsProjectionSupported(CRS, DataSource.CRS) == true)

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -66,12 +66,17 @@ namespace Mapsui
         /// </summary>
         public MinMax ZoomLimits { get; set; }
 
-        public string CRS { get; set; }
+        /// <summary>
+        /// Map uses a EPSG:3857 as coordinate system. It couldn't be changed.
+        /// </summary>
+        public string CRS { get; } = "EPSG:3857";
 
         /// <summary>
-        /// The maps coordinate system
+        /// Maps default coordinate transformation system
+        /// MinimalTransformation could be used for transformations 
+        /// from EPSG:3857 (web mercator) to EPSG:4326 (WGS84) and vice versa.
         /// </summary>
-        public ITransformation Transformation { get; set; }
+        public ITransformation Transformation { get; set; } = new MinimalTransformation();
 
         /// <summary>
         /// A collection of layers. The first layer in the list is drawn first, the last one on top.
@@ -246,9 +251,9 @@ namespace Mapsui
         {
             layer.DataChanged += LayerDataChanged;
             layer.PropertyChanged += LayerPropertyChanged;
-
-            layer.Transformation = Transformation;
-            layer.CRS = CRS;
+            // If layer hasn't a Transformation, use MinimalTransformation from Map
+            if (layer.Transformation == null)
+                layer.Transformation = Transformation;
             Resolutions = DetermineResolutions(Layers);
             OnPropertyChanged(nameof(Layers));
         }

--- a/Samples/Mapsui.Samples.Common.Desktop/WmsSample.cs
+++ b/Samples/Mapsui.Samples.Common.Desktop/WmsSample.cs
@@ -7,7 +7,7 @@ namespace Mapsui.Samples.Common.Desktop
     {
         public static Map CreateMap()
         {
-            var map = new Map {CRS = "EPSG:28992"};
+            var map = new Map();
             // The WMS request needs a CRS
             map.Layers.Add(CreateLayer());
             return map;

--- a/Samples/Mapsui.Samples.Common/Maps/ProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/ProjectionSample.cs
@@ -18,7 +18,6 @@ namespace Mapsui.Samples.Common.Maps
             var map = new Map
             {
                 Transformation = new MinimalTransformation(),
-                CRS = "EPSG:3857",
                 BackColor = Color.Gray
             };
             map.Layers.Add(OpenStreetMap.CreateTileLayer());


### PR DESCRIPTION
I worked on the projection problems I see. If there are even more, I can do this too.

What I didn't changed, was, that Map.Info() results (and surely more others) aren't converted back to coordinate system of layer, which would be correct.