### PR TITLE
Wpf cast exception

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
@@ -11,12 +11,12 @@ namespace Mapsui.Rendering.Skia
         public static void Draw(SKCanvas canvas, IReadOnlyViewport viewport, 
             float opacity, Point destination, CalloutStyle calloutStyle)
         {
-            if (calloutStyle.BitmapId < 0 || calloutStyle.Invalidated || calloutStyle.TitleFont.Invalidated || calloutStyle.SubtitleFont.Invalidated)
+            if (calloutStyle.BitmapId < 0 || calloutStyle.Invalidated)
             {
                 if (calloutStyle.Content < 0 && calloutStyle.Type == CalloutType.Custom)
                     return;
 
-                if (calloutStyle.Invalidated || calloutStyle.TitleFont.Invalidated || calloutStyle.SubtitleFont.Invalidated)
+                if (calloutStyle.Invalidated)
                 {
                     UpdateContent(calloutStyle);
                 }
@@ -102,7 +102,7 @@ namespace Mapsui.Rendering.Skia
                     BitmapRegistry.Instance.Set(callout.BitmapId, picture);
             }
 
-            callout.Invalidated = callout.TitleFont.Invalidated = callout.SubtitleFont.Invalidated = false;
+            callout.Invalidated = false;
         }
 
         /// <summary>

--- a/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
@@ -163,8 +163,11 @@ namespace Mapsui.Rendering.Skia
             if (callout.Type == CalloutType.Custom)
                 return;
 
-            if (callout.Title == null) 
-                return; 
+            if (callout.Title == null)
+            {
+                callout.Content = -1;
+                return;
+            }
 
             var styleSubtitle = new Topten.RichTextKit.Style();
             var styleTitle = new Topten.RichTextKit.Style();

--- a/Mapsui/Styles/CalloutStyle.cs
+++ b/Mapsui/Styles/CalloutStyle.cs
@@ -309,6 +309,7 @@ namespace Mapsui.Rendering.Skia
                 if (_content != value)
                 {
                     _content = value;
+                    _type = CalloutType.Custom;
                     Invalidated = true;
                 }
             }

--- a/Mapsui/Styles/CalloutStyle.cs
+++ b/Mapsui/Styles/CalloutStyle.cs
@@ -70,6 +70,7 @@ namespace Mapsui.Rendering.Skia
         private double _maxWidth;
         private Color _titleFontColor;
         private Color _subtitleFontColor;
+        private bool _invalidated;
 
         public new static double DefaultWidth { get; set; } = 100;
         public new static double DefaultHeight { get; set; } = 30;
@@ -468,6 +469,18 @@ namespace Mapsui.Rendering.Skia
             }
         }
 
-        public bool Invalidated { get; set; }
+        public bool Invalidated
+        {
+            get
+            {
+                return _invalidated | TitleFont.Invalidated | SubtitleFont.Invalidated;
+            }
+            set
+            {
+                _invalidated = value;
+                TitleFont.Invalidated = value;
+                SubtitleFont.Invalidated = value;
+            }
+        }
     }
 }


### PR DESCRIPTION
Removed the bug in the callout example. It seems, that this comes from the refactoring from OnPropertyChange to Invalidate.

Did also centralise handling of Invalidate in callout.