### PR TITLE
Fix WmsProvider ContentType Header validation

### DIFF
--- a/Mapsui.Desktop/Wms/WmsProvider.cs
+++ b/Mapsui.Desktop/Wms/WmsProvider.cs
@@ -506,9 +506,9 @@ namespace Mapsui.Desktop.Wms
                 throw new Exception($"Unexpected WMS response code: {response.StatusCode}");
             }
 
-            if (response.Content.Headers.ContentType.ToString().ToLower() != _mimeType)
+            if (response.Content.Headers.ContentType.MediaType.ToLower() != _mimeType)
             { 
-                throw new Exception($"Unexpected WMS response content type. Expected - {_mimeType}, getted - {response.Content.Headers.ContentType}");
+                throw new Exception($"Unexpected WMS response content type. Expected - {_mimeType}, getted - {response.Content.Headers.ContentType.MediaType}");
             }
        
             return await response.Content.ReadAsStreamAsync();


### PR DESCRIPTION
The WmsProviders compares the content-type of the response with the one requested. But if the response content-type contains additional parameters, it throws an exception that makes some WMS services impossible to use.

Example service [here](https://geoservices.buergernetz.bz.it/geoserver/p_bz-cadastre_public/ows?SERVICE=WMS&VERSION=1.3.0):

Request content-type: `image/png`
Response content-type: `image/png; mode=8bit`

Another common parameter is `quality` e.g. `image/jpg; quality=50`

This fix compares only the `ContentType.MediaType` (mime-type without parameters).