### PR TITLE
Remove IgnorePixelScaling in WPF

### DIFF
--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -52,7 +52,6 @@ namespace Mapsui.UI.Wpf
             Children.Add(SkiaCanvas);
             Children.Add(_selectRectangle);
 
-            SkiaCanvas.IgnorePixelScaling = true;
             SkiaCanvas.PaintSurface += SKElementOnPaintSurface;
 
             Map = new Map();
@@ -526,6 +525,7 @@ namespace Mapsui.UI.Wpf
             if (Renderer == null) return;
             if (_map == null) return;
 
+            args.Surface.Canvas.Scale(PixelDensity, PixelDensity);
             Renderer.Render(args.Surface.Canvas, Viewport, Map.Layers, Map.Widgets, Map.BackColor);
         }
         


### PR DESCRIPTION
Apparently something went wrong. I though I had already done this but perhaps that was in UWP