### PR TITLE
Wfs Fixes: HttpClientUtil Close, Appending Query to Url

### DIFF
--- a/Mapsui/Mapsui.csproj
+++ b/Mapsui/Mapsui.csproj
@@ -16,10 +16,6 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Providers\Wfs\" />
-  </ItemGroup>
   <PropertyGroup>
     <DebugType>portable</DebugType>
     <PackageId>NotMapsui</PackageId>

--- a/Mapsui/Providers/Wfs/Utilities/HttpClientUtil.cs
+++ b/Mapsui/Providers/Wfs/Utilities/HttpClientUtil.cs
@@ -163,9 +163,16 @@ namespace Mapsui.Providers.Wfs.Utilities
         {
             if (_webResponse != null)
             {
-                _webResponse.Close();
+                // ATTENTION: Dispose first the Response Stream
+                // or else a disposed exception occours.
                 var responseStream = _webResponse.GetResponseStream();
-                if (responseStream != null) responseStream.Dispose();
+                if (responseStream != null)
+                {
+                    responseStream.Dispose();
+                }
+                _webResponse.Close();
+                
+                _webResponse = null;
             }
         }
 

--- a/Mapsui/Providers/Wfs/Utilities/HttpClientUtil.cs
+++ b/Mapsui/Providers/Wfs/Utilities/HttpClientUtil.cs
@@ -165,12 +165,12 @@ namespace Mapsui.Providers.Wfs.Utilities
             {
                 // ATTENTION: Dispose first the Response Stream
                 // or else a disposed exception occours.
-                var responseStream = _webResponse.GetResponseStream();
+                var responseStream = _webResponse?.GetResponseStream();
                 if (responseStream != null)
                 {
                     responseStream.Dispose();
                 }
-                _webResponse.Close();
+                _webResponse?.Close();
                 
                 _webResponse = null;
             }

--- a/Mapsui/Providers/Wfs/Utilities/UrlQueryHelper.cs
+++ b/Mapsui/Providers/Wfs/Utilities/UrlQueryHelper.cs
@@ -1,0 +1,51 @@
+﻿namespace Mapsui.Providers.Wfs.Utilities
+{
+    public static class UrlQueryHelper
+    {
+        /// <summary> Append Query  </summary>
+        /// <param name="url">url</param>
+        /// <param name="query">query</param>
+        /// <returns>uri with query</returns>
+        public static string AppendQuery(this string url, string query)
+        {
+            // remove lending /
+            if (url.EndsWith(@"/"))
+            {
+                url = url.Substring(0, url.Length - 1);
+            }
+
+            if (url.Contains("?"))
+            {
+                // is already a query string
+
+                // remove starting ?
+                if (query.StartsWith("?"))
+                {
+                    query = query.Substring(1, query.Length - 1);
+                }
+
+                // remove starting &
+                if (query.StartsWith("&"))
+                {
+                    query = query.Substring(1, query.Length - 1);
+                }
+
+                // Add & if necessery
+                if (!url.EndsWith("&"))
+                {
+                    url = url + "&";
+                }
+            }
+            else
+            {
+                if (!query.StartsWith("?"))
+                {
+                    // add ? to query
+                    query = "?" + query;
+                }
+            }
+
+            return url + query;
+        }
+    }
+}

--- a/Mapsui/Providers/Wfs/WFSProvider.cs
+++ b/Mapsui/Providers/Wfs/WFSProvider.cs
@@ -901,7 +901,7 @@ namespace Mapsui.Providers.Wfs
                                                                           string targetUrl)
             {
                 httpClientUtil.Reset();
-                httpClientUtil.Url = targetUrl + _wfsTextResources.GetCapabilitiesRequest();
+                httpClientUtil.Url = targetUrl.AppendQuery(_wfsTextResources.GetCapabilitiesRequest());
                 return httpClientUtil;
             }
 
@@ -914,7 +914,7 @@ namespace Mapsui.Providers.Wfs
                                                                               string featureTypeName)
             {
                 httpClientUtil.Reset();
-                httpClientUtil.Url = targetUrl + _wfsTextResources.DescribeFeatureTypeRequest(featureTypeName);
+                httpClientUtil.Url = targetUrl.AppendQuery(_wfsTextResources.DescribeFeatureTypeRequest(featureTypeName));
                 return httpClientUtil;
             }
 
@@ -932,8 +932,8 @@ namespace Mapsui.Providers.Wfs
                 if (get)
                 {
                     /* HTTP-GET */
-                    httpClientUtil.Url += _wfsTextResources.GetFeatureGETRequest(
-                        featureTypeInfo, labelProperties, boundingBox, filter);
+                    httpClientUtil.Url = httpClientUtil.Url.AppendQuery(_wfsTextResources.GetFeatureGETRequest(
+                        featureTypeInfo, labelProperties, boundingBox, filter));
                 }
                 else
                 {

--- a/Tests/Mapsui.Tests/Providers/Wfs/HttpClientUtilTests.cs
+++ b/Tests/Mapsui.Tests/Providers/Wfs/HttpClientUtilTests.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mapsui.Providers.Wfs.Utilities;
+using NUnit.Framework;
+
+namespace Mapsui.Tests.Providers.Wfs
+{
+    [TestFixture]
+    public class HttpClientUtilTests
+    {
+        [Test]
+        public void CloseDoesNotThrowException()
+        {
+            // Arrange
+            var httpClientUtil = new HttpClientUtil
+            {
+                Url = "https://www.google.com"
+            };
+
+            // Act
+            using var stream = httpClientUtil.GetDataStream();
+
+            // Assert
+            Assert.DoesNotThrow(httpClientUtil.Close);
+        }
+    }
+}

--- a/Tests/Mapsui.Tests/Providers/Wfs/HttpClientUtilTests.cs
+++ b/Tests/Mapsui.Tests/Providers/Wfs/HttpClientUtilTests.cs
@@ -26,5 +26,22 @@ namespace Mapsui.Tests.Providers.Wfs
             // Assert
             Assert.DoesNotThrow(httpClientUtil.Close);
         }
+
+        [Test]
+        public void TwoCloseDoesNotThrowException()
+        {
+            // Arrange
+            var httpClientUtil = new HttpClientUtil
+            {
+                Url = "https://www.google.com"
+            };
+
+            // Act
+            using var stream = httpClientUtil.GetDataStream();
+            httpClientUtil.Close();
+
+            // Assert
+            Assert.DoesNotThrow(httpClientUtil.Close);
+        }
     }
 }

--- a/Tests/Mapsui.Tests/Providers/Wfs/Utilities/UrlAppendQueryHelperTests.cs
+++ b/Tests/Mapsui.Tests/Providers/Wfs/Utilities/UrlAppendQueryHelperTests.cs
@@ -1,0 +1,65 @@
+﻿using Mapsui.Providers.Wfs.Utilities;
+using NUnit.Framework;
+
+namespace Mapsui.Tests.Providers.Wfs.Utilities
+{
+    [TestFixture]
+    public class UrlAppendQueryHelperTests
+    {
+        [Test]
+        public void AppendQueryToUrl()
+        {
+            // Arrange
+            string url = "www.test.de/test";
+            string query = "?query=test";
+
+            // Act
+            string combinedUrl = url.AppendQuery(query);
+
+            // Assert
+            Assert.AreEqual("www.test.de/test?query=test" ,combinedUrl);
+        }
+
+        [Test]
+        public void AppendQueryToQueryUrl()
+        {
+            // Arrange
+            string url = "www.test.de/test?Service=WFS";
+            string query = "?query=test";
+
+            // Act
+            string combinedUrl = url.AppendQuery(query);
+
+            // Assert
+            Assert.AreEqual("www.test.de/test?Service=WFS&query=test" ,combinedUrl);
+        }
+
+        [Test]
+        public void AppendQueryToQueryUrlWithAppersend()
+        {
+            // Arrange
+            string url = "www.test.de/test?Service=WFS&";
+            string query = "?query=test";
+
+            // Act
+            string combinedUrl = url.AppendQuery(query);
+
+            // Assert
+            Assert.AreEqual("www.test.de/test?Service=WFS&query=test" ,combinedUrl);
+        }
+
+        [Test]
+        public void AppendQueryToQueryUrlWithOutQuestionMark()
+        {
+            // Arrange
+            string url = "www.test.de/test?Service=WFS";
+            string query = "query=test";
+
+            // Act
+            string combinedUrl = url.AppendQuery(query);
+
+            // Assert
+            Assert.AreEqual("www.test.de/test?Service=WFS&query=test" ,combinedUrl);
+        }
+    }
+}


### PR DESCRIPTION
Fix the Close of the HttpClient Util. So that it doesn't throw an exception