### PR TITLE
Removed a bug where the callout has wrong anchor while rotating

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
@@ -35,7 +35,18 @@ namespace Mapsui.Rendering.Skia
             var symbolOffsetY = calloutStyle.SymbolOffset.IsRelative ? picture.CullRect.Height * (float)calloutStyle.SymbolOffset.Y : (float)calloutStyle.SymbolOffset.Y;
 
             var rotation = (float)calloutStyle.SymbolRotation;
-            if (calloutStyle.RotateWithMap) rotation += (float)viewport.Rotation;
+            
+            if (viewport.Rotation != 0 && calloutStyle.RotateWithMap) 
+                rotation += (float)viewport.Rotation;
+            
+            if (viewport.Rotation != 0 && calloutStyle.SymbolOffsetRotatesWithMap)
+            { 
+                var mapRotation = viewport.Rotation / 180.0 * Math.PI;
+                var x = Math.Cos(mapRotation) * symbolOffsetX - Math.Sin(mapRotation) * symbolOffsetY;
+                var y = Math.Sin(mapRotation) * symbolOffsetX + Math.Cos(mapRotation) * symbolOffsetY;
+                symbolOffsetX = (float)x;
+                symbolOffsetY = (float)y;
+            }
 
             // Save state of the canvas, so we could move and rotate the canvas
             canvas.Save();

--- a/Mapsui.UI.Forms/Objects/Callout.cs
+++ b/Mapsui.UI.Forms/Objects/Callout.cs
@@ -613,6 +613,7 @@ namespace Mapsui.UI.Forms
             style.BackgroundColor = BackgroundColor.ToMapsui(); ;
             style.Color = Color.ToMapsui();
             style.SymbolOffset = new Offset(Anchor.X, Anchor.Y);
+            style.SymbolOffsetRotatesWithMap = _pin.RotateWithMap;
             style.Padding = new BoundingBox(Padding.Left, Padding.Top, Padding.Right, Padding.Bottom);
             style.RectRadius = (float)RectRadius;
             style.RotateWithMap = RotateWithMap;

--- a/Mapsui/Styles/ImageStyle.cs
+++ b/Mapsui/Styles/ImageStyle.cs
@@ -55,5 +55,10 @@ namespace Mapsui.Styles
         ///     <see cref="SymbolScale" />=1.0.
         /// </remarks>
         public Offset SymbolOffset { get; set; }
+
+        /// <summary>
+        /// Should SymbolOffset position rotate with map
+        /// </summary>
+        public bool SymbolOffsetRotatesWithMap { get; set; }
     }
 }

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PinSample.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PinSample.cs
@@ -40,6 +40,7 @@ namespace Mapsui.Samples.Forms.Shared
                         Color = new Color(_random.Next(0, 256) / 256.0, _random.Next(0, 256) / 256.0, _random.Next(0, 256) / 256.0),
                         Transparency = 0.5f,
                         Scale = _random.Next(50, 130) / 100f,
+                        RotateWithMap = true,
                     };
                     pin.Callout.Anchor = new Point(0, pin.Height * pin.Scale);
                     pin.Callout.RectRadius = _random.Next(0, 10);


### PR DESCRIPTION
Removed a bug where the callout didn't have the correct anchor if the map is rotated. See #1151.