### PR TITLE
Cleared any touch events when size of Forms MapControl changed

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -91,11 +91,18 @@ namespace Mapsui.UI.Forms
 
             PaintSurface += OnPaintSurface;
             Touch += OnTouch;
-            SizeChanged += OnSizeChanged; 
+            SizeChanged += OnSizeChanged;
+            Unfocused += OnUnfocused;
+        }
+
+        private void OnUnfocused(object sender, FocusEventArgs e)
+        {
+            _fingers.Clear();
         }
 
         private void OnSizeChanged(object sender, EventArgs e)
         {
+            _fingers.Clear();
             SetViewportSize();
         }
 


### PR DESCRIPTION
Cleared any touch events when size of Forms MapControl changed (e.g. home button is pressed)