### PR TITLE
Add missing callouts in iOS and MacOS samples

### DIFF
--- a/Mapsui.Mac.sln
+++ b/Mapsui.Mac.sln
@@ -72,6 +72,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{12D153CE
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VersionUpdater", "Tools\VersionUpdater\VersionUpdater.csproj", "{8AF9DD38-ADC0-471F-A14C-D9C3A68AF972}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Mapsui.UI.Shared", "Mapsui.UI.Shared\Mapsui.UI.Shared.shproj", "{239F2B0D-13CB-4BCF-83BF-F52D696A47B7}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Mapsui.UI.Shared\Mapsui.UI.Shared.projitems*{06e3ebf5-49a2-4c71-948a-1720831213d4}*SharedItemsImports = 5

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Mac/Mapsui.Samples.Forms.Mac.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Mac/Mapsui.Samples.Forms.Mac.csproj
@@ -192,7 +192,7 @@
     <PackageReference Include="System.Linq.Expressions">
       <Version>4.3.0</Version>
     </PackageReference>
-    <PackageReference Include="System.Memory">
+    <PackageReference Include="System.Memory" IncludeAssets="None">
       <Version>4.5.4</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.iOS/Mapsui.Samples.Forms.iOS.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.iOS/Mapsui.Samples.Forms.iOS.csproj
@@ -165,6 +165,9 @@
     <PackageReference Include="BruTile.MbTiles">
       <Version>3.1.3</Version>
     </PackageReference>
+    <PackageReference Include="System.Memory" IncludeAssets="None">
+      <Version>4.5.4</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mapsui.Geometries\Mapsui.Geometries.csproj">


### PR DESCRIPTION
This fixes #1093 (it's a workaround for an issue with xamarin-macios). For details see the issue.

Also I include here a small fixup for Mapsui.Mac.sln, which was forgotten in #1123.