### PR TITLE
Removed storing of PixelDensity

### DIFF
--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -63,16 +63,9 @@ namespace Mapsui.UI.Wpf
             }
         }
 
-        private float? _pixelDensity;
-
         public float PixelDensity
         {
-            get
-            {
-                if (_pixelDensity == null || _pixelDensity <= 0)
-                    _pixelDensity = GetPixelDensity();
-                return _pixelDensity.Value;
-            }
+            get => GetPixelDensity();
         }
 
         private IRenderer _renderer = new MapRenderer();

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml
@@ -6,6 +6,7 @@
     <ContentPage.Content>
         <StackLayout>
           <mapsui:MapView x:Name="mapView"
+            IsVisible="False"
 		    VerticalOptions="FillAndExpand"
             HorizontalOptions="Fill"
 		    BackgroundColor="Gray" 

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml.cs
@@ -44,6 +44,7 @@ namespace Mapsui.Samples.Forms
 
         protected override void OnAppearing()
         {
+            mapView.IsVisible = true;
             mapView.Refresh();
         }
 


### PR DESCRIPTION
With this, PixelDensity is calculated each time new. There was a problem with storing this value in the Forms implementation (IsVisible = true after adding MapControl/MapView). All other MapControls except WPF don't have to calculate this value. For WPF it could be good to save this calculated value.

For the problem see #884.