### PR TITLE
Exposed some more events on MapView for Forms

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -29,9 +29,6 @@ namespace Mapsui.UI.Forms
             }
         }
 
-        private const int None = 0;
-        private const int Dragging = 1;
-        private const int Zooming = 2;
         // See http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/4.0.4_r2.1/android/view/ViewConfiguration.java#ViewConfiguration.0PRESSED_STATE_DURATION for values
         private const int shortTap = 125;
         private const int shortClick = 250;

--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -69,7 +69,14 @@ namespace Mapsui.UI.Forms
             _mapControl.SingleTap += HandlerTap;
             _mapControl.DoubleTap += HandlerTap;
             _mapControl.LongTap += HandlerLongTap;
-            _mapControl.Hovered += HandlerHover;
+            _mapControl.Hovered += HandlerHovered;
+            _mapControl.TouchStarted += HandlerTouchStarted;
+            _mapControl.TouchEnded += HandlerTouchEnded;
+            _mapControl.TouchMove += HandlerTouchMove;
+            _mapControl.Swipe += HandlerSwipe;
+            _mapControl.Fling += HandlerFling;
+            _mapControl.Zoomed += HandlerZoomed;
+
             _mapControl.TouchMove += (s, e) =>
             {
                 Device.BeginInvokeOnMainThread(() => MyLocationFollow = false);
@@ -176,6 +183,56 @@ namespace Mapsui.UI.Forms
         /// Occurs when map long clicked
         /// </summary>
         public event EventHandler<MapLongClickedEventArgs> MapLongClicked;
+
+        /// <summary>
+        /// TouchStart is called, when user press a mouse button or touch the display
+        /// </summary>
+        public event EventHandler<TouchedEventArgs> TouchStarted;
+
+        /// <summary>
+        /// TouchEnd is called, when user release a mouse button or doesn't touch display anymore
+        /// </summary>
+        public event EventHandler<TouchedEventArgs> TouchEnded;
+
+        /// <summary>
+        /// TouchMove is called, when user move mouse over map (independent from mouse button state) or move finger on display
+        /// </summary>
+        public event EventHandler<TouchedEventArgs> TouchMove;
+
+        /// <summary>
+        /// Hovered is called, when user move mouse over map without pressing mouse button
+        /// </summary>
+        public event EventHandler<HoveredEventArgs> Hovered;
+
+        /// <summary>
+        /// Swipe is called, when user release mouse button or lift finger while moving with a certain speed 
+        /// </summary>
+        public event EventHandler<SwipedEventArgs> Swipe;
+
+        /// <summary>
+        /// Fling is called, when user release mouse button or lift finger while moving with a certain speed, higher than speed of swipe 
+        /// </summary>
+        public event EventHandler<SwipedEventArgs> Fling;
+
+        /// <summary>
+        /// SingleTap is called, when user clicks with a mouse button or tap with a finger on map 
+        /// </summary>
+        public event EventHandler<TappedEventArgs> SingleTap;
+
+        /// <summary>
+        /// LongTap is called, when user clicks with a mouse button or tap with a finger on map for 500 ms
+        /// </summary>
+        public event EventHandler<TappedEventArgs> LongTap;
+
+        /// <summary>
+        /// DoubleTap is called, when user clicks with a mouse button or tap with a finger two or more times on map
+        /// </summary>
+        public event EventHandler<TappedEventArgs> DoubleTap;
+
+        /// <summary>
+        /// Zoom is called, when map should be zoomed
+        /// </summary>
+        public event EventHandler<ZoomedEventArgs> Zoomed;
 
         /// <inheritdoc />
         public event EventHandler ViewportInitialized;
@@ -725,8 +782,9 @@ namespace Mapsui.UI.Forms
             Refresh();
         }
 
-        private void HandlerHover(object sender, HoveredEventArgs e)
+        private void HandlerHovered(object sender, HoveredEventArgs e)
         {
+            Hovered?.Invoke(sender, e);
         }
 
         private void HandlerInfo(object sender, MapInfoEventArgs e)
@@ -844,6 +902,36 @@ namespace Mapsui.UI.Forms
                 // A feature is clicked
                 HandlerInfo(sender, new MapInfoEventArgs { MapInfo = mapInfo, Handled = e.Handled, NumTaps = e.NumOfTaps });
             }
+        }
+
+        private void HandlerZoomed(object sender, ZoomedEventArgs e)
+        {
+            Zoomed?.Invoke(sender, e);
+        }
+
+        private void HandlerFling(object sender, SwipedEventArgs e)
+        {
+            Fling?.Invoke(sender, e);
+        }
+
+        private void HandlerSwipe(object sender, SwipedEventArgs e)
+        {
+            Swipe?.Invoke(sender, e);
+        }
+
+        private void HandlerTouchEnded(object sender, TouchedEventArgs e)
+        {
+            TouchEnded?.Invoke(sender, e);
+        }
+
+        private void HandlerTouchMove(object sender, TouchedEventArgs e)
+        {
+            TouchMove?.Invoke(sender, e);
+        }
+
+        private void HandlerTouchStarted(object sender, TouchedEventArgs e)
+        {
+            TouchStarted?.Invoke(sender, e);
         }
 
         private void HandlerPinPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
Perhaps the event "Zoomed" from shared MapControl ist misleading. It suggest, that it is called, when the map is zommed, but in real life it is called, when the map should zoom in or out. Perhaps this event should better called "Zooming". 