### PR TITLE
Changed setter of Navigator in MapControl

### DIFF
--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -95,8 +95,12 @@ namespace Mapsui.UI.Wpf
         public INavigator Navigator
         {
             get => _navigator;
-            private set
+            set
             {
+                if (_navigator != null)
+                {
+                    _navigator.Navigated -= Navigated;
+                }
                 _navigator = value ?? throw new ArgumentException($"{nameof(Navigator)} can not be null");
                 _navigator.Navigated += Navigated;
             }


### PR DESCRIPTION
Changed setter of Navigator in MapControl from private to public, so that it is possible to use own implementations of INavigator.