### PR TITLE
Allow custom user agent

### DIFF
--- a/Mapsui/Utilities/OpenStreetMap.cs
+++ b/Mapsui/Utilities/OpenStreetMap.cs
@@ -10,12 +10,12 @@ namespace Mapsui.Utilities
         private static readonly BruTile.Attribution OpenStreetMapAttribution = new BruTile.Attribution(
             "© OpenStreetMap contributors", "https://www.openstreetmap.org/copyright");
 
-        public static TileLayer CreateTileLayer()
+        public static TileLayer CreateTileLayer(string userAgent = DefaultUserAgent)
         {
-            return new TileLayer(CreateTileSource()) { Name = "OpenStreetMap" };
+            return new TileLayer(CreateTileSource(userAgent)) { Name = "OpenStreetMap" };
         }
 
-        private static HttpTileSource CreateTileSource(string userAgent = DefaultUserAgent)
+        private static HttpTileSource CreateTileSource(string userAgent)
         {
             return new HttpTileSource(new GlobalSphericalMercator(),
                 "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",

--- a/Mapsui/Utilities/OpenStreetMap.cs
+++ b/Mapsui/Utilities/OpenStreetMap.cs
@@ -6,6 +6,7 @@ namespace Mapsui.Utilities
 {
     public static class OpenStreetMap
     {
+        private const string DefaultUserAgent = "Default Mapsui user-agent";
         private static readonly BruTile.Attribution OpenStreetMapAttribution = new BruTile.Attribution(
             "© OpenStreetMap contributors", "https://www.openstreetmap.org/copyright");
 
@@ -14,12 +15,12 @@ namespace Mapsui.Utilities
             return new TileLayer(CreateTileSource()) { Name = "OpenStreetMap" };
         }
 
-        private static HttpTileSource CreateTileSource()
+        private static HttpTileSource CreateTileSource(string userAgent = DefaultUserAgent)
         {
             return new HttpTileSource(new GlobalSphericalMercator(),
                 "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
                 new[] { "a", "b", "c" }, name: "OpenStreetMap",
-                attribution: OpenStreetMapAttribution, userAgent:"OpenStreetMap in Mapsui");
+                attribution: OpenStreetMapAttribution, userAgent: userAgent);
         }
     }
 }


### PR DESCRIPTION
Why: Because the default user agents can get blocked by osm