### PR TITLE
Forms MapControl Fixes

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -150,7 +150,7 @@ namespace Mapsui.UI.Forms
                 // Is this a fling or swipe?
                 if (_touches.Count == 0)
                 {
-                    if (velocityX > 10000 || velocityY > 10000)
+                    if (Math.Abs(velocityX) > 10000 || Math.Abs(velocityY) > 10000)
                     {
                         // This was the last finger on screen, so this is a fling
                         e.Handled = OnFlinged(velocityX, velocityY);


### PR DESCRIPTION
@charlenni I finally have some time to play around with the forms side of mapsui, just updated to the beta to get started converting our mapsui usage over to v2. Have found a few issues that I have had to get around in hacky ways that we could discuss?

First is just a bug:

- Add math.abs around velocity decision for flight as it would only allow fling in specific directions. Only certain fling directions were allowed based on the logic.

Ideas:

- I have implemented double tap zoom using the xamarin.forms animation library that I could bring into this. When double tapping somewhere on the screen it will zoom about that point smootly over a short time.

- I am also reimplimenting fling also using the xamarin.forms library (although I am having issues with this compared with the native guesture recognisers). This could also be brought in to enable natual fling movements on the map if I can get it working. I am finding the flings are pretty long


I am only using the MapControl as the other one is pretty limiting. Have you seen the tearing issues when playing around with the mapcontrol?