### PR TITLE
update BruTile to version 3.1.2

### DIFF
--- a/Mapsui.Desktop/Mapsui.Desktop.csproj
+++ b/Mapsui.Desktop/Mapsui.Desktop.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" Version="3.0.0" />
+    <PackageReference Include="BruTile" Version="3.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.Rendering.Xaml/Mapsui.Rendering.Xaml.csproj
+++ b/Mapsui.Rendering.Xaml/Mapsui.Rendering.Xaml.csproj
@@ -23,28 +23,21 @@
     <ProjectReference Include="..\Mapsui\Mapsui.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile">
-      <Version>3.0.0</Version>
+    <PackageReference Include="BruTile" Version="3.1.2">
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Svg2Xaml">
-      <Version>0.3.0.5</Version>
+    <PackageReference Include="Svg2Xaml" Version="0.3.0.5">
     </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Memory">
-      <Version>4.5.4</Version>
+    <PackageReference Include="System.Memory" Version="4.5.4">
     </PackageReference>
-    <PackageReference Include="System.Net.Http">
-      <Version>4.3.4</Version>
+    <PackageReference Include="System.Net.Http" Version="4.3.4">
     </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.7.1</Version>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Algorithms">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.X509Certificates">
-      <Version>4.3.2</Version>
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2">
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Mapsui.UI.Wpf/Mapsui.UI.Wpf.csproj
+++ b/Mapsui.UI.Wpf/Mapsui.UI.Wpf.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" Version="3.0.0" />
+    <PackageReference Include="BruTile" Version="3.1.2" />
     <PackageReference Include="SkiaSharp" Version="2.80.2" />
     <PackageReference Include="SkiaSharp.Views" Version="2.80.2" />
   </ItemGroup>

--- a/Mapsui/Mapsui.csproj
+++ b/Mapsui/Mapsui.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile" Version="3.0.0" />
+    <PackageReference Include="BruTile" Version="3.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/Samples/Mapsui.Samples.Common.Desktop/Mapsui.Samples.Common.Desktop.csproj
+++ b/Samples/Mapsui.Samples.Common.Desktop/Mapsui.Samples.Common.Desktop.csproj
@@ -81,8 +81,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" Version="3.0.0" />
-    <PackageReference Include="BruTile.Desktop" Version="3.0.0" />
+    <PackageReference Include="BruTile" Version="3.1.2" />
+    <PackageReference Include="BruTile.Desktop" Version="3.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.Common/Mapsui.Samples.Common.csproj
+++ b/Samples/Mapsui.Samples.Common/Mapsui.Samples.Common.csproj
@@ -59,9 +59,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" Version="3.0.0" />
+    <PackageReference Include="BruTile" Version="3.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="BruTile.MbTiles" Version="3.0.0" />
+    <PackageReference Include="BruTile.MbTiles" Version="3.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.Droid/Mapsui.Samples.Droid.csproj
+++ b/Samples/Mapsui.Samples.Droid/Mapsui.Samples.Droid.csproj
@@ -103,7 +103,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BruTile.MbTiles">
-      <Version>3.0.0</Version>
+      <Version>3.1.2</Version>
     </PackageReference>
     <PackageReference Include="SkiaSharp">
       <Version>2.80.2</Version>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Android/Mapsui.Samples.Forms.Android.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Android/Mapsui.Samples.Forms.Android.csproj
@@ -102,7 +102,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BruTile.MbTiles">
-      <Version>3.0.0</Version>
+      <Version>3.1.2</Version>
     </PackageReference>
     <PackageReference Include="ConcurrentHashSet">
       <Version>1.1.0</Version>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Mac/Mapsui.Samples.Forms.Mac.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Mac/Mapsui.Samples.Forms.Mac.csproj
@@ -112,7 +112,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BruTile.MbTiles">
-      <Version>3.0.0</Version>
+      <Version>3.1.2</Version>
     </PackageReference>
     <PackageReference Include="ConcurrentHashSet">
       <Version>1.1.0</Version>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.WPF/Mapsui.Samples.Forms.WPF.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.WPF/Mapsui.Samples.Forms.WPF.csproj
@@ -14,55 +14,39 @@
     <ProjectReference Include="..\Mapsui.Samples.Forms.Shared\Mapsui.Samples.Forms.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile.MbTiles">
-      <Version>3.0.0</Version>
+    <PackageReference Include="BruTile.MbTiles" Version="3.1.2">
     </PackageReference>
-    <PackageReference Include="HarfBuzzSharp">
-      <Version>2.6.1.7</Version>
+    <PackageReference Include="HarfBuzzSharp" Version="2.6.1.7">
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3">
     </PackageReference>
-    <PackageReference Include="OpenTK.GLControl">
-      <Version>3.1.0</Version>
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0">
     </PackageReference>
-    <PackageReference Include="SkiaSharp.Views.Forms.WPF">
-      <Version>2.80.2</Version>
+    <PackageReference Include="SkiaSharp.Views.Forms.WPF" Version="2.80.2">
     </PackageReference>
-    <PackageReference Include="SQLitePCLRaw.bundle_green">
-      <Version>1.1.14</Version>
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="1.1.14">
     </PackageReference>
-    <PackageReference Include="Svg.Skia">
-      <Version>0.4.1</Version>
+    <PackageReference Include="Svg.Skia" Version="0.4.1">
     </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Memory">
-      <Version>4.5.4</Version>
+    <PackageReference Include="System.Memory" Version="4.5.4">
     </PackageReference>
-    <PackageReference Include="System.Net.Http">
-      <Version>4.3.4</Version>
+    <PackageReference Include="System.Net.Http" Version="4.3.4">
     </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.7.1</Version>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Algorithms">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.X509Certificates">
-      <Version>4.3.2</Version>
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2">
     </PackageReference>
-    <PackageReference Include="Topten.RichTextKit">
-      <Version>0.3.134</Version>
+    <PackageReference Include="Topten.RichTextKit" Version="0.3.134">
     </PackageReference>
-    <PackageReference Include="Xam.Plugin.Geolocator">
-      <Version>4.5.0.6</Version>
+    <PackageReference Include="Xam.Plugin.Geolocator" Version="4.5.0.6">
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms">
-      <Version>5.0.0.1905</Version>
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1905">
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms.Platform.WPF">
-      <Version>5.0.0.1905</Version>
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.1905">
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.iOS/Mapsui.Samples.Forms.iOS.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.iOS/Mapsui.Samples.Forms.iOS.csproj
@@ -133,7 +133,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BruTile">
-      <Version>3.0.0</Version>
+      <Version>3.1.2</Version>
     </PackageReference>
     <PackageReference Include="HarfBuzzSharp">
       <Version>2.6.1.7</Version>
@@ -163,7 +163,7 @@
       <Version>1.6.292</Version>
     </PackageReference>
     <PackageReference Include="BruTile.MbTiles">
-      <Version>3.0.0</Version>
+      <Version>3.1.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/Mapsui.Samples.Wpf.Editing/Mapsui.Samples.Wpf.Editing.csproj
+++ b/Samples/Mapsui.Samples.Wpf.Editing/Mapsui.Samples.Wpf.Editing.csproj
@@ -13,56 +13,40 @@
     <ProjectReference Include="..\..\Mapsui\Mapsui.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile.MbTiles">
-      <Version>3.0.0</Version>
+    <PackageReference Include="BruTile.MbTiles" Version="3.1.2">
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3">
     </PackageReference>
-    <PackageReference Include="OpenTK.GLControl">
-      <Version>3.1.0</Version>
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0">
     </PackageReference>
-    <PackageReference Include="SkiaSharp.Views">
-      <Version>2.80.2</Version>
+    <PackageReference Include="SkiaSharp.Views" Version="2.80.2">
     </PackageReference>
-    <PackageReference Include="SQLitePCLRaw.bundle_green">
-      <Version>1.1.14</Version>
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="1.1.14">
     </PackageReference>
-    <PackageReference Include="Svg.Skia">
-      <Version>0.4.1</Version>
+    <PackageReference Include="Svg.Skia" Version="0.4.1">
     </PackageReference>
-    <PackageReference Include="System.Collections">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Collections" Version="4.3.0">
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Diagnostics.Debug">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Memory">
-      <Version>4.5.4</Version>
+    <PackageReference Include="System.Memory" Version="4.5.4">
     </PackageReference>
-    <PackageReference Include="System.Net.Http">
-      <Version>4.3.4</Version>
+    <PackageReference Include="System.Net.Http" Version="4.3.4">
     </PackageReference>
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Runtime" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.7.1</Version>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1">
     </PackageReference>
-    <PackageReference Include="System.Runtime.Extensions">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Algorithms">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.X509Certificates">
-      <Version>4.3.2</Version>
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2">
     </PackageReference>
-    <PackageReference Include="System.Threading">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Threading" Version="4.3.0">
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Samples/Mapsui.Samples.Wpf/Mapsui.Samples.Wpf.csproj
+++ b/Samples/Mapsui.Samples.Wpf/Mapsui.Samples.Wpf.csproj
@@ -41,10 +41,10 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Update="System.Core"/>
+    <Reference Update="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Xaml" />
-    <Reference Update="System.Xml.Linq"/>
+    <Reference Update="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -110,160 +110,109 @@
     <ProjectReference Include="..\Mapsui.Samples.CustomWidget\Mapsui.Samples.CustomWidget.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile.MbTiles">
-      <Version>3.0.0</Version>
+    <PackageReference Include="BruTile.MbTiles" Version="3.1.2">
     </PackageReference>
-    <PackageReference Include="HarfBuzzSharp">
-      <Version>2.6.1.7</Version>
+    <PackageReference Include="HarfBuzzSharp" Version="2.6.1.7">
     </PackageReference>
-    <PackageReference Include="Microsoft.NETCore.Platforms">
-      <Version>3.1.0</Version>
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="3.1.0">
     </PackageReference>
-    <PackageReference Include="Microsoft.Win32.Primitives">
-      <Version>4.3.0</Version>
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="NETStandard.Library">
-      <Version>2.0.3</Version>
+    <PackageReference Include="NETStandard.Library" Version="2.0.3">
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3">
     </PackageReference>
-    <PackageReference Include="OpenTK.GLControl">
-      <Version>3.1.0</Version>
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0">
     </PackageReference>
-    <PackageReference Include="SkiaSharp.Views">
-      <Version>2.80.2</Version>
+    <PackageReference Include="SkiaSharp.Views" Version="2.80.2">
     </PackageReference>
-    <PackageReference Include="SQLitePCLRaw.bundle_green">
-      <Version>1.1.14</Version>
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="1.1.14">
     </PackageReference>
-    <PackageReference Include="Svg.Skia">
-      <Version>0.4.1</Version>
+    <PackageReference Include="Svg.Skia" Version="0.4.1">
     </PackageReference>
-    <PackageReference Include="System.AppContext">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.AppContext" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Collections">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Collections" Version="4.3.0">
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
-    <PackageReference Include="System.Console">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Console" Version="4.3.1">
     </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Diagnostics.Debug">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource">
-      <Version>4.7.0</Version>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0">
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.Tools">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.Tracing">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Globalization">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Globalization" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Globalization.Calendars">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Globalization.Calendars" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.IO.Compression">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.IO.Compression" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.IO.Compression.ZipFile">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.IO.FileSystem">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Linq">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Linq" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Linq.Expressions">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Linq.Expressions" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Memory">
-      <Version>4.5.4</Version>
+    <PackageReference Include="System.Memory" Version="4.5.4">
     </PackageReference>
-    <PackageReference Include="System.Net.Http">
-      <Version>4.3.4</Version>
+    <PackageReference Include="System.Net.Http" Version="4.3.4">
     </PackageReference>
-    <PackageReference Include="System.Net.Primitives">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Net.Primitives" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Net.Sockets">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.ObjectModel">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.ObjectModel" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Reflection">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Reflection" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Reflection.Extensions">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Reflection.Primitives">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Reflection.Primitives" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Resources.ResourceManager">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Runtime" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.7.1</Version>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1">
     </PackageReference>
-    <PackageReference Include="System.Runtime.Extensions">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Runtime.Handles">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Runtime.InteropServices">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Runtime.Numerics">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Runtime.Numerics" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Algorithms">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.X509Certificates">
-      <Version>4.3.2</Version>
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2">
     </PackageReference>
-    <PackageReference Include="System.Text.Encoding">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Text.Encoding.Extensions">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Text.RegularExpressions">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Threading">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Threading" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Threading.Tasks">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Threading.Timer">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Threading.Timer" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Xml.ReaderWriter">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Xml.XDocument">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Xml.XDocument" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="Topten.RichTextKit">
-      <Version>0.3.134</Version>
+    <PackageReference Include="Topten.RichTextKit" Version="0.3.134">
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Samples/Mapsui.Samples.iOS/Mapsui.Samples.iOS.csproj
+++ b/Samples/Mapsui.Samples.iOS/Mapsui.Samples.iOS.csproj
@@ -242,7 +242,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BruTile.MbTiles">
-      <Version>3.0.0</Version>
+      <Version>3.1.2</Version>
     </PackageReference>
     <PackageReference Include="HarfBuzzSharp">
       <Version>2.6.1.7</Version>

--- a/Tests/Mapsui.Rendering.Skia.Tests/Mapsui.Rendering.Skia.Tests.csproj
+++ b/Tests/Mapsui.Rendering.Skia.Tests/Mapsui.Rendering.Skia.Tests.csproj
@@ -41,20 +41,12 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Mapsui.Geometries\Mapsui.Geometries.csproj">
-      <Project>{ee55b62d-ffa2-4c24-a4ad-7a47ace55ce5}</Project>
-      <Name>Mapsui.Geometries</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj">
-      <Project>{AE632270-38CA-4203-93A5-8612629CD944}</Project>
-      <Name>Mapsui.Rendering.Skia</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\Mapsui\Mapsui.csproj">
-      <Project>{d74c052a-c07e-4b37-a898-134218aca5c9}</Project>
-      <Name>Mapsui</Name>
     </ProjectReference>
     <ProjectReference Include="..\Mapsui.Tests.Common\Mapsui.Tests.Common.csproj">
-      <Project>{81bb36d2-4d01-44e3-9024-e7cbd10da316}</Project>
-      <Name>Mapsui.Tests.Common</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -96,160 +88,110 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile">
-      <Version>3.0.0</Version>
+    <PackageReference Include="BruTile" Version="3.1.2">
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeCoverage">
-      <Version>16.5.0</Version>
+    <PackageReference Include="Microsoft.CodeCoverage" Version="16.5.0">
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NETCore.Platforms">
-      <Version>3.1.0</Version>
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="3.1.0">
     </PackageReference>
-    <PackageReference Include="Microsoft.Win32.Primitives">
-      <Version>4.3.0</Version>
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="NETStandard.Library">
-      <Version>2.0.3</Version>
+    <PackageReference Include="NETStandard.Library" Version="2.0.3">
     </PackageReference>
-    <PackageReference Include="NUnit">
-      <Version>3.12.0</Version>
+    <PackageReference Include="NUnit" Version="3.12.0">
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter">
-      <Version>3.16.1</Version>
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="OpenTK.GLControl">
-      <Version>3.1.0</Version>
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0">
     </PackageReference>
-    <PackageReference Include="SkiaSharp.Views">
-      <Version>2.80.2</Version>
+    <PackageReference Include="SkiaSharp.Views" Version="2.80.2">
     </PackageReference>
-    <PackageReference Include="Svg.Skia">
-      <Version>0.4.1</Version>
+    <PackageReference Include="Svg.Skia" Version="0.4.1">
     </PackageReference>
-    <PackageReference Include="System.AppContext">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.AppContext" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Collections">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Collections" Version="4.3.0">
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
-    <PackageReference Include="System.Console">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Console" Version="4.3.1">
     </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Diagnostics.Debug">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource">
-      <Version>4.7.0</Version>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0">
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.Tools">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.Tracing">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Globalization">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Globalization" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Globalization.Calendars">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Globalization.Calendars" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.IO.Compression">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.IO.Compression" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.IO.Compression.ZipFile">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.IO.FileSystem">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Linq">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Linq" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Linq.Expressions">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Linq.Expressions" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Memory">
-      <Version>4.5.4</Version>
+    <PackageReference Include="System.Memory" Version="4.5.4">
     </PackageReference>
-    <PackageReference Include="System.Net.Http">
-      <Version>4.3.4</Version>
+    <PackageReference Include="System.Net.Http" Version="4.3.4">
     </PackageReference>
-    <PackageReference Include="System.Net.Primitives">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Net.Primitives" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Net.Sockets">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.ObjectModel">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.ObjectModel" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Reflection">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Reflection" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Reflection.Extensions">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Reflection.Primitives">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Reflection.Primitives" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Resources.ResourceManager">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Runtime" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.7.1</Version>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1">
     </PackageReference>
-    <PackageReference Include="System.Runtime.Extensions">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Runtime.Handles">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Runtime.InteropServices">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Runtime.Numerics">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Runtime.Numerics" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Algorithms">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.X509Certificates">
-      <Version>4.3.2</Version>
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2">
     </PackageReference>
-    <PackageReference Include="System.Text.Encoding">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Text.Encoding.Extensions">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Text.RegularExpressions">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Threading">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Threading" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Threading.Tasks">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Threading.Timer">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Threading.Timer" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Xml.ReaderWriter">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Xml.XDocument">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Xml.XDocument" Version="4.3.0">
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Tests/Mapsui.Rendering.Xaml.Tests/Mapsui.Rendering.Xaml.Tests.csproj
+++ b/Tests/Mapsui.Rendering.Xaml.Tests/Mapsui.Rendering.Xaml.Tests.csproj
@@ -62,39 +62,29 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile">
-      <Version>3.0.0</Version>
+    <PackageReference Include="BruTile" Version="3.1.2">
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeCoverage">
-      <Version>16.5.0</Version>
+    <PackageReference Include="Microsoft.CodeCoverage" Version="16.5.0">
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="NUnit">
-      <Version>3.12.0</Version>
+    <PackageReference Include="NUnit" Version="3.12.0">
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter">
-      <Version>3.16.1</Version>
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SkiaSharp">
-      <Version>2.80.2</Version>
+    <PackageReference Include="SkiaSharp" Version="2.80.2">
     </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Memory">
-      <Version>4.5.4</Version>
+    <PackageReference Include="System.Memory" Version="4.5.4">
     </PackageReference>
-    <PackageReference Include="System.Net.Http">
-      <Version>4.3.4</Version>
+    <PackageReference Include="System.Net.Http" Version="4.3.4">
     </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.7.1</Version>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Algorithms">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.X509Certificates">
-      <Version>4.3.2</Version>
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2">
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Tests/Mapsui.Tests.Common/Mapsui.Tests.Common.csproj
+++ b/Tests/Mapsui.Tests.Common/Mapsui.Tests.Common.csproj
@@ -37,7 +37,7 @@
     <ProjectReference Include="..\..\Samples\Mapsui.Samples.CustomWidget\Mapsui.Samples.CustomWidget.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile" Version="3.0.0" />
+    <PackageReference Include="BruTile" Version="3.1.2" />
   </ItemGroup>
 
 </Project>

--- a/Tests/Mapsui.Tests/Mapsui.Tests.csproj
+++ b/Tests/Mapsui.Tests/Mapsui.Tests.csproj
@@ -23,46 +23,33 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile">
-      <Version>3.0.0</Version>
+    <PackageReference Include="BruTile" Version="3.1.2">
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeCoverage">
-      <Version>16.5.0</Version>
+    <PackageReference Include="Microsoft.CodeCoverage" Version="16.5.0">
     </PackageReference>
-    <PackageReference Include="NUnit">
-      <Version>3.12.0</Version>
+    <PackageReference Include="NUnit" Version="3.12.0">
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter">
-      <Version>3.16.1</Version>
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Collections">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Collections" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.Debug">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0">
     </PackageReference>
-    <PackageReference Include="System.Memory">
-      <Version>4.5.4</Version>
+    <PackageReference Include="System.Memory" Version="4.5.4">
     </PackageReference>
-    <PackageReference Include="System.Net.Http">
-      <Version>4.3.4</Version>
+    <PackageReference Include="System.Net.Http" Version="4.3.4">
     </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.7.1</Version>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1">
     </PackageReference>
-    <PackageReference Include="System.Runtime.Extensions">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Algorithms">
-      <Version>4.3.1</Version>
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1">
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.X509Certificates">
-      <Version>4.3.2</Version>
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2">
     </PackageReference>
-    <PackageReference Include="System.Threading">
-      <Version>4.3.0</Version>
+    <PackageReference Include="System.Threading" Version="4.3.0">
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR updates the three BruTile packages ...

* BruTile
* BruTile.Desktop
* BruTile.MbTiles

... from version 3.0.0 to 3.1.2.

The update is done via VS for Mac. The changes include a couple of linebreak changes (automatically done by VS) and some line removals in the ProjectReferences of `Mapsui.Rendering.Skia.Tests`. I don't really understand the latter, but since this is also an automatic change by VS, I assume it is harmless.

To be on the safe side, I tried to run those unit test, and all 11 fail on the branch, but in fact the also fail on master already (so it's definitely not due to my changes).