### PR TITLE
Update getting-started-xamarin-forms.md

### DIFF
--- a/docfx/documentation/getting-started-xamarin-forms.md
+++ b/docfx/documentation/getting-started-xamarin-forms.md
@@ -22,8 +22,31 @@ Add the Mapsui.Forms view with
     HorizontalOptions="Fill"
     BackgroundColor="Gray" />
 ```
-to the Xaml <ContentPage> part file
+to the Xaml <ContentPage> part file.
     
+Nest the MapView element inside a container, this child element needs to be placed inside a parent Layout 
+for the view to be correctly setup and attached to the code behind, for instance,
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:mapsui="clr-namespace:Mapsui.UI.Forms;assembly=Mapsui.UI.Forms"
+             mc:Ignorable="d">
+
+    <StackLayout>
+        <mapsui:MapView x:Name="mapView"
+         VerticalOptions="FillAndExpand"
+         HorizontalOptions="Fill"
+         BackgroundColor="Gray" />
+    </StackLayout>
+
+</ContentPage>
+```
+the Xaml file should look similar to this after this step.
+
 ### Step 5
 
 Add in the code behind the following


### PR DESCRIPTION
## Improvement in documentation

### Addition

[http://mapsui.com/documentation/getting-started-xamarin-forms.html](url)

#### Changes to Step 4
The `mapsui:MapView` element needs to be nested inside a parent `Layout`  in the for the map to be set up and load correctly, which is not clear in Step 4 that just tells the user to add it to the Xaml file. Now there might be confusion as to add it under the <ContentPage> tag with no parent View or Layout. While working around with the MapView element, **it might be hard for a first-time user to figure out its placement and root in the Xaml file.**

Instead of 

Add the Mapsui.Forms view with

```xml
<mapsui:MapView x:Name="mapView"
    VerticalOptions="FillAndExpand"
    HorizontalOptions="Fill"
    BackgroundColor="Gray" />
```
to the Xaml part file

This step should explicitly mention adding the view inside a Xamarin.Forms Layout under `<ContentPage>` root

#### Step 4
Add the Mapsui.Forms view 

```xml
<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
             xmlns:mapsui="clr-namespace:Mapsui.UI.Forms;assembly=Mapsui.UI.Forms"
             mc:Ignorable="d">

<!-- Choose a Xamarin.Forms Layout -->
    <StackLayout>
         <mapsui:MapView 
            x:Name="mapView"
            VerticalOptions="FillAndExpand"
            HorizontalOptions="Fill"
            BackgroundColor="Gray" />
    </StackLayout>

</ContentPage>
```
to the Xaml part file

### Inform the user and avoiding build errors

- This helps add to the clarity of the procedure. A first time user might find implicit information to be much more intimidating than explicitly providing a detailed description of the steps. 
- A misplaced child element inside the Xaml file might introduce build errors since the code behind may not able to wire up the MapView with the defined Xaml element.