### PR TITLE
Create Callout on main thread

### DIFF
--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -518,10 +518,13 @@ namespace Mapsui.UI.Forms
         /// <param name="position">Position of callout</param>
         public Callout CreateCallout(Position position)
         {
-            _callout = new Callout(_mapControl)
+            Device.BeginInvokeOnMainThread(() =>
             {
-                Anchor = position
-            };
+                _callout = new Callout(_mapControl)
+                {
+                    Anchor = position
+                };
+            });
 
             // My interpretation (PDD): This while keeps looping until the asynchronous call
             // above has created a callout.

--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -518,6 +518,7 @@ namespace Mapsui.UI.Forms
         /// <param name="position">Position of callout</param>
         public Callout CreateCallout(Position position)
         {
+            // In Forms.UWP, the Callout needs to be created on the UI Thread
             Device.BeginInvokeOnMainThread(() =>
             {
                 _callout = new Callout(_mapControl)


### PR DESCRIPTION
This PR is solves a thread issue in UWP when creating a PIN.

Creating a PIN in UWP throws a thread exception. In UWP we need the creation of UI elements to be done on the UI thread. 

The exception occurs when creating `Label` as a part of the Callout
![image](https://user-images.githubusercontent.com/1128034/72016128-7982fc80-3263-11ea-898b-3c496254076f.png)

If we ignore the font settings of the label, everything works fine (except the missing font settings)
![image](https://user-images.githubusercontent.com/1128034/72016354-ea2a1900-3263-11ea-98fb-9a424967122d.png)

Instead of ignoring Font settings on the labels, we can run the Callout creation on the UI Thread. I believe this is only necessary in UWP. This PR uses this solution.
![image](https://user-images.githubusercontent.com/1128034/72016513-3412ff00-3264-11ea-964b-4885b27156cc.png)

