### PR TITLE
Removed a bug where Circles couldn't have different colors and widths

### DIFF
--- a/Mapsui.UI.Forms/Objects/Circle.cs
+++ b/Mapsui.UI.Forms/Objects/Circle.cs
@@ -75,6 +75,12 @@ namespace Mapsui.UI.Forms
                 case nameof(FillColor):
                     ((VectorStyle)Feature.Styles.First()).Fill = new Styles.Brush(FillColor.ToMapsui());
                     break;
+                case nameof(StrokeWidth):
+                    ((VectorStyle)Feature.Styles.First()).Outline.Width = StrokeWidth;
+                    break;
+                case nameof(StrokeColor):
+                    ((VectorStyle)Feature.Styles.First()).Outline.Color = StrokeColor.ToMapsui();
+                    break;
             }
         }
 
@@ -95,7 +101,7 @@ namespace Mapsui.UI.Forms
                     Feature.Styles.Clear();
                     Feature.Styles.Add(new VectorStyle
                     {
-                        Line = new Pen { Width = StrokeWidth, Color = StrokeColor.ToMapsui() },
+                        Outline = new Pen { Width = StrokeWidth, Color = StrokeColor.ToMapsui() },
                         Fill = new Styles.Brush { Color = FillColor.ToMapsui() }
                     });
                 }

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/CircleSample.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/CircleSample.cs
@@ -25,6 +25,7 @@ namespace Mapsui.Samples.Forms
                 Radius = Distance.FromMeters(rnd.Next(100000, 1000000)),
                 Quality = rnd.Next(0, 60),
                 StrokeColor = new Color(rnd.Next(0, 255) / 255.0, rnd.Next(0, 255) / 255.0, rnd.Next(0, 255) / 255.0),
+                StrokeWidth = rnd.Next(1, 5),
                 FillColor = new Color(rnd.Next(0, 255) / 255.0, rnd.Next(0, 255) / 255.0, rnd.Next(0, 255) / 255.0, rnd.Next(0, 255) / 255.0)
             };
 


### PR DESCRIPTION
Removed a bug where Circles couldn't have different colors and widths for the outline. See issue #1100.

LineStrings use Line as Pen for the line, Polygons use Outline as Pen for the line. Why? Don't ask me. So Circles have to use Outline in Style instead of Line.

Checked it in Polygons, where it is right.