### PR TITLE
Sealed classes cannot be parent of custom extended implementation

### DIFF
--- a/Mapsui.UI.Forms/Objects/Circle.cs
+++ b/Mapsui.UI.Forms/Objects/Circle.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace Mapsui.UI.Forms
 {
-    public sealed class Circle : Drawable
+    public class Circle : Drawable
     {
         public static readonly BindableProperty CenterProperty = BindableProperty.Create(nameof(Center), typeof(Position), typeof(Circle), default(Position));
         public static readonly BindableProperty RadiusProperty = BindableProperty.Create(nameof(Radius), typeof(Distance), typeof(Circle), Distance.FromMeters(1));

--- a/Mapsui.UI.Forms/Objects/Circle.cs
+++ b/Mapsui.UI.Forms/Objects/Circle.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace Mapsui.UI.Forms
 {
-    public class Circle : Drawable
+    public sealed class Circle : Drawable
     {
         public static readonly BindableProperty CenterProperty = BindableProperty.Create(nameof(Center), typeof(Position), typeof(Circle), default(Position));
         public static readonly BindableProperty RadiusProperty = BindableProperty.Create(nameof(Radius), typeof(Distance), typeof(Circle), Distance.FromMeters(1));

--- a/Mapsui.UI.Forms/Objects/MapSpan.cs
+++ b/Mapsui.UI.Forms/Objects/MapSpan.cs
@@ -6,7 +6,7 @@ namespace Mapsui.UI.Forms
     /// <summary>
     /// MapSpan represents an area of the earth
     /// </summary>
-    public sealed class MapSpan
+    public class MapSpan
     {
         /// <summary>
         /// Radius of earth in EPSG:4327 in kilometers

--- a/Mapsui.UI.Forms/Objects/MapSpan.cs
+++ b/Mapsui.UI.Forms/Objects/MapSpan.cs
@@ -6,7 +6,7 @@ namespace Mapsui.UI.Forms
     /// <summary>
     /// MapSpan represents an area of the earth
     /// </summary>
-    public class MapSpan
+    public sealed class MapSpan
     {
         /// <summary>
         /// Radius of earth in EPSG:4327 in kilometers

--- a/Mapsui.UI.Forms/Objects/Pin.cs
+++ b/Mapsui.UI.Forms/Objects/Pin.cs
@@ -12,7 +12,7 @@ using Xamarin.Forms;
 
 namespace Mapsui.UI.Forms
 {
-    public sealed class Pin : BindableObject, IFeatureProvider
+    public class Pin : BindableObject, IFeatureProvider
     {
         private int _bitmapId = -1;
         private byte[] _bitmapData;

--- a/Mapsui.UI.Forms/Objects/Pin.cs
+++ b/Mapsui.UI.Forms/Objects/Pin.cs
@@ -12,7 +12,7 @@ using Xamarin.Forms;
 
 namespace Mapsui.UI.Forms
 {
-    public class Pin : BindableObject, IFeatureProvider
+    public sealed class Pin : BindableObject, IFeatureProvider
     {
         private int _bitmapId = -1;
         private byte[] _bitmapData;

--- a/Mapsui.UI.Forms/Objects/Polygon.cs
+++ b/Mapsui.UI.Forms/Objects/Polygon.cs
@@ -12,7 +12,7 @@ using Xamarin.Forms;
 
 namespace Mapsui.UI.Forms
 {
-    public sealed class Polygon : Drawable
+    public class Polygon : Drawable
     {
         public static readonly BindableProperty FillColorProperty = BindableProperty.Create(nameof(FillColor), typeof(Xamarin.Forms.Color), typeof(Polygon), Xamarin.Forms.Color.DarkGray);
 

--- a/Mapsui.UI.Forms/Objects/Polygon.cs
+++ b/Mapsui.UI.Forms/Objects/Polygon.cs
@@ -12,7 +12,7 @@ using Xamarin.Forms;
 
 namespace Mapsui.UI.Forms
 {
-    public class Polygon : Drawable
+    public sealed class Polygon : Drawable
     {
         public static readonly BindableProperty FillColorProperty = BindableProperty.Create(nameof(FillColor), typeof(Xamarin.Forms.Color), typeof(Polygon), Xamarin.Forms.Color.DarkGray);
 

--- a/Mapsui.UI.Forms/Objects/Polyline.cs
+++ b/Mapsui.UI.Forms/Objects/Polyline.cs
@@ -11,7 +11,7 @@ using System.Runtime.CompilerServices;
 
 namespace Mapsui.UI.Forms
 {
-    public sealed class Polyline : Drawable
+    public class Polyline : Drawable
     {
         private readonly ObservableCollection<Position> _positions = new ObservableCollection<Position>();
 

--- a/Mapsui.UI.Forms/Objects/Polyline.cs
+++ b/Mapsui.UI.Forms/Objects/Polyline.cs
@@ -11,7 +11,7 @@ using System.Runtime.CompilerServices;
 
 namespace Mapsui.UI.Forms
 {
-    public class Polyline : Drawable
+    public sealed class Polyline : Drawable
     {
         private readonly ObservableCollection<Position> _positions = new ObservableCollection<Position>();
 


### PR DESCRIPTION
Hello, 

Thanks for the Mapsui, we use it in our project :)
We have encountered on a problem whereas we cannot extend implementation of Pins, Circles, Polygons etc. as it is marked sealed. Is there any meaning behind this? 

Thanks,
Sebastian 