### PR TITLE
Added a NeedsRefresh flag to DataChangedEventArgs

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -150,8 +150,6 @@ namespace Mapsui.UI.Forms
                 // Is this a fling or swipe?
                 if (velocityX > 10000 || velocityY > 10000)
                 {
-                    System.Diagnostics.Debug.WriteLine($"Velocity X = {velocityX}, Velocity Y = {velocityY}");
-
                     e.Handled = OnFlinged(velocityX, velocityY);
                 }
 
@@ -428,7 +426,6 @@ namespace Mapsui.UI.Forms
             // Last touch released
             if (touchPoints.Count == 0)
             {
-                RefreshGraphics();
                 _mode = TouchMode.None;
                 _map.RefreshData(_viewport.Extent, _viewport.Resolution, true);
             }

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -201,7 +201,7 @@ namespace Mapsui.UI.Wpf
                     {
                         Logger.Log(LogLevel.Warning, "An error occurred while fetching data", e.Error);
                     }
-                    else // no problems
+                    else if (e.NeedsRefresh) // no problems
                     {
                         RefreshGraphics();
                     }

--- a/Mapsui/Fetcher/IAsyncDataFetcher.cs
+++ b/Mapsui/Fetcher/IAsyncDataFetcher.cs
@@ -38,25 +38,27 @@ namespace Mapsui.Fetcher
 
     public class DataChangedEventArgs : EventArgs
     {
-        public DataChangedEventArgs() : this(null, false, null)
+        public DataChangedEventArgs(bool needsRefresh = true) : this(null, false, null, needsRefresh)
         {
         }
 
-        public DataChangedEventArgs(Exception error, bool cancelled, TileInfo tileInfo)
-            : this(error, cancelled, tileInfo, string.Empty)
+        public DataChangedEventArgs(Exception error, bool cancelled, TileInfo tileInfo, bool needsRefresh = true)
+            : this(error, cancelled, tileInfo, string.Empty, needsRefresh)
         {
         }
 
-        public DataChangedEventArgs(Exception error, bool cancelled, TileInfo tileInfo, string layerName)
+        public DataChangedEventArgs(Exception error, bool cancelled, TileInfo tileInfo, string layerName, bool needsRefresh = true)
         {
             Error = error;
             Cancelled = cancelled;
+            NeedsRefresh = needsRefresh;
             TileInfo = tileInfo;
             LayerName = layerName;
         }
 
         public Exception Error { get; }
         public bool Cancelled { get; }
+        public bool NeedsRefresh { get; } = true;
         public TileInfo TileInfo { get; } // todo: remove
         public string LayerName { get; }
     }

--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -22,7 +22,23 @@ namespace Mapsui.Layers
         /// <param name="layername">Name to use for layer</param>
         public MemoryLayer(string layername) : base(layername) { }
 
-        public IProvider DataSource { get; set; }
+        private IProvider _dataSource;
+
+        public IProvider DataSource
+        {
+            get
+            {
+                return _dataSource;
+            }
+            set
+            {
+                if (_dataSource != value)
+                {
+                    _dataSource = value;
+                    OnDataChanged(new DataChangedEventArgs());
+                }
+            }
+        }
 
         public override IEnumerable<IFeature> GetFeaturesInView(BoundingBox box, double resolution)
         {
@@ -30,7 +46,7 @@ namespace Mapsui.Layers
             if (box == null) { return new List<IFeature>(); }
 
             var biggerBox = box.Grow(SymbolStyle.DefaultWidth * 2 * resolution, SymbolStyle.DefaultHeight * 2 * resolution);
-            return DataSource.GetFeaturesInView(biggerBox, resolution);
+            return _dataSource.GetFeaturesInView(biggerBox, resolution);
         }
 
         public override void RefreshData(BoundingBox extent, double resolution, bool majorChange)
@@ -39,6 +55,6 @@ namespace Mapsui.Layers
             OnDataChanged(new DataChangedEventArgs(false));
         }
 
-        public override BoundingBox Envelope => DataSource?.GetExtents();
+        public override BoundingBox Envelope => _dataSource?.GetExtents();
     }
 }

--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -36,7 +36,7 @@ namespace Mapsui.Layers
         public override void RefreshData(BoundingBox extent, double resolution, bool majorChange)
         {
             //The MemoryLayer always has it's data ready so can fire a DataChanged event immediately so that listeners can act on it.
-            OnDataChanged(new DataChangedEventArgs());
+            OnDataChanged(new DataChangedEventArgs(false));
         }
 
         public override BoundingBox Envelope => DataSource?.GetExtents();


### PR DESCRIPTION
Added a NeedsRefresh flag to DataChangedEventArgs. With this, it is possible, that MemoryLayer isn't refreshed all the time.
Removed a debug WriteLine for Forms implementation.