### PR TITLE
ZoomIn function with invalid FOR loop.

### DIFF
--- a/Mapsui/Utilities/ZoomHelper.cs
+++ b/Mapsui/Utilities/ZoomHelper.cs
@@ -26,7 +26,7 @@ namespace Mapsui.Utilities
         {
             if (resolutions == null) return resolution / 2.0;
 
-            for (var i = 0; i >= resolutions.Count; i++)
+            for (var i = 0; i <= resolutions.Count - 1; i++)
             {
                 // If there is a smaller resolution in the array return it
                 if (resolutions[i] < (resolution + double.Epsilon)) return resolutions[i];


### PR DESCRIPTION
There was a bug in the ZoomIn helper function, which made iterating the resolutions invalid and therefore new resolution returned would always be "resolution / 2.0" instead of the next resolution out of the 20 known resolutions.