### PR TITLE
[Forms] MapControl clears all touches when gesture is cancelled

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -215,7 +215,8 @@ namespace Mapsui.UI.Forms
             }
             else if (e.ActionType == SKTouchAction.Cancelled)
             {
-                _touches.TryRemove(e.Id, out _);
+                // This gesture is cancelled, so clear all touches
+                _touches.Clear();
             }
             else if (e.ActionType == SKTouchAction.Exited && _touches.TryRemove(e.Id, out var exitedTouch))
             {


### PR DESCRIPTION
When gesture in MapControl for Forms is cancelled, all touches are cleared. See #898.