### PR TITLE
Feature/cumulative resolutions on wpf mouse wheel

### DIFF
--- a/Mapsui/Utilities/Easing.cs
+++ b/Mapsui/Utilities/Easing.cs
@@ -38,8 +38,10 @@ namespace Mapsui.Utilities
 
         public static readonly Easing CubicIn = new Easing(x => x * x * x);
         public static readonly Easing CubicOut = new Easing(x => Math.Pow(x - 1.0f, 3.0f) + 1.0f);
-
         public static readonly Easing CubicInOut = new Easing(x => x < 0.5f ? Math.Pow(x * 2.0f, 3.0f) / 2.0f : (Math.Pow((x - 1) * 2.0f, 3.0f) + 2.0f) / 2.0f);
+
+        public static readonly Easing QuarticIn = new Easing(x => x * x * x * x * x);
+        public static readonly Easing QuarticOut = new Easing(x => 1 - (--x) * x * x * x);
 
         public static readonly Easing BounceOut;
         public static readonly Easing BounceIn;


### PR DESCRIPTION
When using the new Navigator animations in WPF this failed to cumulate the mouse wheel event. With cumulative mouse wheel event I mean that if a mouse wheel event is fired and during the animation a new mouse wheel event comes in, then the target resolution is not just the next resolution but the one after that. 

Without this mechanism a second mouse wheel event would start a new animation to the same target which would only delay the time it would take to reach that target.