### PR TITLE
Fix #1087

### DIFF
--- a/Mapsui/Navigation/Navigator.cs
+++ b/Mapsui/Navigation/Navigator.cs
@@ -85,8 +85,8 @@ namespace Mapsui
 
             if (duration == 0)
             {
-                _viewport.SetCenter(center);
                 _viewport.SetResolution(resolution);
+                _viewport.SetCenter(center);
 
                 Navigated?.Invoke(this, ChangeType.Discrete);
             }
@@ -190,8 +190,8 @@ namespace Mapsui
 
             if (duration == 0)
             {
-                _viewport.SetCenter(CalculateCenterOfMap(centerOfZoom, resolution));
                 _viewport.SetResolution(resolution);
+                _viewport.SetCenter(CalculateCenterOfMap(centerOfZoom, resolution));
                 
                 Navigated?.Invoke(this, ChangeType.Discrete);
             }


### PR DESCRIPTION
#1087

This fixes the incorrect order of updating the viewport for when fully zoomed out in a limited viewport. If Center is set first then the Y value will end up as 0 as the zoom happened second.