### PR TITLE
Replace SQLite path for MBTiles files with full path

### DIFF
--- a/Samples/Mapsui.Samples.Common/Maps/MbTilesSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/MbTilesSample.cs
@@ -22,7 +22,7 @@ namespace Mapsui.Samples.Common.Maps
         public static Map CreateMap()
         {
             var map = new Map();
-            map.Layers.Add(CreateMbTilesLayer(Path.Combine(MbTilesLocation, "world.mbtiles"), "regular"));
+            map.Layers.Add(CreateMbTilesLayer(Path.GetFullPath(Path.Combine(MbTilesLocation, "world.mbtiles")), "regular"));
             return map;
         }
 


### PR DESCRIPTION
Replace SQLite path for MBTiles files with full path, so that doesn't throw an exception on UWP