### PR TITLE
TouchAction implemented and tested

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -111,6 +111,10 @@ namespace Mapsui.UI.Forms
 
             var location = GetScreenPosition(e.Location);
 
+            // if user handles action by his own return
+            TouchAction?.Invoke(sender, e);
+            if (e.Handled) return;
+
             if (e.ActionType == SKTouchAction.Pressed)
             {
                 _firstTouch = location;
@@ -308,6 +312,11 @@ namespace Mapsui.UI.Forms
         public new event EventHandler<TouchedEventArgs> TouchMove;
 #else
         public event EventHandler<TouchedEventArgs> TouchMove;
+
+        /// <summary>
+        /// TouchAction is called, when user provoques a touch event
+        /// </summary>
+        public event EventHandler<SKTouchEventArgs> TouchAction;
 #endif
 
         /// <summary>

--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Svg.Skia;
 using Xamarin.Forms;
+using SkiaSharp.Views.Forms;
 
 namespace Mapsui.UI.Forms
 {
@@ -77,6 +78,7 @@ namespace Mapsui.UI.Forms
             _mapControl.TouchEntered += HandlerTouchEntered;
             _mapControl.TouchExited += HandlerTouchExited;
             _mapControl.TouchMove += HandlerTouchMove;
+            _mapControl.TouchAction += HandlerTouchAction;
             _mapControl.Swipe += HandlerSwipe;
             _mapControl.Fling += HandlerFling;
             _mapControl.Zoomed += HandlerZoomed;
@@ -215,6 +217,11 @@ namespace Mapsui.UI.Forms
         /// TouchMove is called, when user move mouse over map (independent from mouse button state) or move finger on display
         /// </summary>
         public event EventHandler<TouchedEventArgs> TouchMove;
+
+        /// <summary>
+        /// TouchAction is called, when user provoques a touch event
+        /// </summary>
+        public event EventHandler<SKTouchEventArgs> TouchAction;
 
         /// <summary>
         /// Hovered is called, when user move mouse over map without pressing mouse button
@@ -944,6 +951,11 @@ namespace Mapsui.UI.Forms
         private void HandlerTouchExited(object sender, TouchedEventArgs e)
         {
             TouchExited?.Invoke(sender, e);
+        }
+
+        private void HandlerTouchAction(object sender, SKTouchEventArgs e)
+        {
+            TouchAction?.Invoke(sender, e);
         }
 
         private void HandlerPinPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
Mapsui offers a lot of possible interactions with the user.

Among those, one has MapInfo events, click events, double click events, long tap events, move events ...

Some of these events rely on SkiSharp touch events, others are driven by timers or control loops on mouse or tap user actions.

Nevertheless, Mapsui cannot provide a suitable interface for all possible cases, some decisions had to be made. For instance timers of 250ms for double click detection can be short on some devices. Sometime detection of the feature contact is not sufficient.

The decision of detecting a long tap rather than a move can be awkward on some devices and in fact depend on the user interface intention.

Enabling double click detection will slow down all the interface interaction as one has to wait for the timer to elapse before being able to detect that no second click occurred, therefore it has to be made case by case depending of the current user interaction with the interface or position on the screen.

I am currently designing a Road Editor, this means adding waypoints, dragging them, clicking or double clicking the waypoints or the road ... 

Tapping on a polyline with big fingers like mines can be difficult, so I prefer to detect if a (long, double) tap occurred a a given distance of a feature rather than on the feature, and this distance has to be adapted to the current resolution of the map ..

It is in no way criticisms to the Mapsui interface that will fulfil most of the user needs but it is unavoidable that some special cases cannot be solved.

Therefore I propose to implement a new interface to the Mapview enabling to connect directly to the SKTouch actions (pressed, released, move, ...)

```
       MapView.TouchAction += MapTouchAction;

        private async void MapTouchAction(object sender, SKTouchEventArgs e)
        {
                switch (e.ActionType)
                {
                    case SKTouchAction.Pressed:
                        //....
                        break;

                    case SKTouchAction.Released:
                        //...
                        break;

                    case SKTouchAction.Moved:
                        //...
                        break;
                     ....
                }
        }
```

This enables the user to write his own Man Machine Interface and to take full control of the behaviour of his application.
