### PR TITLE
New callout create uwp fix

### DIFF
--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -511,33 +511,6 @@ namespace Mapsui.UI.Forms
 
         private Callout _callout;
 
-        /// <summary>
-        /// Creates a callout at the given position
-        /// </summary>
-        /// <returns>The callout</returns>
-        /// <param name="position">Position of callout</param>
-        public Callout CreateCallout(Position position)
-        {
-            // In Forms.UWP, the Callout needs to be created on the UI Thread
-            Device.BeginInvokeOnMainThread(() =>
-            {
-                _callout = new Callout(_mapControl)
-                {
-                    Anchor = position
-                };
-            });
-
-            // My interpretation (PDD): This while keeps looping until the asynchronous call
-            // above has created a callout.
-            // An alternative might be to avoid CreateCallout from a non-ui thread by throwing
-            // early.
-            while (_callout == null) ;
-
-            var result = _callout;
-            _callout = null;
-
-            return result;
-        }
 
         /// <summary>
         /// Shows given callout

--- a/Mapsui.UI.Forms/Objects/Pin.cs
+++ b/Mapsui.UI.Forms/Objects/Pin.cs
@@ -243,7 +243,11 @@ namespace Mapsui.UI.Forms
                 if (_callout == null)
                 {
                     // Create a default pin
-                    _callout = _mapView.CreateCallout(Position);
+                    //_callout = _mapView.CreateCallout(Position);
+                    _callout = new Callout(this._mapView.MapControl as MapControl)
+                    {
+                        Anchor = Position
+                    };
                     if (string.IsNullOrWhiteSpace(Address))
                     {
                         _callout.Type = CalloutType.Single;

--- a/Mapsui.sln
+++ b/Mapsui.sln
@@ -1,6 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29215.179
+VisualStudioVersion = 16.0.29025.244
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapsui", "Mapsui\Mapsui.csproj", "{D74C052A-C07E-4B37-A898-134218ACA5C9}"
 EndProject

--- a/Samples/Mapsui.Samples.Common/Maps/BingSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/BingSample.cs
@@ -15,11 +15,11 @@ namespace Mapsui.Samples.Common.Maps
             mapControl.Map = CreateMap();
         }
 
-        public static Map CreateMap()
+        public static Map CreateMap(KnownTileSource source = KnownTileSource.BingAerial)
         {
             var map = new Map();
             var apiKey = "Enter your api key here"; // Contact Microsoft about how to use this
-            map.Layers.Add(new TileLayer(KnownTileSources.Create(KnownTileSource.BingAerial, apiKey), 
+            map.Layers.Add(new TileLayer(KnownTileSources.Create(source, apiKey), 
                 fetchStrategy: new FetchStrategy()) // FetchStrategy get tiles from higher levels in advance
             {
                 Name = "Bing Aerial",

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PinSample.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PinSample.cs
@@ -101,7 +101,11 @@ namespace Mapsui.Samples.Forms
 
         public void Setup(IMapControl mapControl)
         {
-            mapControl.Map = OsmSample.CreateMap();
+            //OSM never displays....
+            //mapControl.Map = OsmSample.CreateMap();
+
+            //I like bing Hybrid
+            mapControl.Map = BingSample.CreateMap(BruTile.Predefined.KnownTileSource.BingHybrid);
 
             ((MapView)mapControl).UseDoubleTap = true;
         }

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.UWP/Mapsui.Samples.Forms.UWP.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.UWP/Mapsui.Samples.Forms.UWP.csproj
@@ -84,6 +84,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>


### PR DESCRIPTION
this avoids the dead-lock condition when creating a pin's callout on UWP.