### PR TITLE
Fix typo in method name

### DIFF
--- a/Samples/Mapsui.Samples.Wpf.Editing/EditManipulation.cs
+++ b/Samples/Mapsui.Samples.Wpf.Editing/EditManipulation.cs
@@ -47,7 +47,7 @@ namespace Mapsui.Samples.Wpf.Editing
                         {
                             if (IsShiftDown())
                             {
-                                return editManager.TryDeleteVertrex(
+                                return editManager.TryDeleteVertex(
                                     mapControl.GetMapInfo(screenPosition, editManager.VertexRadius), editManager.VertexRadius);
                             }
                             return editManager.TryInsertVertex(

--- a/Samples/Mapsui.Samples.Wpf.Editing/Editing/EditManager.cs
+++ b/Samples/Mapsui.Samples.Wpf.Editing/Editing/EditManager.cs
@@ -194,7 +194,7 @@ namespace Mapsui.Samples.Wpf.Editing.Editing
             }
         }
 
-        public bool TryDeleteVertrex(MapInfo mapInfo, double screenDistance)
+        public bool TryDeleteVertex(MapInfo mapInfo, double screenDistance)
         {
             if (mapInfo.Feature == null) return false;
 


### PR DESCRIPTION
Just fixing a small typo in method name of a sample class.