### PR TITLE
Fix info event on forms version and fix fling velocity in forms

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -142,14 +142,14 @@ namespace Mapsui.UI.Forms
                 var releasedTouch = _touches[e.Id];
                 _touches.Remove(e.Id);
 
-                double velocityX;
-                double velocityY;
-
-                (velocityX, velocityY) = _velocityTracker.CalcVelocity(e.Id, ticks);
-
                 // Is this a fling or swipe?
                 if (_touches.Count == 0)
                 {
+                    double velocityX;
+                    double velocityY;
+
+                    (velocityX, velocityY) = _velocityTracker.CalcVelocity(e.Id, ticks);
+
                     if (Math.Abs(velocityX) > 200 || Math.Abs(velocityY) > 200)
                     {
                         // This was the last finger on screen, so this is a fling

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -579,10 +579,13 @@ namespace Mapsui.UI.Forms
             if (args.Handled)
                 return true;
 
-            var eventReturn = InvokeInfo(screenPosition, screenPosition, 1);
+            var infoToInvoke = InvokeInfo(screenPosition, screenPosition, 1);
 
-            if (eventReturn != null)
-                return eventReturn.Handled;
+            if (infoToInvoke != null && !infoToInvoke.Handled)
+            {
+                OnInfo(infoToInvoke);
+                return infoToInvoke.Handled;
+            }
 
             return false;
         }

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -580,14 +580,9 @@ namespace Mapsui.UI.Forms
                 return true;
 
             var infoToInvoke = InvokeInfo(screenPosition, screenPosition, 1);
-
-            if (infoToInvoke != null && !infoToInvoke.Handled)
-            {
-                OnInfo(infoToInvoke);
-                return infoToInvoke.Handled;
-            }
-
-            return false;
+                        
+            OnInfo(infoToInvoke);
+            return infoToInvoke?.Handled ?? false;
         }
 
         /// <summary>

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -52,7 +52,7 @@ namespace Mapsui.UI.Forms
         private Geometries.Point _firstTouch;
         private System.Threading.Timer _doubleTapTestTimer;
         private int _numOfTaps = 0;
-        private VelocityTracker _velocityTracker = new VelocityTracker();
+        private FlingTracker _velocityTracker = new FlingTracker();
         private Geometries.Point _previousCenter;
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace Mapsui.UI.Forms
                 // Is this a fling or swipe?
                 if (_touches.Count == 0)
                 {
-                    if (Math.Abs(velocityX) > 10000 || Math.Abs(velocityY) > 10000)
+                    if (Math.Abs(velocityX) > 200 || Math.Abs(velocityY) > 200)
                     {
                         // This was the last finger on screen, so this is a fling
                         e.Handled = OnFlinged(velocityX, velocityY);
@@ -198,6 +198,8 @@ namespace Mapsui.UI.Forms
                             e.Handled = OnLongTapped(location);
                     }
                 }
+
+                _velocityTracker.RemoveId(e.Id);
 
                 if (_touches.Count == 1)
                 {
@@ -616,7 +618,7 @@ namespace Mapsui.UI.Forms
             centerX = centerX / locations.Count;
             centerY = centerY / locations.Count;
 
-            var radius = Geometries.Utilities.Algorithms.Distance(centerX, centerY, locations[0].X, locations[0].Y);
+            var radius = Algorithms.Distance(centerX, centerY, locations[0].X, locations[0].Y);
 
             var angle = Math.Atan2(locations[1].Y - locations[0].Y, locations[1].X - locations[0].X) * 180.0 / Math.PI;
 

--- a/Mapsui.UI.Forms/Utils/FlingTracker.cs
+++ b/Mapsui.UI.Forms/Utils/FlingTracker.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Mapsui.UI.Utils
+{
+    public class FlingTracker
+    {
+        const int maxSize = 2;
+        const long maxTicks = 200 * 10000;  // Use only events from the last 200 ms
+
+        readonly Dictionary<long, Queue<(double x, double y, long time)>> events;
+
+        public FlingTracker()
+        {
+            events = new Dictionary<long, Queue<(double x, double y, long time)>>();
+        }
+
+        public void AddEvent(long id, Geometries.Point location, long ticks)
+        {
+            // Save event data
+            if (!events.ContainsKey(id))
+            {
+                events.Add(id, new Queue<(double x, double y, long time)>());
+            }
+
+            events[id].Enqueue((location.X, location.Y, ticks));
+            
+            // Check, if we at the end of array
+            if (events[id].Count > maxSize)
+            {
+                events[id].Dequeue();
+            }
+        }
+
+        // STOP TRACKING THIS ONE
+        public void RemoveId(long id)
+        {
+            if (events.ContainsKey(id))
+            {
+                events.Remove(id);
+            }
+        }
+
+        public void Clear()
+        {
+            events.Clear();
+        }
+
+        public (double vx, double vy) CalcVelocity(long id, long now)
+        {
+            double velocityX = 0;
+            double velocityY = 0;
+
+            if (!events.ContainsKey(id) || events[id].Count != 2)
+                return (0d, 0d);
+
+            var eventQueue = events[id];
+            var eventsArray = eventQueue.ToArray();
+
+            (var lastX, var lastY, var lastTime) = eventsArray[0];
+            (var nowX, var nowY, var nowTime) = eventsArray[1];
+
+            // Only calc velocities for last maxTicks ticks
+            if (now - lastTime < maxTicks)
+            {
+                // Calc velocity in pixel per sec
+                velocityX = (nowX - lastX) * 10000000 / (nowTime - lastTime);
+                velocityY = (nowY - lastY) * 10000000 / (nowTime - lastTime);
+            }
+            
+            return (velocityX, velocityY);
+        }
+    }
+}


### PR DESCRIPTION
The info event never got called in the forms map control. This calls it if it exists, to keep the same logic as the native versions.