### PR TITLE
Csharp8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Common Project Properties -->
+  <PropertyGroup>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+</Project>

--- a/Mapsui.Desktop/Mapsui.Desktop.csproj
+++ b/Mapsui.Desktop/Mapsui.Desktop.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Mapsui.Geometries/Mapsui.Geometries.csproj
+++ b/Mapsui.Geometries/Mapsui.Geometries.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj
+++ b/Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Mapsui.Rendering.Xaml/Mapsui.Rendering.Xaml.csproj
+++ b/Mapsui.Rendering.Xaml/Mapsui.Rendering.Xaml.csproj
@@ -33,8 +33,7 @@
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>latest</LangVersion>
+    <WarningLevel>4</WarningLevel>    
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/Mapsui.UI.Android/Mapsui.UI.Android.csproj
+++ b/Mapsui.UI.Android/Mapsui.UI.Android.csproj
@@ -38,7 +38,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Java.Interop" />

--- a/Mapsui.UI.Uwp/Mapsui.UI.Uwp.csproj
+++ b/Mapsui.UI.Uwp/Mapsui.UI.Uwp.csproj
@@ -36,7 +36,6 @@
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;__UWP__</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>

--- a/Mapsui.UI.Wpf/Mapsui.UI.Wpf.csproj
+++ b/Mapsui.UI.Wpf/Mapsui.UI.Wpf.csproj
@@ -7,7 +7,6 @@
     <DefineConstants>TRACE;DEBUG;NET46;__WPF__</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.iOS/Mapsui.UI.iOS.csproj
+++ b/Mapsui.UI.iOS/Mapsui.UI.iOS.csproj
@@ -32,7 +32,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Mapsui.sln
+++ b/Mapsui.sln
@@ -48,6 +48,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		appveyor-docs.yml = appveyor-docs.yml
 		appveyor.yml = appveyor.yml
+		Directory.Build.props = Directory.Build.props
 		LICENSE.md = LICENSE.md
 		Mapsui.Common.props = Mapsui.Common.props
 		Mapsui.ncrunchsolution = Mapsui.ncrunchsolution

--- a/Mapsui/Mapsui.csproj
+++ b/Mapsui/Mapsui.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BruTile" Version="3.0.0" />

--- a/Tools/VersionUpdater/VersionUpdater.csproj
+++ b/Tools/VersionUpdater/VersionUpdater.csproj
@@ -24,7 +24,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Set the CSharp Language Version only in Directory.Build.props

This Pull Request Changes the CSharp Language Version to C# 8.0 so that nullable annotations could be made. 