### PR TITLE
Do not Limit zoom in ZoomHelper

### DIFF
--- a/Mapsui/AnimatedNavigator.cs
+++ b/Mapsui/AnimatedNavigator.cs
@@ -185,7 +185,7 @@ namespace Mapsui
         /// </summary>
         public void ZoomIn()
         {
-            var resolution = ZoomHelper.ZoomIn(_map.Resolutions, _viewport.Resolution, _map.Limiter.ZoomMode == UI.ZoomMode.Unlimited);
+            var resolution = ZoomHelper.ZoomIn(_map.Resolutions, _viewport.Resolution);
 
             ZoomTo(resolution);
         }
@@ -195,7 +195,7 @@ namespace Mapsui
         /// </summary>
         public void ZoomOut()
         {
-            var resolution = ZoomHelper.ZoomOut(_map.Resolutions, _viewport.Resolution, _map.Limiter.ZoomMode == UI.ZoomMode.Unlimited);
+            var resolution = ZoomHelper.ZoomOut(_map.Resolutions, _viewport.Resolution);
 
             ZoomTo(resolution);
         }
@@ -206,7 +206,7 @@ namespace Mapsui
         /// <param name="centerOfZoom">Center to use for zoom in</param>
         public void ZoomIn(Point centerOfZoom)
         {
-            var resolution = ZoomHelper.ZoomIn(_map.Resolutions, _viewport.Resolution, _map.Limiter.ZoomMode == UI.ZoomMode.Unlimited);
+            var resolution = ZoomHelper.ZoomIn(_map.Resolutions, _viewport.Resolution);
             ZoomTo(resolution, centerOfZoom);
         }
 
@@ -216,7 +216,7 @@ namespace Mapsui
         /// <param name="centerOfZoom">Center to use for zoom out</param>
         public void ZoomOut(Point centerOfZoom)
         {
-            var resolution = ZoomHelper.ZoomOut(_map.Resolutions, _viewport.Resolution, _map.Limiter.ZoomMode == UI.ZoomMode.Unlimited);
+            var resolution = ZoomHelper.ZoomOut(_map.Resolutions, _viewport.Resolution);
             ZoomTo(resolution, centerOfZoom);
         }
 

--- a/Mapsui/Navigator.cs
+++ b/Mapsui/Navigator.cs
@@ -91,7 +91,7 @@ namespace Mapsui
 
         public void ZoomIn()
         {
-            var resolution = ZoomHelper.ZoomIn(_map.Resolutions, _viewport.Resolution, _map.Limiter.ZoomMode == UI.ZoomMode.Unlimited);
+            var resolution = ZoomHelper.ZoomIn(_map.Resolutions, _viewport.Resolution);
             _viewport.SetResolution(resolution);
 
             Navigated?.Invoke(this, EventArgs.Empty);
@@ -99,7 +99,7 @@ namespace Mapsui
 
         public void ZoomOut()
         {
-            var resolution = ZoomHelper.ZoomOut(_map.Resolutions, _viewport.Resolution, _map.Limiter.ZoomMode == UI.ZoomMode.Unlimited);
+            var resolution = ZoomHelper.ZoomOut(_map.Resolutions, _viewport.Resolution);
             _viewport.SetResolution(resolution);
 
             Navigated?.Invoke(this, EventArgs.Empty);
@@ -107,7 +107,7 @@ namespace Mapsui
 
         public void ZoomIn(Point centerOfZoom)
         {
-            var resolution = ZoomHelper.ZoomIn(_map.Resolutions, _viewport.Resolution, _map.Limiter.ZoomMode == UI.ZoomMode.Unlimited);
+            var resolution = ZoomHelper.ZoomIn(_map.Resolutions, _viewport.Resolution);
             ZoomTo(resolution, centerOfZoom);
 
             Navigated?.Invoke(this, EventArgs.Empty);
@@ -115,7 +115,7 @@ namespace Mapsui
 
         public void ZoomOut(Point centerOfZoom)
         {
-            var resolution = ZoomHelper.ZoomOut(_map.Resolutions, _viewport.Resolution, _map.Limiter.ZoomMode == UI.ZoomMode.Unlimited);
+            var resolution = ZoomHelper.ZoomOut(_map.Resolutions, _viewport.Resolution);
             ZoomTo(resolution, centerOfZoom);
 
             Navigated?.Invoke(this, EventArgs.Empty);

--- a/Mapsui/UI/IViewportLimiter.cs
+++ b/Mapsui/UI/IViewportLimiter.cs
@@ -17,11 +17,6 @@ namespace Mapsui.UI
         /// </summary>
         MinMax ZoomLimits { get; set; }
 
-        /// <summary>
-        /// Mode for zoom
-        /// </summary>
-        ZoomMode ZoomMode { get; }
-
         void Limit(IViewport viewport, IReadOnlyList<double> mapResolutions, BoundingBox mapEnvelope);
 
         double LimitResolution(double resolution, double screenWidth, double screenHeight, 

--- a/Mapsui/UI/ViewportLimiter.cs
+++ b/Mapsui/UI/ViewportLimiter.cs
@@ -61,7 +61,7 @@ namespace Mapsui.UI
             if (resolutions == null || resolutions.Count == 0) return null;
             resolutions = resolutions.OrderByDescending(r => r).ToList();
             var mostZoomedOut = resolutions[0];
-            var mostZoomedIn = resolutions[resolutions.Count - 1] * 0.5; // divide by two to allow one extra level to zoom-in
+            var mostZoomedIn = resolutions[resolutions.Count - 1];
             return new MinMax(mostZoomedOut, mostZoomedIn);
         }
 

--- a/Mapsui/UI/ViewportLimiterKeepWithin.cs
+++ b/Mapsui/UI/ViewportLimiterKeepWithin.cs
@@ -23,8 +23,6 @@ namespace Mapsui.UI
         /// </summary>
         public MinMax ZoomLimits { get; set; }
 
-        public ZoomMode ZoomMode => ZoomMode.KeepWithinResolutions;
-
         private MinMax GetExtremes(IReadOnlyList<double> resolutions)
         {
             if (resolutions == null || resolutions.Count == 0) return null;

--- a/Mapsui/UI/ViewportLimiterWithoutLimits.cs
+++ b/Mapsui/UI/ViewportLimiterWithoutLimits.cs
@@ -8,8 +8,6 @@ namespace Mapsui.UI
         public BoundingBox PanLimits { get; set; }
         public MinMax ZoomLimits { get; set; }
 
-        public ZoomMode ZoomMode => ZoomMode.Unlimited;
-
         public void Limit(IViewport viewport, IReadOnlyList<double> mapResolutions, BoundingBox mapEnvelope)
         {
         }

--- a/Mapsui/Utilities/ZoomHelper.cs
+++ b/Mapsui/Utilities/ZoomHelper.cs
@@ -22,29 +22,32 @@ namespace Mapsui.Utilities
 {
     public static class ZoomHelper
     {
-        public static double ZoomIn(IReadOnlyList<double> resolutions, double resolution, bool overzoom = false)
+        public static double ZoomIn(IReadOnlyList<double> resolutions, double resolution)
         {
-            if (resolutions == null || resolutions.Count == 0) return resolution / 2.0;
+            if (resolutions == null) return resolution / 2.0;
 
-            foreach (var r in resolutions)
-                if (r < resolution) return r;
+            for (var i = 0; i >= resolutions.Count; i++)
+            {
+                // If there is a smaller resolution in the array return it
+                if (resolutions[i] < (resolution + double.Epsilon)) return resolutions[i];
+            }
 
-            if (overzoom)
-                return resolution / 2.0;
-            else
-                return resolutions[resolutions.Count - 1];
+            // Else return half of the current resolution
+            return resolution / 2.0;
         }
         
-        public static double ZoomOut(IReadOnlyList<double> resolutions, double resolution, bool overzoom = false)
+        public static double ZoomOut(IReadOnlyList<double> resolutions, double resolution)
         {
-            if (resolutions == null || resolutions.Count == 0) return resolution * 2.0;
-
-            if (overzoom && resolutions[resolutions.Count - 1] > resolution)
-                return Math.Min(resolution * 2.0, resolutions[resolutions.Count - 1]);
+            if (resolutions == null) return resolution * 2.0;
 
             for (var i = resolutions.Count - 1; i >= 0; i--)
-                if (resolutions[i] > resolution) return resolutions[i];
-            return resolutions[0];
+            {
+                // If there is a bigger resolution in the array return it
+                if (resolutions[i] > (resolution + double.Epsilon)) return resolutions[i];
+            }
+
+            // Else return double the current resolution
+            return resolution * 2.0;
         }
 
         [Obsolete("Use ViewportLimiter.LimitExtent instead")]


### PR DESCRIPTION
@charlenni I now removed the limiting in ZoomHelper. The only place there is there is limiting is in the ViewportLimiter. It is of course better to have it in one place. There was already a problem with the current solution, the ViewportLimiter allowed one level more than the ZoomHelper. I now removed this extra level in the ViewportLimiter to keep the behavior for mouse wheel the same but I am not sure I changed it for some other use case. Either way, the current logic is straight forward and if users want an extra level this is possible through another ViewportLimiter implementation.