### PR TITLE
Added a check, if the native SKGLView is initialized correct

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -225,7 +225,8 @@ namespace Mapsui.UI.Forms
 
         public void RefreshGraphics()
         {
-            RunOnUIThread(() => InvalidateSurface());
+            if (GRContext != null)
+                RunOnUIThread(() => InvalidateSurface());
         }
 
         /// <summary>


### PR DESCRIPTION
Added a check, if the native SKGLView of Forms MapControl is initialized correct. If not, all drawing operations lead to an error and a black screen.

See #570.