### PR TITLE
Fix: Xamarin Forms Quick Start Guide steps don't work on Android

### DIFF
--- a/docfx/documentation/getting-started-xamarin-forms.md
+++ b/docfx/documentation/getting-started-xamarin-forms.md
@@ -58,13 +58,7 @@ var map = new Map
     Transformation = new MinimalTransformation()
 };
 
-var attribution = new BruTile.Attribution("© OpenStreetMap contributors",
-    "http://www.openstreetmap.org/copyright");
-var tileSource = new HttpTileSource(new GlobalSphericalMercator(),
-    "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-    new[] { "a", "b", "c" }, name: "OpenStreetMap",
-    attribution: attribution);
-var tileLayer = new TileLayer(tileSource) { Name = "OpenStreetMap" };
+var tileLayer = OpenStreetMap.CreateTileLayer();
 
 map.Layers.Add(tileLayer);
 map.Widgets.Add(new Widgets.ScaleBar.ScaleBarWidget(map) { TextAlignment = Widgets.Alignment.Center, HorizontalAlignment = Widgets.HorizontalAlignment.Left, VerticalAlignment = Widgets.VerticalAlignment.Bottom });


### PR DESCRIPTION
Fixes issue #974 by using the Tile Layer generated in [OpenStreetMaps.cs](https://github.com/Mapsui/Mapsui/blob/945ce990d130ca7ec3ca93db734b58a88798c7df/Mapsui/Utilities/OpenStreetMap.cs) instead of having the user create there own.