### PR TITLE
add a build script for Mac

### DIFF
--- a/NuSpec/Mapsui.Mac.nuspec
+++ b/NuSpec/Mapsui.Mac.nuspec
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Mapsui</id>
+    <version>$version$</version>
+    <title>Mapsui</title>
+    <authors>Paul den Dulk</authors>
+    <owners>Paul den Dulk</owners>
+    <projectUrl>https://github.com/Mapsui/Mapsui</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+      Mapsui - Library for mapping
+    </description>
+    <tags>map maps mapping geo gis osm</tags>
+    <language>en-US</language>
+    <dependencies>
+      <!-- [ or ] is including, ( or ) is excluding -->
+      <group targetFramework="netstandard2.0">
+        <dependency id="BruTile" version="[3.1.3,4.0.0)"/>
+        <dependency id="Newtonsoft.json" version="[11.0.1,)"/>
+      </group>
+      <!-- <group targetFramework="net48">
+        <dependency id="BruTile" version="[3.1.3,4.0.0)"/>
+        <dependency id="Newtonsoft.json" version="[11.0.1,)"/>
+        <dependency id="SkiaSharp" version="[2.80.2,3.0.0)"/>
+        <dependency id="Svg.Skia" version="[0.4.1,0.6)"/>
+        <dependency id="SkiaSharp.Views" version="[2.80.2,3.0.0)"/>
+        <dependency id="Topten.RichTextKit" version="[0.4.139,0.5)"/>
+      </group>
+      <group targetFramework="uap">
+        <dependency id="BruTile" version="[3.1.3,4.0.0)"/>
+        <dependency id="Newtonsoft.json" version="[11.0.1,)"/>
+        <dependency id="SkiaSharp" version="[2.80.2,3.0.0)"/>
+        <dependency id="Svg.Skia" version="[0.4.1,0.6)"/>
+        <dependency id="SkiaSharp.Views" version="[2.80.2,3.0.0)"/>
+        <dependency id="Topten.RichTextKit" version="[0.4.139,0.5)"/>
+      </group> -->
+      <group targetFramework="MonoAndroid">
+        <dependency id="BruTile" version="[3.1.3,4.0.0)"/>
+        <dependency id="Newtonsoft.json" version="[11.0.1,)"/>
+        <dependency id="SkiaSharp" version="[2.80.2,3.0.0)"/>
+        <dependency id="Svg.Skia" version="[0.4.1,0.6)"/>
+        <dependency id="SkiaSharp.Views" version="[2.80.2,3.0.0)"/>
+        <dependency id="Topten.RichTextKit" version="[0.4.139,0.5)"/>
+      </group>
+      <group targetFramework="Xamarin.iOS">
+        <dependency id="BruTile" version="[3.1.3,4.0.0)"/>
+        <dependency id="Newtonsoft.json" version="[11.0.1,)"/>
+        <dependency id="SkiaSharp" version="[2.80.2,3.0.0)"/>
+        <dependency id="Svg.Skia" version="[0.4.1,0.6)"/>
+        <dependency id="SkiaSharp.Views" version="[2.80.2,3.0.0)"/>
+        <dependency id="Topten.RichTextKit" version="[0.4.139,0.5)"/>
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+
+    <file src="..\Mapsui\bin\Release\netstandard2.0\Mapsui.Geometries.dll" target="lib\netstandard2.0\Mapsui.Geometries.dll" />
+    <file src="..\Mapsui\bin\Release\netstandard2.0\Mapsui.dll" target="lib\netstandard2.0\Mapsui.dll" />
+    <file src="..\Mapsui.Rendering.Skia\bin\Release\netstandard2.0\Mapsui.Rendering.Skia.dll" target="lib\netstandard2.0\Mapsui.Rendering.Skia.dll" />
+
+    <!-- The WPF & UWP parts are not being built on Mac OS! -->
+
+    <!-- <file src="..\Mapsui.UI.Wpf\bin\Release\net48\Mapsui.Geometries.dll" target="lib\net48\Mapsui.Geometries.dll" />
+    <file src="..\Mapsui.UI.Wpf\bin\Release\net48\Mapsui.dll" target="lib\net48\Mapsui.dll" />
+    <file src="..\Mapsui.UI.Wpf\bin\Release\net48\Mapsui.Rendering.Xaml.dll" target="lib\net48\Mapsui.Rendering.Xaml.dll" />
+    <file src="..\Mapsui.UI.Wpf\bin\Release\net48\Mapsui.Rendering.Skia.dll" target="lib\net48\Mapsui.Rendering.Skia.dll" />
+    <file src="..\Mapsui.UI.Wpf\bin\Release\net48\Mapsui.UI.Wpf.dll" target="lib\net48\Mapsui.UI.Wpf.dll" /> -->
+
+    <!-- <file src="..\Mapsui.UI.Uwp\bin\Release\Mapsui.Geometries.dll" target="lib\uap\Mapsui.Geometries.dll" />
+    <file src="..\Mapsui.UI.Uwp\bin\Release\Mapsui.dll" target="lib\uap\Mapsui.dll" />
+    <file src="..\Mapsui.UI.Uwp\bin\Release\Mapsui.Rendering.Skia.dll" target="lib\uap\Mapsui.Rendering.Skia.dll" />
+    <file src="..\Mapsui.UI.Uwp\bin\Release\Mapsui.UI.Uwp.dll" target="lib\uap\Mapsui.UI.Uwp.dll" /> -->
+
+    <file src="..\Mapsui.UI.Android\bin\Release\Mapsui.Geometries.dll" target="lib\MonoAndroid\Mapsui.Geometries.dll" />
+    <file src="..\Mapsui.UI.Android\bin\Release\Mapsui.dll" target="lib\MonoAndroid\Mapsui.dll" />
+    <file src="..\Mapsui.UI.Android\bin\Release\Mapsui.Rendering.Skia.dll" target="lib\MonoAndroid\Mapsui.Rendering.Skia.dll" />
+    <file src="..\Mapsui.UI.Android\bin\Release\Mapsui.UI.Android.dll" target="lib\MonoAndroid\Mapsui.UI.Android.dll" />
+
+    <file src="..\Mapsui.UI.iOS\bin\Release\Mapsui.Geometries.dll" target="lib\Xamarin.iOS\Mapsui.Geometries.dll" />
+    <file src="..\Mapsui.UI.iOS\bin\Release\Mapsui.dll" target="lib\Xamarin.iOS\Mapsui.dll" />
+    <file src="..\Mapsui.UI.iOS\bin\Release\Mapsui.Rendering.Skia.dll" target="lib\Xamarin.iOS\Mapsui.Rendering.Skia.dll" />
+    <file src="..\Mapsui.UI.iOS\bin\Release\Mapsui.UI.iOS.dll" target="lib\Xamarin.iOS\Mapsui.UI.iOS.dll" />
+
+  </files>
+</package>

--- a/Scripts/Mac/buildpack.sh
+++ b/Scripts/Mac/buildpack.sh
@@ -1,0 +1,14 @@
+#!/bin/zsh
+VERSION=$1
+
+# clean up
+find . -type d \( -name 'bin' -o -name 'obj' \) -prune -exec rm -rf {} \;
+nuget restore Mapsui.Mac.sln
+# update version
+msbuild Tools/VersionUpdater/VersionUpdater.csproj /p:Configuration=Release
+mono Tools/VersionUpdater/bin/Release/net48/win-x64/VersionUpdater.exe /version:$VERSION
+# build
+msbuild Mapsui.Mac.sln /p:Configuration=Release
+# package
+nuget pack NuSpec/Mapsui.Mac.nuspec -Version $VERSION -outputdirectory Artifacts
+nuget pack NuSpec/Mapsui.Forms.nuspec -Version $VERSION -outputdirectory Artifacts

--- a/Scripts/Mac/cleanup.sh
+++ b/Scripts/Mac/cleanup.sh
@@ -1,0 +1,7 @@
+#/bin/sh
+
+# remove 'bin' and 'obj' directories
+find . -type d \( -name 'bin' -o -name 'obj' \) -prune -exec rm -rf {} \;
+
+# remove Resource.designer.cs files
+find . -name 'Resource.designer.cs' -exec rm -rf {} \;

--- a/Scripts/Mac/readme.txt
+++ b/Scripts/Mac/readme.txt
@@ -1,0 +1,11 @@
+This folder contains shell scripts for building and packaging Mapsui on MacOS.
+They should be run from the Mapsui base directory like this:
+
+> Script/Mac/cleanup.sh
+(This cleans up all files that are generated during the build.)
+
+> Scripts/Mac/buildpack.sh 3.0.0-alpha.5
+(This updates the version to the one specified as argument,
+builds everything and creates nuget packages for Mapsui and Mapsui.Forms.)
+
+Not that the nuget packages created in this way will be missing WPF and UWP support.


### PR DESCRIPTION
* analogous to the Windows build script
* since the Windows-specific parts can not be built,
  we need a separate nuspec file as well
* a cleanup script is also included
* cf. #1135
