### PR TITLE
Mapsui.nuspec: remove dependency on SkiaSharp.Views

### DIFF
--- a/NuSpec/Mapsui.nuspec
+++ b/NuSpec/Mapsui.nuspec
@@ -22,7 +22,6 @@
         <dependency id="Newtonsoft.json" version="[11.0.1,)"/>
         <dependency id="SkiaSharp" version="[2.80.3,3.0.0)"/>
         <dependency id="Svg.Skia" version="[0.5.0,0.6)"/>
-        <dependency id="SkiaSharp.Views" version="[2.80.3,3.0.0)"/>
         <dependency id="Topten.RichTextKit" version="[0.4.139,0.5)"/>
       </group>
     </dependencies>


### PR DESCRIPTION
* SkiaSharp.Views is only used in the Mapsui.UI.* parts
  (which are contained in the Mapsui.Native and Mapsui.Forms packages)
* this avoids nuget warnings like this, when referencing the Mapsui package from another project:
  Package 'SkiaSharp.Views 2.80.3' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project target framework '.NETStandard,Version=v2.0'. This package may not be fully compatible with your project.
* it is a fixup for PR #1175