### PR TITLE
Invalidate loop

### DIFF
--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -56,14 +56,14 @@ namespace Mapsui.UI.Android
         public MapControl(Context context, IAttributeSet attrs) :
             base(context, attrs)
         {
-            InternalInitialize();
+            CommonInitialize();
             Initialize();
         }
 
         public MapControl(Context context, IAttributeSet attrs, int defStyle) :
             base(context, attrs, defStyle)
         {
-            InternalInitialize();
+            CommonInitialize();
             Initialize();
         }
 
@@ -88,14 +88,16 @@ namespace Mapsui.UI.Android
             _gestureDetector.DoubleTap += OnDoubleTapped;
         }
 
-        private void CanvasOnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+        private void CanvasOnPaintSurface(object sender, SKPaintSurfaceEventArgs args)
         {
-            if (PixelDensity <= 0) return;
+            if (PixelDensity <= 0) 
+                return;
 
-            e.Surface.Canvas.Scale(PixelDensity, PixelDensity);
+            var canvas = args.Surface.Canvas;
+                
+            canvas.Scale(PixelDensity, PixelDensity);
 
-            Navigator.UpdateAnimations();
-            Renderer.Render(e.Surface.Canvas, new Viewport(Viewport), _map.Layers, _map.Widgets, _map.BackColor);
+            CommonDrawControl(canvas);
         }
 
         public SkiaRenderMode RenderMode
@@ -156,7 +158,7 @@ namespace Mapsui.UI.Android
 
             canvas.Scale(PixelDensity, PixelDensity);
 
-            CommonPaintControl(canvas);
+            CommonDrawControl(canvas);
         }
 
         public void OnFling(object sender, GestureDetector.FlingEventArgs args)

--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -149,10 +149,14 @@ namespace Mapsui.UI.Android
 
         private void CanvasOnPaintSurfaceGL(object sender, SKPaintGLSurfaceEventArgs args)
         {
-            args.Surface.Canvas.Scale(PixelDensity, PixelDensity);
+            if (PixelDensity <= 0)
+                return;
 
-            Navigator.UpdateAnimations();
-            Renderer.Render(args.Surface.Canvas, new Viewport(Viewport), _map.Layers, _map.Widgets, _map.BackColor);
+            var canvas = args.Surface.Canvas;
+
+            canvas.Scale(PixelDensity, PixelDensity);
+
+            CommonPaintControl(canvas);
         }
 
         public void OnFling(object sender, GestureDetector.FlingEventArgs args)

--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -67,7 +67,7 @@ namespace Mapsui.UI.Android
             Initialize();
         }
 
-        public void Initialize()
+        void Initialize()
         {
             _invalidate = () => { RunOnUIThread(RefreshGraphicsWithTryCatch); };
 

--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -56,24 +56,27 @@ namespace Mapsui.UI.Android
         public MapControl(Context context, IAttributeSet attrs) :
             base(context, attrs)
         {
+            InternalInitialize();
             Initialize();
         }
 
         public MapControl(Context context, IAttributeSet attrs, int defStyle) :
             base(context, attrs, defStyle)
         {
+            InternalInitialize();
             Initialize();
         }
 
         public void Initialize()
         {
+            _invalidate = () => { RunOnUIThread(RefreshGraphicsWithTryCatch); };
+
             SetBackgroundColor(Color.Transparent);
             _canvas = RenderMode == SkiaRenderMode.Software ? StartSoftwareRenderMode() : StartHardwareRenderMode();
             _mainLooperHandler = new Handler(Looper.MainLooper);
 
             SetViewportSize(); // todo: check if size is available, perhaps we need a load event
 
-            Map = new Map();
             Touch += MapView_Touch;
 
             var listener = new MapControlGestureListener();
@@ -307,11 +310,6 @@ namespace Mapsui.UI.Android
         private static Point GetScreenPositionInPixels(MotionEvent motionEvent, View view)
         {
             return new PointF(motionEvent.GetX(0) - view.Left, motionEvent.GetY(0) - view.Top).ToMapsui();
-        }
-
-        public void RefreshGraphics()
-        {
-            RunOnUIThread(RefreshGraphicsWithTryCatch);
         }
 
         private void RefreshGraphicsWithTryCatch()

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -36,7 +36,6 @@ namespace Mapsui.UI.Forms
 
         private SKGLView _glView;
         private SKCanvasView _canvasView;
-        private Action _invalidate;
 
         // See http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/4.0.4_r2.1/android/view/ViewConfiguration.java#ViewConfiguration.0PRESSED_STATE_DURATION for values
         private const int shortTap = 125;
@@ -76,6 +75,7 @@ namespace Mapsui.UI.Forms
         public MapControl()
         {
             Initialize();
+            CommonInitialize();
         }
 
         public float ScreenWidth => (float)Width;
@@ -318,11 +318,6 @@ namespace Mapsui.UI.Forms
         private Geometries.Point GetScreenPosition(SKPoint point)
         {
             return new Geometries.Point(point.X / PixelDensity, point.Y / PixelDensity);
-        }
-
-        public void RefreshGraphics()
-        {
-            _invalidate();
         }
 
         /// <summary>

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -74,8 +74,8 @@ namespace Mapsui.UI.Forms
 
         public MapControl()
         {
-            Initialize();
             CommonInitialize();
+            Initialize();
         }
 
         public float ScreenWidth => (float)Width;

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -306,13 +306,12 @@ namespace Mapsui.UI.Forms
 
         void PaintSurface(SKCanvas canvas)
         {
-            if (PixelDensity <= 0) return;
-
-            Navigator.UpdateAnimations();
+            if (PixelDensity <= 0) 
+                return;
 
             canvas.Scale(PixelDensity, PixelDensity);
 
-            _renderer.Render(canvas, new Viewport(Viewport), _map.Layers, _map.Widgets, _map.BackColor);
+            CommonPaintControl(canvas);
         }
 
         private Geometries.Point GetScreenPosition(SKPoint point)

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -311,7 +311,7 @@ namespace Mapsui.UI.Forms
 
             canvas.Scale(PixelDensity, PixelDensity);
 
-            CommonPaintControl(canvas);
+            CommonDrawControl(canvas);
         }
 
         private Geometries.Point GetScreenPosition(SKPoint point)

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -90,7 +90,7 @@ namespace Mapsui.UI.Forms
 
         public bool UseDoubleTap = true;
 
-        public void Initialize()
+        void Initialize()
         {
             Xamarin.Forms.View view;
 

--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -459,6 +459,11 @@ namespace Mapsui.UI.Forms
         internal IMapControl MapControl => _mapControl;
 
         /// <summary>
+        /// Update interval for invalidation timer in ms
+        /// </summary>
+        public int UpdateInterval => _mapControl.UpdateInterval;
+
+        /// <summary>
         /// IMapControl
         /// </summary>
 
@@ -527,6 +532,29 @@ namespace Mapsui.UI.Forms
         }
 
         #endregion
+
+        /// <summary>
+        /// Start updates for control
+        /// </summary>
+        /// <remarks>
+        /// When this function is called, the control is redrawn if needed
+        /// </remarks>
+        public void StartUpdates(bool refresh)
+        {
+            _mapControl.StartUpdates(refresh);
+        }
+
+        /// <summary>
+        /// Stop updates for control
+        /// </summary>
+        /// <remarks>
+        /// When this function is called, the control stops to redraw itself, 
+        /// even if it is needed
+        /// </remarks>
+        public void StopUpdates()
+        {
+            _mapControl.StopUpdates();
+        }
 
         internal void AddCallout(Callout callout)
         {

--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -461,7 +461,14 @@ namespace Mapsui.UI.Forms
         /// <summary>
         /// Update interval for invalidation timer in ms
         /// </summary>
-        public int UpdateInterval => _mapControl.UpdateInterval;
+        public int UpdateInterval
+        {
+            get => _mapControl.UpdateInterval;
+            set
+            {
+                _mapControl.UpdateInterval = value;
+            }
+        }
 
         /// <summary>
         /// IMapControl

--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -539,7 +539,7 @@ namespace Mapsui.UI.Forms
         /// <remarks>
         /// When this function is called, the control is redrawn if needed
         /// </remarks>
-        public void StartUpdates(bool refresh)
+        public void StartUpdates(bool refresh = true)
         {
             _mapControl.StartUpdates(refresh);
         }

--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -556,6 +556,17 @@ namespace Mapsui.UI.Forms
             _mapControl.StopUpdates();
         }
 
+        /// <summary>
+        /// Force a update of control
+        /// </summary>
+        /// <remarks>
+        /// When this function is called, the control draws itself once 
+        /// </remarks>
+        public void ForceUpdate()
+        {
+            _mapControl.ForceUpdate();
+        }
+
         internal void AddCallout(Callout callout)
         {
             if (!_callouts.Contains(callout))

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -40,6 +40,19 @@ namespace Mapsui.UI.Wpf
             Map = new Map();
         }
 
+        void CommonPaintControl(object canvas)
+        {
+            if (Renderer == null) 
+                return;
+            if (_map == null) 
+                return;
+            if (!Viewport.HasSize) 
+                return;
+
+            Navigator.UpdateAnimations();
+            Renderer.Render(canvas, new Viewport(Viewport), _map.Layers, _map.Widgets, _map.BackColor);
+        }
+
         /// <summary>
         /// After how many degrees start rotation to take place
         /// </summary>

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -28,6 +28,17 @@ namespace Mapsui.UI.Wpf
     {
         private Map _map;
         private double _unSnapRotationDegrees;
+        // Flag indicating if a drawing process is running
+        private bool _drawing = false;
+        // Flag indicating if a new drawing process should start
+        private bool _refresh = false;
+        // Action to call for a redraw of the control
+        private Action _invalidate;
+
+       void CommonInitialize()
+        {
+            Map = new Map();
+        }
 
         /// <summary>
         /// After how many degrees start rotation to take place
@@ -186,6 +197,11 @@ namespace Mapsui.UI.Wpf
         {
             RefreshData(changeType);
             RefreshGraphics();
+        }
+
+        public void RefreshGraphics()
+        {
+            _refresh = true;
         }
 
         private void MapDataChanged(object sender, DataChangedEventArgs e)

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -103,6 +103,17 @@ namespace Mapsui.UI.Wpf
         }
 
         /// <summary>
+        /// Force a update of control
+        /// </summary>
+        /// <remarks>
+        /// When this function is called, the control draws itself once 
+        /// </remarks>
+        public void ForceUpdate()
+        {
+            _invalidate?.Invoke();
+        }
+
+        /// <summary>
         /// Interval between two redraws of the MapControl in ms
         /// </summary>
         public int UpdateInterval

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -46,7 +46,7 @@ namespace Mapsui.UI.Wpf
             // Create timer for invalidating the control
             _invalidateTimer = new((state) => InvalidateTimerCallback(state), null, System.Threading.Timeout.Infinite, 16);
             // Start the invalidation timer
-            StartUpdates();
+            StartUpdates(false);
         }
 
         void CommonDrawControl(object canvas)
@@ -84,8 +84,9 @@ namespace Mapsui.UI.Wpf
         /// <remarks>
         /// When this function is called, the control is redrawn if needed
         /// </remarks>
-        public void StartUpdates()
+        public void StartUpdates(bool refresh = true)
         {
+            _refresh = refresh;
             _invalidateTimer.Change(0, _updateInterval);
         }
 

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -75,7 +75,7 @@ namespace Mapsui.UI.Wpf
             if (_drawing || !_refresh)
                 return;
 
-            _invalidate();
+            _invalidate?.Invoke();
         }
 
         /// <summary>

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -109,6 +109,9 @@ namespace Mapsui.UI.Wpf
             get => _updateInterval;
             set
             {
+                if (value <= 0)
+                    throw new ArgumentOutOfRangeException("UpdateInterval must be greater than 0");
+
                 if (_updateInterval != value)
                 {
                     _updateInterval = value;

--- a/Mapsui.UI.Uwp/MapControl.cs
+++ b/Mapsui.UI.Uwp/MapControl.cs
@@ -50,7 +50,12 @@ namespace Mapsui.UI.Uwp
 
         void Initialize()
         {
-            _invalidate = () => { RunOnUIThread(() => _canvas?.Invalidate()); };
+            _invalidate = () => {
+                // The commented out code crashes the app when MouseWheelAnimation.Duration > 0. Could be a bug in SKXamlCanvas
+                //if (Dispatcher.HasThreadAccess) _canvas?.Invalidate();
+                //else RunOnUIThread(() => _canvas?.Invalidate());
+                RunOnUIThread(() => _canvas?.Invalidate()); 
+            };
 
             Background = new SolidColorBrush(Colors.White); // DON'T REMOVE! Touch events do not work without a background
 
@@ -159,14 +164,6 @@ namespace Mapsui.UI.Uwp
             Navigator.ZoomTo(resolution, mousePosition, MouseWheelAnimation.Duration, MouseWheelAnimation.Easing);
 
             e.Handled = true;
-        }
-        
-        public void RefreshGraphics()
-        {
-            _refresh = true;
-            // The commented out code crashes the app when MouseWheelAnimation.Duration > 0. Could be a bug in SKXamlCanvas
-            //if (Dispatcher.HasThreadAccess) _canvas?.Invalidate();
-            //else RunOnUIThread(() => _canvas?.Invalidate());
         }
 
         private void MapControlLoaded(object sender, RoutedEventArgs e)

--- a/Mapsui.UI.Uwp/MapControl.cs
+++ b/Mapsui.UI.Uwp/MapControl.cs
@@ -44,14 +44,20 @@ namespace Mapsui.UI.Uwp
 
         public MapControl()
         {
+            CommonInitialize();
+            Initialize();
+        }
+
+        void Initialize()
+        {
+            _invalidate = () => { RunOnUIThread(() => _canvas?.Invalidate()); };
+
             Background = new SolidColorBrush(Colors.White); // DON'T REMOVE! Touch events do not work without a background
 
             Children.Add(_canvas);
             Children.Add(_selectRectangle);
 
             _canvas.PaintSurface += Canvas_PaintSurface;
-
-            Map = new Map();
 
             Loaded += MapControlLoaded;
 
@@ -157,10 +163,10 @@ namespace Mapsui.UI.Uwp
         
         public void RefreshGraphics()
         {
+            _refresh = true;
             // The commented out code crashes the app when MouseWheelAnimation.Duration > 0. Could be a bug in SKXamlCanvas
             //if (Dispatcher.HasThreadAccess) _canvas?.Invalidate();
             //else RunOnUIThread(() => _canvas?.Invalidate());
-            RunOnUIThread(() => _canvas?.Invalidate());
         }
 
         private void MapControlLoaded(object sender, RoutedEventArgs e)

--- a/Mapsui.UI.Uwp/MapControl.cs
+++ b/Mapsui.UI.Uwp/MapControl.cs
@@ -187,15 +187,14 @@ namespace Mapsui.UI.Uwp
 
         private void Canvas_PaintSurface(object sender, SKPaintSurfaceEventArgs e)
         {
-            if (Renderer == null) return;
-            if (_map == null) return;
-            if (!Viewport.HasSize) return;
-            if (PixelDensity <= 0) return;
+            if (PixelDensity <= 0) 
+                return;
 
-            e.Surface.Canvas.Scale(PixelDensity, PixelDensity);
+            var canvas = e.Surface.Canvas;
+            
+            canvas.Scale(PixelDensity, PixelDensity);
 
-            Navigator.UpdateAnimations();
-            Renderer.Render(e.Surface.Canvas, new Viewport(Viewport), _map.Layers, _map.Widgets, _map.BackColor);
+            CommonPaintControl(canvas);
         }
 
         [Obsolete("Use MapControl.Navigate.NavigateTo instead", true)]

--- a/Mapsui.UI.Uwp/MapControl.cs
+++ b/Mapsui.UI.Uwp/MapControl.cs
@@ -194,7 +194,7 @@ namespace Mapsui.UI.Uwp
             
             canvas.Scale(PixelDensity, PixelDensity);
 
-            CommonPaintControl(canvas);
+            CommonDrawControl(canvas);
         }
 
         [Obsolete("Use MapControl.Navigate.NavigateTo instead", true)]

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -492,12 +492,12 @@ namespace Mapsui.UI.Wpf
             
             canvas.Scale(PixelDensity, PixelDensity);
 
-            CommonPaintControl(canvas);
+            CommonDrawControl(canvas);
         }
 
         private void PaintWpf()
         {
-            CommonPaintControl(WpfCanvas);
+            CommonDrawControl(WpfCanvas);
         }
 
         private float GetPixelDensity()

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -161,7 +161,6 @@ namespace Mapsui.UI.Wpf
         {
             if (RenderMode == RenderMode.Wpf) InvalidateVisual(); // To trigger OnRender of this MapControl
             else SkiaCanvas.InvalidateVisual();
-
         }
 
         private void MapControlLoaded(object sender, RoutedEventArgs e)
@@ -486,23 +485,19 @@ namespace Mapsui.UI.Wpf
 
         private void SKElementOnPaintSurface(object sender, SKPaintSurfaceEventArgs args)
         {
-            if (Renderer == null) return;
-            if (_map == null) return;
-            if (PixelDensity <= 0) return;
+            if (PixelDensity <= 0) 
+                return;
 
-            args.Surface.Canvas.Scale(PixelDensity, PixelDensity);
+            var canvas = args.Surface.Canvas;
+            
+            canvas.Scale(PixelDensity, PixelDensity);
 
-            Navigator.UpdateAnimations();
-            Renderer.Render(args.Surface.Canvas, new Viewport(Viewport), Map.Layers, Map.Widgets, Map.BackColor);
+            CommonPaintControl(canvas);
         }
 
         private void PaintWpf()
         {
-            if (Renderer == null) return;
-            if (_map == null) return;
-
-            Navigator.UpdateAnimations();
-            Renderer.Render(WpfCanvas, Viewport, _map.Layers, Map.Widgets, _map.BackColor);
+            CommonPaintControl(WpfCanvas);
         }
 
         private float GetPixelDensity()

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -47,13 +47,22 @@ namespace Mapsui.UI.Wpf
 
         public MapControl()
         {
+            CommonInitialize();
+            Initialize();
+        }
+
+        void Initialize()
+        {
+            _invalidate = () => {
+                if (Dispatcher.CheckAccess()) InvalidateCanvas();
+                else RunOnUIThread(InvalidateCanvas);
+            };
+
             Children.Add(WpfCanvas);
             Children.Add(SkiaCanvas);
             Children.Add(_selectRectangle);
 
             SkiaCanvas.PaintSurface += SKElementOnPaintSurface;
-
-            Map = new Map();
 
             Loaded += MapControlLoaded;
             MouseLeftButtonDown += MapControlMouseLeftButtonDown;
@@ -147,12 +156,6 @@ namespace Mapsui.UI.Wpf
         }
 
         public event EventHandler<FeatureInfoEventArgs> FeatureInfo; // todo: Remove and add sample for alternative
-
-        public void RefreshGraphics()
-        {
-            if (Dispatcher.CheckAccess()) InvalidateCanvas();
-            else RunOnUIThread(InvalidateCanvas);
-        }
 
         internal void InvalidateCanvas()
         {

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -99,12 +99,14 @@ namespace Mapsui.UI.iOS
 
         void OnPaintSurface(object sender, SKPaintGLSurfaceEventArgs args)
         {
-            if (PixelDensity <= 0) return;
+            if (PixelDensity <= 0) 
+                return;
 
-            args.Surface.Canvas.Scale(PixelDensity, PixelDensity);
+            var canvas = args.Surface.Canvas;
+            
+            canvas.Scale(PixelDensity, PixelDensity);
 
-            Navigator.UpdateAnimations();
-            Renderer.Render(args.Surface.Canvas, new Viewport(Viewport), _map.Layers, _map.Widgets, _map.BackColor);
+            CommonPaintControl(canvas);
         }
 
         public override void TouchesBegan(NSSet touches, UIEvent evt)

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -106,7 +106,7 @@ namespace Mapsui.UI.iOS
             
             canvas.Scale(PixelDensity, PixelDensity);
 
-            CommonPaintControl(canvas);
+            CommonDrawControl(canvas);
         }
 
         public override void TouchesBegan(NSSet touches, UIEvent evt)

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -22,18 +22,27 @@ namespace Mapsui.UI.iOS
         public MapControl(CGRect frame)
             : base(frame)
         {
+            CommonInitialize();
             Initialize();
         }
 
         [Preserve]
         public MapControl(IntPtr handle) : base(handle) // used when initialized from storyboard
         {
+            CommonInitialize();
             Initialize();
         }
 
         public void Initialize()
         {
-            Map = new Map();
+            _invalidate = () => {
+                RunOnUIThread(() =>
+                {
+                    SetNeedsDisplay();
+                    _canvas?.SetNeedsDisplay();
+                });
+            };
+
             BackgroundColor = UIColor.White;
 
             _canvas.TranslatesAutoresizingMaskIntoConstraints = false;
@@ -182,15 +191,6 @@ namespace Mapsui.UI.iOS
         private void RunOnUIThread(Action action)
         {
             DispatchQueue.MainQueue.DispatchAsync(action);
-        }
-
-        public void RefreshGraphics()
-        {
-            RunOnUIThread(() =>
-            {
-                SetNeedsDisplay();
-                _canvas?.SetNeedsDisplay();
-            });
         }
 
         public override CGRect Frame

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -33,7 +33,7 @@ namespace Mapsui.UI.iOS
             Initialize();
         }
 
-        public void Initialize()
+        void Initialize()
         {
             _invalidate = () => {
                 RunOnUIThread(() =>


### PR DESCRIPTION
A first shoot to use an invalidate loop to redraw MapControl. For this, more things are moved into the common MapControl. The interval of the loop could be changed and the loop could be started and stopped, if the control vanishes from screen.
`RefreshGraphics()` now only set a flag.

Should replace #1187