### PR TITLE
Added handling of owner drawn styles in Skia and WPF

### DIFF
--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -6,6 +6,7 @@ using Mapsui.Geometries;
 using Mapsui.Layers;
 using Mapsui.Logging;
 using Mapsui.Providers;
+using Mapsui.Rendering.Skia.SkiaStyles;
 using Mapsui.Rendering.Skia.SkiaWidgets;
 using Mapsui.Styles;
 using Mapsui.UI;
@@ -28,6 +29,11 @@ namespace Mapsui.Rendering.Skia
         public ISymbolCache SymbolCache => _symbolCache;
 
         public IDictionary<Type, IWidgetRenderer> WidgetRenders { get; } = new Dictionary<Type, IWidgetRenderer>();
+
+        /// <summary>
+        /// Dictionary holding all special renderers for styles
+        /// </summary>
+        public IDictionary<Type, IStyleRenderer> StyleRenderers { get; } = new Dictionary<Type, IStyleRenderer>();
 
         static MapRenderer()
         {
@@ -135,6 +141,21 @@ namespace Mapsui.Rendering.Skia
 
         private void RenderFeature(SKCanvas canvas, IReadOnlyViewport viewport, ILayer layer, IStyle style, IFeature feature, float layerOpacity)
         {
+            // Check, if we have a special renderer for this style
+            if (StyleRenderers.ContainsKey(style.GetType()))
+            {
+                // Save canvas
+                canvas.Save();
+                // We have a special renderer, so try, if it could draw this
+                var result = ((ISkiaStyleRenderer)StyleRenderers[style.GetType()]).Draw(canvas, viewport, layer, feature, style, _symbolCache);
+                // Restore old canvas
+                canvas.Restore();
+                // Was it drawn?
+                if (result)
+                    // Yes, special style renderer drawn correct
+                    return;
+            }
+            // No special style renderer handled this up to now, than try standard renderers
             if (feature.Geometry is Point)
                 PointRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, _symbolCache, layerOpacity * style.Opacity);
             else if (feature.Geometry is MultiPoint)
@@ -192,6 +213,7 @@ namespace Mapsui.Rendering.Skia
                     var color = pixmap.GetPixelColor(intX, intY);
 
                     VisibleFeatureIterator.IterateLayers(viewport, layers, (v, layer, style, feature, opacity) => {
+                        surface.Canvas.Save();
                         // 1) Clear the entire bitmap
                         surface.Canvas.Clear(SKColors.Transparent);
                         // 2) Render the feature to the clean canvas
@@ -200,6 +222,7 @@ namespace Mapsui.Rendering.Skia
                         if (color != pixmap.GetPixelColor(intX, intY))
                             // 4) Add feature and style to result
                             list.Add(new MapInfoRecord(feature, style, layer));
+                        surface.Canvas.Restore();
                     });
                 }
 

--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -45,6 +45,8 @@ namespace Mapsui.Rendering.Skia
             WidgetRenders[typeof(Hyperlink)] = new HyperlinkWidgetRenderer();
             WidgetRenders[typeof(ScaleBarWidget)] = new ScaleBarWidgetRenderer();
             WidgetRenders[typeof(ZoomInOutWidget)] = new ZoomInOutWidgetRenderer();
+
+            StyleRenderers.Add(typeof(VectorStyle), new VectorStyleRenderer(this));
         }
 
         public void Render(object target, IReadOnlyViewport viewport, IEnumerable<ILayer> layers,

--- a/Mapsui.Rendering.Skia/SkiaStyles/ISkiaStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/ISkiaStyleRenderer.cs
@@ -1,0 +1,22 @@
+﻿using Mapsui.Layers;
+using Mapsui.Providers;
+using Mapsui.Styles;
+using SkiaSharp;
+
+namespace Mapsui.Rendering.Skia.SkiaStyles
+{
+    public interface ISkiaStyleRenderer : IStyleRenderer
+    {
+        /// <summary>
+        /// Drawing function for special styles
+        /// </summary>
+        /// <param name="canvas">SKCanvas for drawing</param>
+        /// <param name="viewport">Active viewport for this drawing operation</param>
+        /// <param name="layer">Layer that contains feature</param>
+        /// <param name="feature">Feature to draw</param>
+        /// <param name="style">Style to draw</param>
+        /// <param name="symbolCache">SymbolCache for ready rendered bitmaps</param>
+        /// <returns></returns>
+        bool Draw(SKCanvas canvas, IReadOnlyViewport viewport, ILayer layer, IFeature feature, IStyle style, ISymbolCache symbolCache);
+    }
+}

--- a/Mapsui.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
@@ -1,0 +1,148 @@
+﻿using Mapsui.Geometries;
+using Mapsui.Layers;
+using Mapsui.Providers;
+using Mapsui.Styles;
+using SkiaSharp;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Mapsui.Rendering.Skia.SkiaStyles
+{
+    /// <summary>
+    /// Demo VectorStyleRenderer
+    /// </summary>
+    public class VectorStyleRenderer : ISkiaStyleRenderer
+    {
+        private MapRenderer mapRenderer;
+        private static bool flag = false;
+
+        public VectorStyleRenderer(MapRenderer renderer)
+        {
+            mapRenderer = renderer;
+        }
+
+        public bool Draw(SKCanvas canvas, IReadOnlyViewport viewport, ILayer layer, IFeature feature, IStyle style, ISymbolCache symbolCache)
+        {
+            if (feature.Geometry is Point destination)
+            {
+                // Draws a dounat at point
+                DrawPoint(canvas, viewport.WorldToScreen(destination), (VectorStyle)style, (float)layer.Opacity);
+                return true;
+            }
+            else if (feature.Geometry is Raster raster)
+            {
+                // Draws a pink frame and cross over raster image
+                DrawRaster(canvas, viewport, layer, feature, style);
+                return true;
+            }
+
+            return false;
+        }
+
+        public static void DrawPoint(SKCanvas canvas, Point destination, VectorStyle vectorStyle, float opacity)
+        {
+            var width = (float)SymbolStyle.DefaultWidth;
+            var halfWidth = width / 2;
+
+            var linePaint = CreateLinePaint(vectorStyle.Outline, opacity);
+            var fillPaint = CreateLinePaint(vectorStyle.Outline, opacity);
+
+            linePaint.StrokeWidth = halfWidth / 2;
+            fillPaint.StrokeWidth = halfWidth / 4;
+            fillPaint.Color = SKColors.Pink;
+
+            canvas.Translate((float)destination.X, (float)destination.Y);
+
+            if (linePaint != null && linePaint.Color.Alpha != 0) canvas.DrawCircle(0, 0, halfWidth, linePaint);
+            if (fillPaint != null && fillPaint.Color.Alpha != 0) canvas.DrawCircle(0, 0, halfWidth, fillPaint);
+        }
+
+        public void DrawRaster(SKCanvas canvas, IReadOnlyViewport viewport, ILayer layer, IFeature feature, IStyle style)
+        {
+            // Get private fields
+            var tileCache = (IDictionary<object, BitmapInfo>)typeof(MapRenderer).GetField("_tileCache", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(mapRenderer);
+            var currentIteration = (long)typeof(MapRenderer).GetField("_currentIteration", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(mapRenderer);
+            // Call original renderer
+            RasterRenderer.Draw(canvas, viewport, style, feature, (float)layer.Opacity * style.Opacity, tileCache, currentIteration);
+
+            var raster = feature.Geometry as Raster;
+            var destination = new BoundingBox(viewport.WorldToScreen(raster.BoundingBox.TopLeft), viewport.WorldToScreen(raster.BoundingBox.BottomRight)).ToSkia();
+            var paint = new SKPaint() { Color = SKColors.Pink, Style = SKPaintStyle.Stroke, StrokeWidth = 3 };
+            var boundingBox = raster.BoundingBox;
+
+            if (viewport.IsRotated)
+            {
+                var priorMatrix = canvas.TotalMatrix;
+                var matrix = CreateRotationMatrix(viewport, boundingBox, priorMatrix);
+
+                canvas.SetMatrix(matrix);
+
+                destination = new BoundingBox(0.0, 0.0, boundingBox.Width, boundingBox.Height).ToSkia();
+            }
+
+            if (flag)
+            {
+                canvas.DrawRect(destination, paint);
+                canvas.DrawLine(new SKPoint(destination.Left, destination.Top), new SKPoint(destination.Right, destination.Bottom), paint);
+                canvas.DrawLine(new SKPoint(destination.Left, destination.Bottom), new SKPoint(destination.Right, destination.Top), paint);
+            }
+
+            // Next time do it the other way 
+            flag = !flag;
+        }
+
+        private static SKPaint CreateLinePaint(Pen outline, float opacity)
+        {
+            if (outline == null) return null;
+
+            return new SKPaint
+            {
+                Color = outline.Color.ToSkia(opacity),
+                StrokeWidth = (float)outline.Width,
+                StrokeCap = outline.PenStrokeCap.ToSkia(),
+                PathEffect = outline.PenStyle.ToSkia((float)outline.Width),
+                Style = SKPaintStyle.Stroke,
+                IsAntialias = true
+            };
+        }
+
+        private static SKPaint CreateFillPaint(Brush fill, float opacity)
+        {
+            if (fill == null) return null;
+
+            return new SKPaint
+            {
+                Color = fill.Color.ToSkia(opacity),
+                Style = SKPaintStyle.Fill,
+                IsAntialias = true
+            };
+        }
+
+        private static SKMatrix CreateRotationMatrix(IReadOnlyViewport viewport, BoundingBox boundingBox, SKMatrix priorMatrix)
+        {
+            SKMatrix matrix = SKMatrix.MakeIdentity();
+
+            // The front-end sets up the canvas with a matrix based on screen scaling (e.g. retina).
+            // We need to retain that effect by combining our matrix with the incoming matrix.
+
+            // We'll create four matrices in addition to the incoming matrix. They perform the
+            // zoom scale, focal point offset, user rotation and finally, centering in the screen.
+
+            var userRotation = SKMatrix.MakeRotationDegrees((float)viewport.Rotation);
+            var focalPointOffset = SKMatrix.MakeTranslation(
+                (float)(boundingBox.Left - viewport.Center.X),
+                (float)(viewport.Center.Y - boundingBox.Top));
+            var zoomScale = SKMatrix.MakeScale((float)(1.0 / viewport.Resolution), (float)(1.0 / viewport.Resolution));
+            var centerInScreen = SKMatrix.MakeTranslation((float)(viewport.Width / 2.0), (float)(viewport.Height / 2.0));
+
+            // We'll concatenate them like so: incomingMatrix * centerInScreen * userRotation * zoomScale * focalPointOffset
+
+            SKMatrix.Concat(ref matrix, zoomScale, focalPointOffset);
+            SKMatrix.Concat(ref matrix, userRotation, matrix);
+            SKMatrix.Concat(ref matrix, centerInScreen, matrix);
+            SKMatrix.Concat(ref matrix, priorMatrix, matrix);
+
+            return matrix;
+        }
+    }
+}

--- a/Mapsui.Rendering.Xaml/MapRenderer.cs
+++ b/Mapsui.Rendering.Xaml/MapRenderer.cs
@@ -20,6 +20,7 @@ using Mapsui.Widgets.ScaleBar;
 using Mapsui.Widgets.Zoom;
 using XamlMedia = System.Windows.Media;
 using Mapsui.UI;
+using Mapsui.Rendering.Xaml.XamlStyles;
 
 namespace Mapsui.Rendering.Xaml
 {
@@ -28,6 +29,11 @@ namespace Mapsui.Rendering.Xaml
         private readonly SymbolCache _symbolCache = new SymbolCache();
         public ISymbolCache SymbolCache => _symbolCache;
         public IDictionary<Type, IWidgetRenderer> WidgetRenders { get; } = new Dictionary<Type, IWidgetRenderer>();
+
+        /// <summary>
+        /// Dictionary holding all special renderers for styles
+        /// </summary>
+        public IDictionary<Type, IStyleRenderer> StyleRenderers { get; } = new Dictionary<Type, IStyleRenderer>();
 
         static MapRenderer()
         {
@@ -204,6 +210,17 @@ namespace Mapsui.Rendering.Xaml
 
         private static void RenderFeature(IReadOnlyViewport viewport, Canvas canvas, IFeature feature, IStyle style, SymbolCache symbolCache, bool rasterizing)
         {
+            //// Check, if we have a special renderer for this style
+            //if (StyleRenderers.ContainsKey(style.GetType()))
+            //{
+            //    // We have a special renderer, so try, if it could draw this
+            //    var result = ((IXamlStyleRenderer)StyleRenderers[style.GetType()]).Draw(canvas, viewport, layer, feature, style, symbolCache);
+            //    // Was it drawn?
+            //    if (result)
+            //        // Yes, special style renderer drawn correct
+            //        return;
+            //}
+            //// No special style renderer handled this up to now, than try standard renderers
             if (style is LabelStyle)
             {
                 var labelStyle = (LabelStyle) style;

--- a/Mapsui.Rendering.Xaml/Mapsui.Rendering.Xaml.csproj
+++ b/Mapsui.Rendering.Xaml/Mapsui.Rendering.Xaml.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ExtensionMethods\VerticalAlignment.cs" />
     <Compile Include="ExtensionMethods\HorizontalAlignment.cs" />
     <Compile Include="ExtensionMethods\BitmapImageExtensions.cs" />
+    <Compile Include="XamlStyles\IXamlStyleRenderer.cs" />
     <Compile Include="XamlWidgets\HyperlinkWidgetRenderer.cs" />
     <Compile Include="OutlinedTextBlock.cs" />
     <Compile Include="XamlWidgets\IXamlWidgetRenderer.cs" />
@@ -121,6 +122,7 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Mapsui.Rendering.Xaml/XamlStyles/IXamlStyleRenderer.cs
+++ b/Mapsui.Rendering.Xaml/XamlStyles/IXamlStyleRenderer.cs
@@ -1,0 +1,22 @@
+﻿using Mapsui.Layers;
+using Mapsui.Providers;
+using Mapsui.Styles;
+using System.Windows.Controls;
+
+namespace Mapsui.Rendering.Xaml.XamlStyles
+{
+    public interface IXamlStyleRenderer : IStyleRenderer
+    {
+        /// <summary>
+        /// Drawing function for special styles
+        /// </summary>
+        /// <param name="canvas">Canvas for drawing</param>
+        /// <param name="viewport">Active viewport for this drawing operation</param>
+        /// <param name="layer">Layer that contains feature</param>
+        /// <param name="feature">Feature to draw</param>
+        /// <param name="style">Style to draw</param>
+        /// <param name="symbolCache">SymbolCache for ready rendered bitmaps</param>
+        /// <returns></returns>
+        bool Draw(Canvas canvas, IReadOnlyViewport viewport, ILayer layer, IFeature feature, IStyle style, ISymbolCache symbolCache);
+    }
+}

--- a/Mapsui/Rendering/IRenderer.cs
+++ b/Mapsui/Rendering/IRenderer.cs
@@ -12,6 +12,7 @@ namespace Mapsui.Rendering
         void Render(object target, IReadOnlyViewport viewport, IEnumerable<ILayer> layers, IEnumerable<IWidget> widgets, Color background = null);
         MemoryStream RenderToBitmapStream(IReadOnlyViewport viewport, IEnumerable<ILayer> layers, Color background = null);
         ISymbolCache SymbolCache { get; }
-        IDictionary<Type, IWidgetRenderer> WidgetRenders { get; } 
+        IDictionary<Type, IWidgetRenderer> WidgetRenders { get; }
+        IDictionary<Type, IStyleRenderer> StyleRenderers { get; }
     }
 }

--- a/Mapsui/Styles/IStyleRenderer.cs
+++ b/Mapsui/Styles/IStyleRenderer.cs
@@ -1,0 +1,6 @@
+﻿namespace Mapsui.Styles
+{
+    public interface IStyleRenderer
+    {
+    }
+}

--- a/Samples/Mapsui.Samples.Common/Maps/SpecialStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/SpecialStyleSample.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using Mapsui.Geometries;
+using Mapsui.Layers;
+using Mapsui.Providers;
+using Mapsui.Rendering;
+using Mapsui.Rendering.Skia.SkiaStyles;
+using Mapsui.Samples.Common.Helpers;
+using Mapsui.Styles;
+using Mapsui.UI;
+using Mapsui.Utilities;
+using SkiaSharp;
+
+namespace Mapsui.Samples.Common.Maps
+{
+    public class SpecialStyle : IStyle
+    {
+        public double MinVisible { get; set; } = 0;
+        public double MaxVisible { get; set; } = double.MaxValue;
+        public bool Enabled { get; set; } = true;
+        public float Opacity { get; set; } = 0.7f;
+    }
+
+    public class SkiaSpecialStyleRenderer : ISkiaStyleRenderer
+    {
+        public static Random rnd = new Random();
+        public bool Draw(SKCanvas canvas, IReadOnlyViewport viewport, ILayer layer, IFeature feature, IStyle style, ISymbolCache symbolCache)
+        {
+            if (!(feature.Geometry is global::Mapsui.Geometries.Point worldPoint))
+                return false;
+
+            var screenPoint = viewport.WorldToScreen(worldPoint);
+            var color = new SKColor((byte)rnd.Next(0, 256), (byte)rnd.Next(0, 256), (byte)rnd.Next(0, 256), (byte)(256.0 * layer.Opacity * style.Opacity));
+            var colored = new SKPaint() { Color = color, IsAntialias = true };
+            var black = new SKPaint() { Color = SKColors.Black, IsAntialias = true };
+
+            canvas.Translate((float)screenPoint.X, (float)screenPoint.Y);
+            canvas.DrawCircle(0, 0, 15, colored);
+            canvas.DrawCircle(-8, -12, 8, colored);
+            canvas.DrawCircle(8, -12, 8, colored);
+            canvas.DrawCircle(8, -8, 2, black);
+            canvas.DrawCircle(-8, -8, 2, black);
+            using (var path = new SKPath())
+            {
+                path.ArcTo(new SKRect(-8, 2, 8, 10), 25, 135, true);
+                canvas.DrawPath(path, new SKPaint() { Style = SKPaintStyle.Stroke, Color = SKColors.Black, IsAntialias = true });
+            }
+
+            return true;
+        }
+    }
+
+    public class SpecialStyleSample : ISample
+    {
+        public string Name => "Special Style";
+        public string Category => "Special";
+
+        public void Setup(IMapControl mapControl)
+        {
+            mapControl.Map = CreateMap();
+
+            if (mapControl.Renderer is Rendering.Skia.MapRenderer && !mapControl.Renderer.StyleRenderers.ContainsKey(typeof(SpecialStyle)))
+                mapControl.Renderer.StyleRenderers.Add(typeof(SpecialStyle), new SkiaSpecialStyleRenderer());
+        }
+
+        public static Map CreateMap()
+        {
+            var map = new Map();
+
+            map.Layers.Add(OpenStreetMap.CreateTileLayer());
+            map.Layers.Add(CreateStylesLayer(map.Envelope));
+            
+            return map;
+        }
+
+        private static ILayer CreateStylesLayer(BoundingBox envelope)
+        {
+            return new MemoryLayer
+            {
+                Name = "Special Styles Layer",
+                DataSource = CreateMemoryProviderWithDiverseSymbols(envelope, 25),
+                Style = null,
+                IsMapInfoLayer = true
+            };
+        }
+
+        public static MemoryProvider CreateMemoryProviderWithDiverseSymbols(BoundingBox envelope, int count = 100)
+        {
+            
+            return new MemoryProvider(CreateDiverseFeatures(RandomPointHelper.GenerateRandomPoints(envelope, count)));
+        }
+
+        private static Features CreateDiverseFeatures(IEnumerable<IGeometry> randomPoints)
+        {
+            var features = new Features();
+            var style = new SpecialStyle();
+            var counter = 1;
+            foreach (var point in randomPoints)
+            {
+                var feature = new Feature { Geometry = point };
+                feature["Label"] = $"I'm no. {counter++} and, \nautsch, you hit me!";
+                feature.Styles.Add(style);
+                feature.Styles.Add(SmalleDot());
+                features.Add(feature);
+            }
+            return features;
+        }
+
+        private static IStyle SmalleDot()
+        {
+            return new SymbolStyle { SymbolScale = 0.2, Fill = new Brush(new Color(40, 40, 40)) };
+        }
+    }
+}

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
@@ -57,6 +57,8 @@ namespace Mapsui.Samples.Forms
 
         private void MapView_Info(object sender, UI.MapInfoEventArgs e)
         {
+            featureInfo.Text = $"Click Info:";
+
             if (e?.MapInfo?.Feature != null)
             {
                 featureInfo.Text = $"Click Info:{Environment.NewLine}{e.MapInfo.Feature.ToDisplayText()}";

--- a/Samples/Mapsui.Samples.Wpf/Mapsui.Samples.Wpf.csproj
+++ b/Samples/Mapsui.Samples.Wpf/Mapsui.Samples.Wpf.csproj
@@ -204,6 +204,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="XamlSpecialStyleRenderer.cs" />
     <Page Include="LayerList.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -276,6 +277,10 @@
     <ProjectReference Include="..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj">
       <Project>{ae632270-38ca-4203-93a5-8612629cd944}</Project>
       <Name>Mapsui.Rendering.Skia</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Mapsui.Rendering.Xaml\Mapsui.Rendering.Xaml.csproj">
+      <Project>{5dc32b05-0b6e-478f-a9fb-57762aa2f814}</Project>
+      <Name>Mapsui.Rendering.Xaml</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\Mapsui.UI.Wpf\Mapsui.UI.Wpf.csproj">
       <Project>{ae693902-feda-4034-a7c5-9aa9872f7878}</Project>

--- a/Samples/Mapsui.Samples.Wpf/Window1.xaml.cs
+++ b/Samples/Mapsui.Samples.Wpf/Window1.xaml.cs
@@ -40,7 +40,11 @@ namespace Mapsui.Samples.Wpf
             var selectedValue = ((ComboBoxItem)((ComboBox)sender).SelectedItem).Content.ToString();
 
             if (selectedValue.ToLower().Contains("wpf"))
+            {
                 MapControl.RenderMode = UI.Wpf.RenderMode.Wpf;
+                if (!((Rendering.Xaml.MapRenderer)MapControl.Renderer).StyleRenderers.ContainsKey(typeof(Common.Maps.SpecialStyle)))
+                    ((Rendering.Xaml.MapRenderer)MapControl.Renderer).StyleRenderers.Add(typeof(Common.Maps.SpecialStyle), new XamlSpecialStyleRenderer());
+            }
             else if (selectedValue.ToLower().Contains("skia"))
                 MapControl.RenderMode = UI.Wpf.RenderMode.Skia;
             else

--- a/Samples/Mapsui.Samples.Wpf/XamlSpecialStyleRenderer.cs
+++ b/Samples/Mapsui.Samples.Wpf/XamlSpecialStyleRenderer.cs
@@ -1,0 +1,50 @@
+﻿using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Providers;
+using Mapsui.Rendering;
+using Mapsui.Rendering.Xaml;
+using Mapsui.Rendering.Xaml.XamlStyles;
+using Mapsui.Styles;
+using System;
+using System.Windows.Controls;
+using XamlMedia = System.Windows.Media;
+using XamlShapes = System.Windows.Shapes;
+using XamlPoint = System.Windows.Point;
+using XamlColors = System.Windows.Media.Colors;
+
+public class XamlSpecialStyleRenderer : IXamlStyleRenderer
+{
+    public static Random rnd = new Random();
+
+    public bool Draw(Canvas canvas, IReadOnlyViewport viewport, ILayer layer, IFeature feature, IStyle style, ISymbolCache symbolCache)
+    {
+        if (!(feature.Geometry is global::Mapsui.Geometries.Point worldPoint))
+            return false;
+
+        var screenPoint = viewport.WorldToScreen(worldPoint);
+
+        var color = new System.Windows.Media.Color() { R = (byte)rnd.Next(0, 256), G = (byte)rnd.Next(0, 256), B = (byte)rnd.Next(0, 256), A = (byte)(256.0 * layer.Opacity * style.Opacity) };
+
+        var path = new XamlShapes.Path
+        {
+            Fill = new XamlMedia.SolidColorBrush(color),
+            Stroke = new XamlMedia.SolidColorBrush(XamlColors.Transparent),
+            StrokeThickness = 0,
+        };
+
+        path.Data = new XamlMedia.EllipseGeometry
+        {
+            Center = new XamlPoint(0, 0),
+            RadiusX = 20 * 0.5,
+            RadiusY = 20 * 0.5
+        };
+
+        var matrix = XamlMedia.Matrix.Identity;
+        MatrixHelper.InvertY(ref matrix);
+        MatrixHelper.Translate(ref matrix, screenPoint.X, screenPoint.Y);
+
+        canvas.Children.Add(path);
+
+        return true;
+    }
+}


### PR DESCRIPTION
Added a design study, how it would possible to add owner drawn styles in Mapsui.
Added a sample for this in "Special" - "Special Style".

Couldn't add it to WPF, because function `RenderFeature()` is static and couldn't access `StyleRenderers`, because it isn't static. Don't know, how to solve this without removing static from all the rendering functions. And the drawing function of sample isn't complete. Would be to time consuming for me to understand, how to do it. Sorry.

This replaces PR #837, because this has not needed parts. So it is easier to understand, when creating a new PR. 