### PR TITLE
Added a render loop instead of always calling InvalidateSurface()

### DIFF
--- a/Mapsui/Navigation/AnimatedNavigator.cs
+++ b/Mapsui/Navigation/AnimatedNavigator.cs
@@ -79,7 +79,7 @@ namespace Mapsui
             throw new NotImplementedException();
         }
 
-        public void UpdateAnimations()
+        public bool UpdateAnimations()
         {
             throw new NotImplementedException();
         }

--- a/Mapsui/Navigation/INavigator.cs
+++ b/Mapsui/Navigation/INavigator.cs
@@ -108,6 +108,6 @@ namespace Mapsui
         /// </summary>
         void StopRunningAnimation();
 
-        void UpdateAnimations();
+        bool UpdateAnimations();
     }
 }

--- a/Mapsui/Navigation/Navigator.cs
+++ b/Mapsui/Navigation/Navigator.cs
@@ -601,9 +601,9 @@ namespace Mapsui
             // Nothing to do
         }
 
-        public void UpdateAnimations()
+        public bool UpdateAnimations()
         {
-            _animation.UpdateAnimations();
+            return _animation.UpdateAnimations();
         }
     }
 }

--- a/Mapsui/Utilities/Animation.cs
+++ b/Mapsui/Utilities/Animation.cs
@@ -97,9 +97,10 @@ namespace Mapsui.Utilities
             }
         }
 
-        public void UpdateAnimations()
+        public bool UpdateAnimations()
         {
-            if (!IsRunning) return;
+            if (!IsRunning) 
+                return false;
 
             double ticks = _stopwatch.ElapsedTicks - _stopwatchStart;
             var value = ticks / _durationTicks;
@@ -107,7 +108,7 @@ namespace Mapsui.Utilities
             if (value >= 1.0)
             {
                 Stop(true);
-                return;
+                return true;
             }
 
             // Calc new values
@@ -116,6 +117,8 @@ namespace Mapsui.Utilities
                 if (value >= entry.AnimationStart && value <= entry.AnimationEnd)
                     entry.Tick(value);
             }
+
+            return true;
         }
 
         public void Start(List<AnimationEntry> entries, long duration)


### PR DESCRIPTION
Added a render loop instead of always calling InvalidateSurface() each time anything changes.

The render loop is called each 16 ms and checks, if something has changed (needs redraw or an animation is running). If a redraw is already running, the frame is dropped.

This is a PR for discussion and isn't tested very heavy. I'm not sure, if this is much faster than the old system. Should be tested carefully.