### PR TITLE
change Pin.Svg from string to byte[]

### DIFF
--- a/Mapsui.UI.Forms/Objects/Pin.cs
+++ b/Mapsui.UI.Forms/Objects/Pin.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using Mapsui.Providers;
 using Mapsui.Rendering.Skia;
 using Mapsui.Styles;
@@ -25,7 +24,7 @@ namespace Mapsui.UI.Forms
         public static readonly BindableProperty LabelProperty = BindableProperty.Create(nameof(Label), typeof(string), typeof(Pin), default(string));
         public static readonly BindableProperty AddressProperty = BindableProperty.Create(nameof(Address), typeof(string), typeof(Pin), default(string));
         public static readonly BindableProperty IconProperty = BindableProperty.Create(nameof(Icon), typeof(byte[]), typeof(Pin), default(byte[]));
-        public static readonly BindableProperty SvgProperty = BindableProperty.Create(nameof(Svg), typeof(string), typeof(Pin), default(string));
+        public static readonly BindableProperty SvgProperty = BindableProperty.Create(nameof(Svg), typeof(byte[]), typeof(Pin), default(byte[]));
         public static readonly BindableProperty ScaleProperty = BindableProperty.Create(nameof(Scale), typeof(float), typeof(Pin), 1.0f);
         public static readonly BindableProperty RotationProperty = BindableProperty.Create(nameof(Rotation), typeof(float), typeof(Pin), 0f);
         public static readonly BindableProperty RotateWithMapProperty = BindableProperty.Create(nameof(RotateWithMap), typeof(bool), typeof(Pin), false);
@@ -148,9 +147,9 @@ namespace Mapsui.UI.Forms
         /// <summary>
         /// String holding the Svg image informations
         /// </summary>
-        public string Svg
+        public byte[] Svg
         {
-            get { return (string)GetValue(SvgProperty); }
+            get { return (byte[])GetValue(SvgProperty); }
             set { SetValue(SvgProperty, value); }
         }
 
@@ -450,8 +449,8 @@ namespace Mapsui.UI.Forms
                 {
                     case PinType.Svg:
                         // Load the SVG document
-                        if (!string.IsNullOrEmpty(Svg))
-                            stream = new MemoryStream(Encoding.UTF8.GetBytes(Svg));
+                        if (Svg != null)
+                            stream = new MemoryStream(Svg);
                         if (stream == null)
                             return;
                         _bitmapId = BitmapRegistry.Instance.Register(stream);

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/ManyPinsSample.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/ManyPinsSample.cs
@@ -39,7 +39,7 @@ namespace Mapsui.Samples.Forms
                         Address = e.Point.ToString(),
                         Position = e.Point,
                         Type = PinType.Pin,
-                        Color = new Xamarin.Forms.Color(rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0),
+                        Color = new Color(rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0),
                         Transparency = 0.5f,
                         Scale = rnd.Next(50, 130) / 100f,
                     };
@@ -56,7 +56,7 @@ namespace Mapsui.Samples.Forms
                         pin.Callout.Type = CalloutType.Detail;
                         pin.Callout.TitleFontSize = rnd.Next(15, 30);
                         pin.Callout.SubtitleFontSize = pin.Callout.TitleFontSize - 5;
-                        pin.Callout.TitleFontColor = new Xamarin.Forms.Color(rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0);
+                        pin.Callout.TitleFontColor = new Color(rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0);
                         pin.Callout.SubtitleFontColor = pin.Color;
                     }
                     else
@@ -72,15 +72,13 @@ namespace Mapsui.Samples.Forms
                         System.Diagnostics.Debug.WriteLine(r);
 
                     var stream = assembly.GetManifestResourceStream("Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg");
-                    StreamReader reader = new StreamReader(stream);
-                    string svgString = reader.ReadToEnd();
                     mapView.Pins.Add(new Pin(mapView)
                     {
                         Label = $"PinType.Svg {markerNum++}",
                         Position = e.Point,
                         Type = PinType.Svg,
                         Scale = 0.1f,
-                        Svg = svgString
+                        Svg = stream.ToBytes()
                     });
                     break;
                 case 3:
@@ -135,7 +133,7 @@ namespace Mapsui.Samples.Forms
                 Address = position.ToString(),
                 Position = position,
                 Type = PinType.Pin,
-                Color = new Xamarin.Forms.Color(rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0),
+                Color = new Color(rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0),
                 Transparency = 0.5f,
                 Scale = rnd.Next(50, 130) / 100f,
             };
@@ -152,7 +150,7 @@ namespace Mapsui.Samples.Forms
                 pin.Callout.Type = CalloutType.Detail;
                 pin.Callout.TitleFontSize = rnd.Next(15, 30);
                 pin.Callout.SubtitleFontSize = pin.Callout.TitleFontSize - 5;
-                pin.Callout.TitleFontColor = new Xamarin.Forms.Color(rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0);
+                pin.Callout.TitleFontColor = new Color(rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0);
                 pin.Callout.SubtitleFontColor = pin.Color;
             }
             else

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PinSample.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PinSample.cs
@@ -94,8 +94,6 @@ namespace Mapsui.Samples.Forms.Shared
                     var resourceName = "Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg";
                     var stream = assembly.GetManifestResourceStream(resourceName);
                     if (stream == null) throw new Exception($"Could not find EmbeddedResource {resourceName}");
-                    var reader = new StreamReader(stream);
-                    string svgString = reader.ReadToEnd();
                     mapView.Pins.Add(new Pin(mapView)
                     {
                         Label = $"PinType.Svg {_markerNum++}",
@@ -103,7 +101,7 @@ namespace Mapsui.Samples.Forms.Shared
                         Type = PinType.Svg,
                         Scale = 0.1f,
                         RotateWithMap = true,
-                        Svg = svgString
+                        Svg = stream.ToBytes()
                     });
                     break;
                 case 3:


### PR DESCRIPTION
* this avoids a conversion in Pin.CreateFeature
* it is more consistent with Pin.Icon (which is also a byte array)
* and it makes the usage easier
  (avoiding the need for a StreamReader)
* see issue #1084