### PR TITLE
add property Pin.RotateWithMap

### DIFF
--- a/Mapsui.UI.Forms/Objects/Pin.cs
+++ b/Mapsui.UI.Forms/Objects/Pin.cs
@@ -28,6 +28,7 @@ namespace Mapsui.UI.Forms
         public static readonly BindableProperty SvgProperty = BindableProperty.Create(nameof(Svg), typeof(string), typeof(Pin), default(string));
         public static readonly BindableProperty ScaleProperty = BindableProperty.Create(nameof(Scale), typeof(float), typeof(Pin), 1.0f);
         public static readonly BindableProperty RotationProperty = BindableProperty.Create(nameof(Rotation), typeof(float), typeof(Pin), 0f);
+        public static readonly BindableProperty RotateWithMapProperty = BindableProperty.Create(nameof(RotateWithMap), typeof(bool), typeof(Pin), false);
         public static readonly BindableProperty IsVisibleProperty = BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(Pin), true);
         public static readonly BindableProperty MinVisibleProperty = BindableProperty.Create(nameof(MinVisible), typeof(double), typeof(Pin), 0.0);
         public static readonly BindableProperty MaxVisibleProperty = BindableProperty.Create(nameof(MaxVisible), typeof(double), typeof(Pin), double.MaxValue);
@@ -160,6 +161,16 @@ namespace Mapsui.UI.Forms
         {
             get { return (float)GetValue(RotationProperty); }
             set { SetValue(RotationProperty, value); }
+        }
+
+        /// <summary>
+        /// When true a symbol will rotate along with the rotation of the map.
+        /// The default is false.
+        /// </summary>
+        public bool RotateWithMap
+        {
+            get { return (bool)GetValue(RotateWithMapProperty); }
+            set { SetValue(RotateWithMapProperty, value); }
         }
 
         /// <summary>
@@ -373,6 +384,9 @@ namespace Mapsui.UI.Forms
                 case nameof(Rotation):
                     ((SymbolStyle)Feature.Styles.First()).SymbolRotation = Rotation;
                     break;
+                case nameof(RotateWithMap):
+                    ((SymbolStyle)Feature.Styles.First()).RotateWithMap = RotateWithMap;
+                    break;
                 case nameof(IsVisible):
                     if (!IsVisible)
                         HideCallout();
@@ -496,6 +510,7 @@ namespace Mapsui.UI.Forms
                         BitmapId = _bitmapId,
                         SymbolScale = Scale,
                         SymbolRotation = Rotation,
+                        RotateWithMap = RotateWithMap,
                         SymbolOffset = new Offset(Anchor.X, Anchor.Y),
                         Opacity = 1 - Transparency,
                         Enabled = IsVisible,

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PinSample.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PinSample.cs
@@ -103,6 +103,7 @@ namespace Mapsui.Samples.Forms.Shared
                         Position = mapClickedArgs.Point,
                         Type = PinType.Svg,
                         Scale = 0.1f,
+                        RotateWithMap = true,
                         Svg = svgString
                     });
                     break;


### PR DESCRIPTION
This PR add a `RotateWithMap` property for the class `Mapsui.UI.Forms.Pin`. See issue #1001.