### PR TITLE
Added methods to make mass edit methods to LayerCollection

### DIFF
--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -92,13 +92,7 @@ namespace Mapsui.UI.Forms
             AddLayers();
 
             // Add some events to _mapControl.Map.Layers
-            _mapControl.Map.Layers.LayerAdded += HandlerLayerChanged;
-            _mapControl.Map.Layers.LayerMoved += HandlerLayerChanged;
-            _mapControl.Map.Layers.LayerRemoved += HandlerLayerChanged;
-
-            _mapControl.Map.Layers.MultipleLayersAdded += HandlerMultipleLayersChanged;
-            _mapControl.Map.Layers.MultipleLayersRemoved += HandlerMultipleLayersChanged;
-            _mapControl.Map.Layers.MultipleLayersModified += HandlerMultipleLayersModified;
+            _mapControl.Map.Layers.Changed += HandleLayersChanged;
 
             AbsoluteLayout.SetLayoutBounds(_mapControl, new Rectangle(0, 0, 1, 1));
             AbsoluteLayout.SetLayoutFlags(_mapControl, AbsoluteLayoutFlags.All);
@@ -700,37 +694,21 @@ namespace Mapsui.UI.Forms
         {
             ViewportInitialized?.Invoke(sender, e);
         }
-
-        private void HandlerLayerChanged(ILayer layer)
+        
+        private void HandleLayersChanged(object sender, LayerCollectionChangedEventArgs args)
         {
-            if (layer == MyLocationLayer || layer == _mapDrawableLayer || layer == _mapPinLayer || layer == _mapCalloutLayer)
-                return;
-
-            // Readd MapView layers, so that they always on top
-            ReAddLayers();
-        }
-
-        private void HandlerMultipleLayersChanged(IEnumerable<ILayer> layers)
-        {
-            var localLayers = layers.ToList();
-            if (localLayers.Contains(MyLocationLayer) || localLayers.Contains(_mapDrawableLayer) || localLayers.Contains(_mapPinLayer) || localLayers.Contains(_mapCalloutLayer))
-                return;
-
-            // Readd MapView layers, so that they always on top
-            ReAddLayers();
-        }
-
-        private void HandlerMultipleLayersModified(IEnumerable<ILayer> layersRemoved, IEnumerable<ILayer> layersAdded)
-        {
-            var localRemovedLayers = layersRemoved.ToList();
-            var localAddedLayers = layersAdded.ToList();
+            var localRemovedLayers = args.RemovedLayers?.ToList() ?? new List<ILayer>();
+            var localAddedLayers = args.AddedLayers?.ToList() ?? new List<ILayer>();
 
             if (localRemovedLayers.Contains(MyLocationLayer) || localRemovedLayers.Contains(_mapDrawableLayer) || localRemovedLayers.Contains(_mapPinLayer) || localRemovedLayers.Contains(_mapCalloutLayer) || 
                 localAddedLayers.Contains(MyLocationLayer) || localAddedLayers.Contains(_mapDrawableLayer) || localAddedLayers.Contains(_mapPinLayer) || localAddedLayers.Contains(_mapCalloutLayer))
                 return;
 
-            // Readd MapView layers, so that they always on top
-            ReAddLayers();
+            // Remove MapView layers
+            RemoveLayers();
+
+            // Readd them, so that they always on top
+            AddLayers();
         }
 
         private void HandlerPinsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -1011,7 +989,7 @@ namespace Mapsui.UI.Forms
         private void AddLayers()
         {
             // Add MapView layers
-            _mapControl.Map.Layers.AddMultiple(new [] { _mapDrawableLayer, _mapPinLayer, _mapCalloutLayer, MyLocationLayer });
+            _mapControl.Map.Layers.Add(_mapDrawableLayer, _mapPinLayer, _mapCalloutLayer, MyLocationLayer);
         }
 
         /// <summary>
@@ -1020,19 +998,7 @@ namespace Mapsui.UI.Forms
         private void RemoveLayers()
         {
             // Remove MapView layers
-            _mapControl.Map.Layers.RemoveMultiple(new[] { MyLocationLayer, _mapCalloutLayer, _mapPinLayer, _mapDrawableLayer });
-        }
-
-        /// <summary>
-        /// Re-adds all layers that MapView uses
-        /// </summary>
-        private void ReAddLayers()
-        {
-            // Remove MapView layers
-            RemoveLayers();
-
-            // Readd them, so that they always on top
-            AddLayers();
+            _mapControl.Map.Layers.Remove(MyLocationLayer, _mapCalloutLayer, _mapPinLayer, _mapDrawableLayer);
         }
 
         /// <summary>

--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -96,6 +96,10 @@ namespace Mapsui.UI.Forms
             _mapControl.Map.Layers.LayerMoved += HandlerLayerChanged;
             _mapControl.Map.Layers.LayerRemoved += HandlerLayerChanged;
 
+            _mapControl.Map.Layers.MultipleLayersAdded += HandlerMultipleLayersChanged;
+            _mapControl.Map.Layers.MultipleLayersRemoved += HandlerMultipleLayersChanged;
+            _mapControl.Map.Layers.MultipleLayersModified += HandlerMultipleLayersModified;
+
             AbsoluteLayout.SetLayoutBounds(_mapControl, new Rectangle(0, 0, 1, 1));
             AbsoluteLayout.SetLayoutFlags(_mapControl, AbsoluteLayoutFlags.All);
 
@@ -709,6 +713,35 @@ namespace Mapsui.UI.Forms
             AddLayers();
         }
 
+        private void HandlerMultipleLayersChanged(IEnumerable<ILayer> layers)
+        {
+            var localLayers = layers.ToList();
+            if (localLayers.Contains(MyLocationLayer) || localLayers.Contains(_mapDrawableLayer) || localLayers.Contains(_mapPinLayer) || localLayers.Contains(_mapCalloutLayer))
+                return;
+
+            // Remove MapView layers
+            RemoveLayers();
+
+            // Readd them, so that they always on top
+            AddLayers();
+        }
+
+        private void HandlerMultipleLayersModified(IEnumerable<ILayer> layersRemoved, IEnumerable<ILayer> layersAdded)
+        {
+            var localRemovedLayers = layersRemoved.ToList();
+            var localAddedLayers = layersAdded.ToList();
+
+            if (localRemovedLayers.Contains(MyLocationLayer) || localRemovedLayers.Contains(_mapDrawableLayer) || localRemovedLayers.Contains(_mapPinLayer) || localRemovedLayers.Contains(_mapCalloutLayer) || 
+                localAddedLayers.Contains(MyLocationLayer) || localAddedLayers.Contains(_mapDrawableLayer) || localAddedLayers.Contains(_mapPinLayer) || localAddedLayers.Contains(_mapCalloutLayer))
+                return;
+
+            // Remove MapView layers
+            RemoveLayers();
+
+            // Readd them, so that they always on top
+            AddLayers();
+        }
+
         private void HandlerPinsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.NewItems != null && e.NewItems.Cast<Pin>().Any(pin => pin.Label == null))
@@ -987,10 +1020,7 @@ namespace Mapsui.UI.Forms
         private void AddLayers()
         {
             // Add MapView layers
-            _mapControl.Map.Layers.Add(_mapDrawableLayer);
-            _mapControl.Map.Layers.Add(_mapPinLayer);
-            _mapControl.Map.Layers.Add(_mapCalloutLayer);
-            _mapControl.Map.Layers.Add(MyLocationLayer);
+            _mapControl.Map.Layers.AddMultiple(new [] { _mapDrawableLayer, _mapPinLayer, _mapCalloutLayer, MyLocationLayer });
         }
 
         /// <summary>
@@ -999,10 +1029,7 @@ namespace Mapsui.UI.Forms
         private void RemoveLayers()
         {
             // Remove MapView layers
-            _mapControl.Map.Layers.Remove(MyLocationLayer);
-            _mapControl.Map.Layers.Remove(_mapCalloutLayer);
-            _mapControl.Map.Layers.Remove(_mapPinLayer);
-            _mapControl.Map.Layers.Remove(_mapDrawableLayer);
+            _mapControl.Map.Layers.RemoveMultiple(new[] { MyLocationLayer, _mapCalloutLayer, _mapPinLayer, _mapDrawableLayer });
         }
 
         /// <summary>

--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -706,11 +706,8 @@ namespace Mapsui.UI.Forms
             if (layer == MyLocationLayer || layer == _mapDrawableLayer || layer == _mapPinLayer || layer == _mapCalloutLayer)
                 return;
 
-            // Remove MapView layers
-            RemoveLayers();
-
-            // Readd them, so that they always on top
-            AddLayers();
+            // Readd MapView layers, so that they always on top
+            ReAddLayers();
         }
 
         private void HandlerMultipleLayersChanged(IEnumerable<ILayer> layers)
@@ -719,11 +716,8 @@ namespace Mapsui.UI.Forms
             if (localLayers.Contains(MyLocationLayer) || localLayers.Contains(_mapDrawableLayer) || localLayers.Contains(_mapPinLayer) || localLayers.Contains(_mapCalloutLayer))
                 return;
 
-            // Remove MapView layers
-            RemoveLayers();
-
-            // Readd them, so that they always on top
-            AddLayers();
+            // Readd MapView layers, so that they always on top
+            ReAddLayers();
         }
 
         private void HandlerMultipleLayersModified(IEnumerable<ILayer> layersRemoved, IEnumerable<ILayer> layersAdded)
@@ -735,11 +729,8 @@ namespace Mapsui.UI.Forms
                 localAddedLayers.Contains(MyLocationLayer) || localAddedLayers.Contains(_mapDrawableLayer) || localAddedLayers.Contains(_mapPinLayer) || localAddedLayers.Contains(_mapCalloutLayer))
                 return;
 
-            // Remove MapView layers
-            RemoveLayers();
-
-            // Readd them, so that they always on top
-            AddLayers();
+            // Readd MapView layers, so that they always on top
+            ReAddLayers();
         }
 
         private void HandlerPinsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -1030,6 +1021,18 @@ namespace Mapsui.UI.Forms
         {
             // Remove MapView layers
             _mapControl.Map.Layers.RemoveMultiple(new[] { MyLocationLayer, _mapCalloutLayer, _mapPinLayer, _mapDrawableLayer });
+        }
+
+        /// <summary>
+        /// Re-adds all layers that MapView uses
+        /// </summary>
+        private void ReAddLayers()
+        {
+            // Remove MapView layers
+            RemoveLayers();
+
+            // Readd them, so that they always on top
+            AddLayers();
         }
 
         /// <summary>

--- a/Mapsui/Layers/LayerCollectionChangedEventArgs.cs
+++ b/Mapsui/Layers/LayerCollectionChangedEventArgs.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mapsui.Layers
+{
+    public class LayerCollectionChangedEventArgs : EventArgs
+    {
+        public IEnumerable<ILayer> AddedLayers { get; }
+        public IEnumerable<ILayer> RemovedLayers { get; }
+        public IEnumerable<ILayer> MovedLayers { get; }
+
+        public LayerCollectionChangedEventArgs(IEnumerable<ILayer> added = null, IEnumerable<ILayer> removed = null, IEnumerable<ILayer> moved = null)
+        {
+            AddedLayers = added;
+            RemovedLayers = removed;
+            MovedLayers = moved;
+        }
+    }
+}

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -112,22 +112,10 @@ namespace Mapsui
             {
                 var tempLayers = _layers;
                 if (tempLayers != null)
-                {
-                    _layers.LayerAdded -= LayersLayerAdded;
-                    _layers.LayerRemoved -= LayersLayerRemoved;
-
-                    _layers.MultipleLayersAdded -= LayersMultipleLayersAdded;
-                    _layers.MultipleLayersRemoved -= LayersMultipleLayersRemoved;
-                    _layers.MultipleLayersModified -= LayersMultipleLayersModified;
-                }
+                    _layers.Changed -= LayersCollectionChanged;
 
                 _layers = value;
-                _layers.LayerAdded += LayersLayerAdded;
-                _layers.LayerRemoved += LayersLayerRemoved;
-
-                _layers.MultipleLayersAdded += LayersMultipleLayersAdded;
-                _layers.MultipleLayersRemoved += LayersMultipleLayersRemoved;
-                _layers.MultipleLayersModified += LayersMultipleLayersModified;
+                _layers.Changed += LayersCollectionChanged;
             }
         }
 
@@ -229,41 +217,13 @@ namespace Mapsui
                 layer.RefreshData(extent, resolution, changeType);
             }
         }
-
-        private void LayersLayerAdded(ILayer layer)
+        
+        private void LayersCollectionChanged(object sender, LayerCollectionChangedEventArgs args)
         {
-            LayerAdded(layer);
-            LayersChanged();
-        }
-
-        private void LayersLayerRemoved(ILayer layer)
-        {
-            LayerRemoved(layer);
-            LayersChanged();
-        }
-
-        private void LayersMultipleLayersAdded(IEnumerable<ILayer> layers)
-        {
-            foreach (var layer in layers)
-                LayerAdded(layer);
-
-            LayersChanged();
-        }
-
-        private void LayersMultipleLayersRemoved(IEnumerable<ILayer> layers)
-        {
-            foreach (var layer in layers)
+            foreach (var layer in args.RemovedLayers ?? Enumerable.Empty<ILayer>())
                 LayerRemoved(layer);
 
-            LayersChanged();
-        }
-
-        private void LayersMultipleLayersModified(IEnumerable<ILayer> layersRemoved, IEnumerable<ILayer> layersAdded)
-        {
-            foreach (var layer in layersRemoved)
-                LayerRemoved(layer);
-
-            foreach (var layer in layersAdded)
+            foreach (var layer in args.AddedLayers ?? Enumerable.Empty<ILayer>())
                 LayerAdded(layer);
 
             LayersChanged();

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -232,84 +232,63 @@ namespace Mapsui
 
         private void LayersLayerAdded(ILayer layer)
         {
-            layer.DataChanged += LayerDataChanged;
-            layer.PropertyChanged += LayerPropertyChanged;
-
-            layer.Transformation = Transformation;
-            layer.CRS = CRS;
-            Resolutions = DetermineResolutions(Layers);
-            OnPropertyChanged(nameof(Layers));
+            LayerAdded(layer);
+            LayersChanged();
         }
 
         private void LayersLayerRemoved(ILayer layer)
         {
-            if (layer is IAsyncDataFetcher asyncLayer)
-            {
-                asyncLayer.AbortFetch();
-            }
-
-            layer.DataChanged -= LayerDataChanged;
-            layer.PropertyChanged -= LayerPropertyChanged;
-
-            Resolutions = DetermineResolutions(Layers);
-
-            OnPropertyChanged(nameof(Layers));
+            LayerRemoved(layer);
+            LayersChanged();
         }
 
         private void LayersMultipleLayersAdded(IEnumerable<ILayer> layers)
         {
             foreach (var layer in layers)
-            {
-                layer.DataChanged += LayerDataChanged;
-                layer.PropertyChanged += LayerPropertyChanged;
+                LayerAdded(layer);
 
-                layer.Transformation = Transformation;
-                layer.CRS = CRS;
-            }
-
-            Resolutions = DetermineResolutions(Layers);
-            OnPropertyChanged(nameof(Layers));
+            LayersChanged();
         }
 
         private void LayersMultipleLayersRemoved(IEnumerable<ILayer> layers)
         {
             foreach (var layer in layers)
-            {
-                if (layer is IAsyncDataFetcher asyncLayer)
-                {
-                    asyncLayer.AbortFetch();
-                }
+                LayerRemoved(layer);
 
-                layer.DataChanged -= LayerDataChanged;
-                layer.PropertyChanged -= LayerPropertyChanged;
-            }
-
-            Resolutions = DetermineResolutions(Layers);
-            OnPropertyChanged(nameof(Layers));
+            LayersChanged();
         }
 
         private void LayersMultipleLayersModified(IEnumerable<ILayer> layersRemoved, IEnumerable<ILayer> layersAdded)
         {
             foreach (var layer in layersRemoved)
-            {
-                if (layer is IAsyncDataFetcher asyncLayer)
-                {
-                    asyncLayer.AbortFetch();
-                }
-
-                layer.DataChanged -= LayerDataChanged;
-                layer.PropertyChanged -= LayerPropertyChanged;
-            }
+                LayerRemoved(layer);
 
             foreach (var layer in layersAdded)
-            {
-                layer.DataChanged += LayerDataChanged;
-                layer.PropertyChanged += LayerPropertyChanged;
+                LayerAdded(layer);
 
-                layer.Transformation = Transformation;
-                layer.CRS = CRS;
-            }
+            LayersChanged();
+        }
 
+        private void LayerAdded(ILayer layer)
+        {
+            layer.DataChanged += LayerDataChanged;
+            layer.PropertyChanged += LayerPropertyChanged;
+
+            layer.Transformation = Transformation;
+            layer.CRS = CRS;
+        }
+
+        private void LayerRemoved(ILayer layer)
+        {
+            if (layer is IAsyncDataFetcher asyncLayer)
+                asyncLayer.AbortFetch();
+
+            layer.DataChanged -= LayerDataChanged;
+            layer.PropertyChanged -= LayerPropertyChanged;
+        }
+
+        private void LayersChanged()
+        {
             Resolutions = DetermineResolutions(Layers);
             OnPropertyChanged(nameof(Layers));
         }


### PR DESCRIPTION
This methods can prevent lag issues when multiple layers are added/removed/modified on espacially iOS. Currently iOS makes a redraw for each add/remove which causes the app to lag heavily for multiple seconds. 