### PR TITLE
Mapsui.Samples.Forms: properly populate the listView on startup (iOS & Android)

### DIFF
--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPage.xaml.cs
@@ -23,14 +23,9 @@ namespace Mapsui.Samples.Forms
             allSamples = AllSamples.GetSamples();
 
             var categories = allSamples.Select(s => s.Category).Distinct().OrderBy(c => c);
-            foreach (var category in categories)
-            {
-                picker.Items?.Add(category);
-            }
+            picker.ItemsSource = categories.ToList<string>();
             picker.SelectedIndexChanged += PickerSelectedIndexChanged;
             picker.SelectedItem = "Forms";
-
-            listView.ItemsSource = allSamples.Select(k => k.Name).ToList();
         }
 
         private void FillListWithSamples()

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
@@ -26,10 +26,7 @@ namespace Mapsui.Samples.Forms
             allSamples = AllSamples.GetSamples();
 
             var categories = allSamples.Select(s => s.Category).Distinct().OrderBy(c => c);
-            foreach (var category in categories)
-            {
-                picker.Items?.Add(category);
-            }
+            picker.ItemsSource = categories.ToList<string>();
             picker.SelectedIndexChanged += PickerSelectedIndexChanged;
             picker.SelectedItem = "Forms";
 


### PR DESCRIPTION
* MainPage: show only the samples from the selected category (Forms) instead of all samples
* this now works the same way as in MainPageLarge (used e.g. for the Mac sample app)
* also simplify the initialization of the category picker