### PR TITLE
WPF: Adding MouseMove handler control

### DIFF
--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -37,7 +37,7 @@ namespace Mapsui.UI.Wpf
         private bool _hasBeenManipulated;
         private double _innerRotation;
         private readonly FlingTracker _flingTracker = new FlingTracker();
-        
+
         public MouseWheelAnimation MouseWheelAnimation { get; } = new MouseWheelAnimation();
 
         /// <summary>
@@ -76,6 +76,10 @@ namespace Mapsui.UI.Wpf
 
             RenderMode = RenderMode.Skia;
         }
+
+        public void RemoveMouseMoveHandler() => MouseMove -= new MouseEventHandler(MapControlMouseMove);
+
+        public void AddMouseMoveHandler() => MouseMove += new MouseEventHandler(MapControlMouseMove);
 
         protected override void OnRender(DrawingContext dc)
         {


### PR DESCRIPTION
Removing temporarily MouseMove handler is convenient to draw something on the map with left clic, and probably also to reassigne left clic as requested here: https://stackoverflow.com/questions/52260870/change-the-panning-button-in-mapsui-control (seems it is not possible to remove events when you are not the owner)