### PR TITLE
Save list of pins in handlers because of race conditions

### DIFF
--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -623,9 +623,10 @@ namespace Mapsui.UI.Forms
 
                 // Check all callout positions
                 var list = _callouts.ToList();
+                var pins = _pins.ToList();
 
                 // First check all Callouts, that belong to a pin
-                foreach (var pin in _pins)
+                foreach (var pin in pins)
                 {
                     if (pin.Callout != null)
                     {
@@ -733,8 +734,9 @@ namespace Mapsui.UI.Forms
         {
             // Click on pin?
             Pin clickedPin = null;
+            var pins = _pins.ToList();
 
-            foreach (var pin in _pins)
+            foreach (var pin in pins)
             {
                 if (pin.IsVisible && pin.Feature.Equals(e.MapInfo.Feature))
                 {
@@ -797,9 +799,10 @@ namespace Mapsui.UI.Forms
         {
             // Close all closable Callouts
             var list = _callouts.ToList();
+            var pins = _pins.ToList();
 
             // First check all Callouts, that belong to a pin
-            foreach (var pin in _pins)
+            foreach (var pin in pins)
             {
                 if (pin.Callout != null)
                 {


### PR DESCRIPTION
See #654.

Perhaps #653 has the same background, but in Map.GetWidgetsOfMapAndLayers().