### PR TITLE
Added two more image formats for symbols:

### DIFF
--- a/Mapsui.Rendering.Skia/BitmapHelper.cs
+++ b/Mapsui.Rendering.Skia/BitmapHelper.cs
@@ -32,10 +32,17 @@ namespace Mapsui.Rendering.Skia
                 var image = SKImage.FromEncodedData(SKData.CreateCopy(stream.ToBytes()));
                 return new BitmapInfo {Bitmap = image};
             }
-
-            if (bitmapStream is Sprite sprite)
+            else if (bitmapStream is Sprite sprite)
             {
                 return new BitmapInfo {Sprite = sprite};
+            }
+            else if (bitmapStream is SKPicture picture)
+            {
+                return new BitmapInfo { Picture = picture };
+            }
+            if (bitmapStream is SKDrawable drawable)
+            {
+                return new BitmapInfo { Drawable = drawable };
             }
 
             return null;
@@ -91,6 +98,55 @@ namespace Mapsui.Rendering.Skia
             canvas.Translate(-halfWidth + offsetX, -halfHeight - offsetY);
 
             canvas.DrawPicture(svg.Picture);
+
+            canvas.Restore();
+        }
+
+
+        public static void RenderPicture(SKCanvas canvas, SKPicture picture, float x, float y, float orientation = 0,
+            float offsetX = 0, float offsetY = 0,
+            LabelStyle.HorizontalAlignmentEnum horizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
+            LabelStyle.VerticalAlignmentEnum verticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
+            float opacity = 1f,
+            float scale = 1f)
+        {
+            canvas.Save();
+
+            canvas.Translate(x, y);
+            canvas.RotateDegrees(orientation, 0, 0); // todo: degrees or radians?
+            canvas.Scale(scale, scale);
+
+            var halfWidth = picture.CullRect.Width / 2;
+            var halfHeight = picture.CullRect.Height / 2;
+
+            // 0/0 are assumed at center of image, but SKPicture has 0/0 at left top position
+            canvas.Translate(-halfWidth + offsetX, -halfHeight - offsetY);
+
+            canvas.DrawPicture(picture);
+
+            canvas.Restore();
+        }
+
+        public static void RenderDrawable(SKCanvas canvas, SKDrawable drawable, float x, float y, float orientation = 0,
+            float offsetX = 0, float offsetY = 0,
+            LabelStyle.HorizontalAlignmentEnum horizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
+            LabelStyle.VerticalAlignmentEnum verticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
+            float opacity = 1f,
+            float scale = 1f)
+        {
+            canvas.Save();
+
+            canvas.Translate(x, y);
+            canvas.RotateDegrees(orientation, 0, 0); // todo: degrees or radians?
+            canvas.Scale(scale, scale);
+
+            var halfWidth = drawable.Bounds.Width / 2;
+            var halfHeight = drawable.Bounds.Height / 2;
+
+            // 0/0 are assumed at center of image, but SKDrawable has 0/0 at left top position
+            canvas.Translate(-halfWidth + offsetX, -halfHeight - offsetY);
+
+            canvas.DrawDrawable(drawable, 0, 0);
 
             canvas.Restore();
         }

--- a/Mapsui.Rendering.Skia/BitmapInfo.cs
+++ b/Mapsui.Rendering.Skia/BitmapInfo.cs
@@ -7,7 +7,9 @@ namespace Mapsui.Rendering.Skia
     {
         Bitmap,
         Svg,
-        Sprite
+        Sprite,
+        Picture,
+        Drawable
     }
 
     public class BitmapInfo
@@ -64,6 +66,38 @@ namespace Mapsui.Rendering.Skia
             }
         }
 
+        public SKPicture Picture
+        {
+            get
+            {
+                if (Type == BitmapType.Picture)
+                    return (SKPicture)_data;
+                else
+                    return null;
+            }
+            set
+            {
+                _data = value;
+                Type = BitmapType.Picture;
+            }
+        }
+
+        public SKDrawable Drawable
+        {
+            get
+            {
+                if (Type == BitmapType.Drawable)
+                    return (SKDrawable)_data;
+                else
+                    return null;
+            }
+            set
+            {
+                _data = value;
+                Type = BitmapType.Drawable;
+            }
+        }
+
         public long IterationUsed { get; set; }
 
         public float Width
@@ -78,6 +112,10 @@ namespace Mapsui.Rendering.Skia
                         return Svg.CanvasSize.Width;
                     case BitmapType.Sprite:
                         return ((Sprite) _data).Width;
+                    case BitmapType.Picture:
+                        return ((SKPicture)_data).CullRect.Width;
+                    case BitmapType.Drawable:
+                        return ((SKDrawable)_data).Bounds.Width;
                     default:
                         return 0;
                 }
@@ -96,6 +134,10 @@ namespace Mapsui.Rendering.Skia
                         return Svg.CanvasSize.Height;
                     case BitmapType.Sprite:
                         return ((Sprite) _data).Height;
+                    case BitmapType.Picture:
+                        return ((SKPicture)_data).CullRect.Height;
+                    case BitmapType.Drawable:
+                        return ((SKDrawable)_data).Bounds.Height;
                     default:
                         return 0;
                 }

--- a/Mapsui.Rendering.Skia/PointRenderer.cs
+++ b/Mapsui.Rendering.Skia/PointRenderer.cs
@@ -205,6 +205,20 @@ namespace Mapsui.Rendering.Skia
                         (float)offsetX, (float)offsetY,
                         opacity: opacity, scale: (float)symbolStyle.SymbolScale);
                     break;
+                case BitmapType.Picture:
+                    BitmapHelper.RenderPicture(canvas, bitmap.Picture,
+                        (float)destination.X, (float)destination.Y,
+                        rotation,
+                        (float)offsetX, (float)offsetY,
+                        opacity: opacity, scale: (float)symbolStyle.SymbolScale);
+                    break;
+                case BitmapType.Drawable:
+                    BitmapHelper.RenderDrawable(canvas, bitmap.Drawable,
+                        (float)destination.X, (float)destination.Y,
+                        rotation,
+                        (float)offsetX, (float)offsetY,
+                        opacity: opacity, scale: (float)symbolStyle.SymbolScale);
+                    break;
             }
         }
     }

--- a/Samples/Mapsui.Samples.Common/Maps/DrawableSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/DrawableSample.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Mapsui.Geometries;
+using Mapsui.Layers;
+using Mapsui.Providers;
+using Mapsui.Samples.Common.Helpers;
+using Mapsui.Styles;
+using Mapsui.UI;
+using Mapsui.Utilities;
+using SkiaSharp;
+
+namespace Mapsui.Samples.Common.Maps
+{
+    public class DrawableSample : ISample
+    {
+        private const string DrawableLayerName = "Drawable Layer";
+        private static readonly Random Random = new Random();
+
+        public string Name => "Drawable";
+
+        public string Category => "Symbols";
+
+        public void Setup(IMapControl mapControl)
+        {
+            mapControl.Map = CreateMap();
+        }
+
+        public static Map CreateMap()
+        {
+            var map = new Map();
+
+            map.Layers.Add(OpenStreetMap.CreateTileLayer());
+            map.Layers.Add(CreateDrawableLayer(map.Envelope));
+           
+            return map;
+        }
+
+        private static ILayer CreateDrawableLayer(BoundingBox envelope)
+        {
+            return new MemoryLayer
+            {
+                Name = DrawableLayerName,
+                DataSource = CreateMemoryProviderWithDiverseSymbols(envelope, 10),
+                Style = null,
+                IsMapInfoLayer = true
+            };
+        }
+
+        public static MemoryProvider CreateMemoryProviderWithDiverseSymbols(BoundingBox envelope, int count = 100)
+        {
+            return new MemoryProvider(CreateDrawableFeatures(RandomPointHelper.GenerateRandomPoints(envelope, count)));
+        }
+
+        private static Features CreateDrawableFeatures(IEnumerable<IGeometry> randomPoints)
+        {
+            var features = new Features();
+            var counter = 0;
+            foreach (var point in randomPoints)
+            {
+                var feature = new Feature { Geometry = point, ["Label"] = counter.ToString() };
+
+                feature.Styles.Add(new VectorStyle() { Line = new Pen(Color.Black) });
+
+                var drawable = new Drawable();
+                var bitmapId = BitmapRegistry.Instance.Register(drawable);
+                feature.Styles.Add(new SymbolStyle { BitmapId = bitmapId });
+
+                features.Add(feature);
+                counter++;
+            }
+            return features;
+        }
+    }
+
+    public class Drawable : SKDrawable
+    {
+        private static readonly Random Random = new Random();
+
+        public Drawable() : base (true)
+        { }
+
+        protected override SKRect OnGetBounds()
+        {
+            return new SKRect(0, 0, 63, 63);
+        }
+
+        protected override void OnDraw(SKCanvas canvas)
+        {
+            base.OnDraw(canvas);
+
+            canvas.DrawRect(new SKRect(0, 0, 63, 63), new SKPaint() { Color = SKColors.Black, StrokeWidth = 1, Style = SKPaintStyle.Stroke });
+
+            var paint = new SKPaint() { Color = new SKColor((byte)Random.Next(0,255), (byte)Random.Next(0, 255), (byte)Random.Next(0, 255)), StrokeWidth = 1 };
+            var lastX = Random.Next(0, 63);
+            var lastY = Random.Next(0, 63);
+            for (var i = 0; i < 4; i++)
+            {
+                var x = Random.Next(0, 63);
+                var y = Random.Next(0, 63);
+                canvas.DrawLine(new SKPoint(lastX, lastY), new SKPoint(x, y), paint);
+                lastX = x;
+                lastY = y;
+            }
+        }
+
+        protected override SKPicture OnSnapshot()
+        {
+            var rec = new SKPictureRecorder();
+            var canvas = rec.BeginRecording(OnGetBounds());
+            OnDraw(canvas);
+            return rec.EndRecording();
+        }
+    }
+}

--- a/Samples/Mapsui.Samples.Common/Maps/PictureSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/PictureSample.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Mapsui.Geometries;
+using Mapsui.Layers;
+using Mapsui.Providers;
+using Mapsui.Samples.Common.Helpers;
+using Mapsui.Styles;
+using Mapsui.UI;
+using Mapsui.Utilities;
+using SkiaSharp;
+
+namespace Mapsui.Samples.Common.Maps
+{
+    public class PictureSample : ISample
+    {
+        private const string PictureLayerName = "Picture Layer";
+        private static readonly Random Random = new Random();
+
+        public string Name => "Picture";
+
+        public string Category => "Symbols";
+
+        public void Setup(IMapControl mapControl)
+        {
+            mapControl.Map = CreateMap();
+        }
+
+        public static Map CreateMap()
+        {
+            var map = new Map();
+
+            map.Layers.Add(OpenStreetMap.CreateTileLayer());
+            map.Layers.Add(CreatePictureLayer(map.Envelope));
+           
+            return map;
+        }
+
+        private static ILayer CreatePictureLayer(BoundingBox envelope)
+        {
+            return new MemoryLayer
+            {
+                Name = PictureLayerName,
+                DataSource = CreateMemoryProviderWithDiverseSymbols(envelope, 10),
+                Style = null,
+                IsMapInfoLayer = true
+            };
+        }
+
+        public static MemoryProvider CreateMemoryProviderWithDiverseSymbols(BoundingBox envelope, int count = 100)
+        {
+            return new MemoryProvider(CreatePictureFeatures(RandomPointHelper.GenerateRandomPoints(envelope, count)));
+        }
+
+        private static Features CreatePictureFeatures(IEnumerable<IGeometry> randomPoints)
+        {
+            var features = new Features();
+            var counter = 0;
+            foreach (var point in randomPoints)
+            {
+                var feature = new Feature { Geometry = point, ["Label"] = counter.ToString() };
+
+                var rec = new SKPictureRecorder();
+                var canvas = rec.BeginRecording(new SKRect(0, 0, 64, 64));
+                var paint = new SKPaint() { Color = SKColors.Red, StrokeWidth = 1 };
+                var lastX = Random.Next(0, 63);
+                var lastY = Random.Next(0, 63);
+                for (var i = 0; i < 4; i++)
+                {
+                    var x = Random.Next(0, 63);
+                    var y = Random.Next(0, 63);
+                    canvas.DrawLine(new SKPoint(lastX, lastY), new SKPoint(x, y), paint);
+                    lastX = x;
+                    lastY = y;
+                }
+                var pic = rec.EndRecording();
+                var bitmapId = BitmapRegistry.Instance.Register(pic);
+                feature.Styles.Add(new SymbolStyle { BitmapId = bitmapId });
+
+                features.Add(feature);
+                counter++;
+            }
+            return features;
+        }
+    }
+}


### PR DESCRIPTION
1. SKPicture: SKPictures are in Skia recorded draw commands, which are than drawn onto the canvas.
2. SKDrawable: SKDrawable are objects, that draw themselfs onto a canvas. They have a OnDraw function, which gets a canvas for this. This is called, each time new.
Added two samples for this new functionalities.

The Drawable sample is a funny thing. The symbol is created new, each time the map gets a draw command. With that, it looks like a Qix opponent ;-) And you could see, how often the map is drawn.