### PR TITLE
release 3.0.0-rc.2

### DIFF
--- a/Mapsui.Common.props
+++ b/Mapsui.Common.props
@@ -3,7 +3,7 @@
   
   <!--- Package information, Version -->
   <PropertyGroup>
-    <Version>3.0.0-alpha.4</Version>
+    <Version>3.0.0-rc.2</Version>
     <NeutralLanguage>en</NeutralLanguage>
     <Copyright>Copyright © Mapsui Developers 2018</Copyright>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Mapsui/Mapsui/master/LICENSE.md</PackageLicenseUrl>

--- a/Mapsui.Rendering.Xaml/Properties/AssemblyInfo.cs
+++ b/Mapsui.Rendering.Xaml/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]

--- a/Mapsui.UI.Android/Properties/AssemblyInfo.cs
+++ b/Mapsui.UI.Android/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using Android.App;
 // Add some common permissions, these can be removed if not needed
 [assembly: UsesPermission(Android.Manifest.Permission.Internet)]
 [assembly: UsesPermission(Android.Manifest.Permission.WriteExternalStorage)]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]

--- a/Mapsui.UI.Uwp/Properties/AssemblyInfo.cs
+++ b/Mapsui.UI.Uwp/Properties/AssemblyInfo.cs
@@ -26,4 +26,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]

--- a/Samples/Mapsui.Samples.Uwp/Properties/AssemblyInfo.cs
+++ b/Samples/Mapsui.Samples.Uwp/Properties/AssemblyInfo.cs
@@ -26,4 +26,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]

--- a/Samples/Mapsui.Samples.Wpf/Properties/AssemblyInfo.cs
+++ b/Samples/Mapsui.Samples.Wpf/Properties/AssemblyInfo.cs
@@ -51,4 +51,4 @@ using System.Windows;
 
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]

--- a/Samples/Mapsui.Samples.iOS/Properties/AssemblyInfo.cs
+++ b/Samples/Mapsui.Samples.iOS/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]

--- a/Tests/Mapsui.Desktop.Tests/Properties/AssemblyInfo.cs
+++ b/Tests/Mapsui.Desktop.Tests/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]

--- a/Tests/Mapsui.Geometries.Tests/Properties/AssemblyInfo.cs
+++ b/Tests/Mapsui.Geometries.Tests/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]

--- a/Tests/Mapsui.Rendering.Skia.Tests/Properties/AssemblyInfo.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]

--- a/Tests/Mapsui.Rendering.Xaml.Tests/Properties/AssemblyInfo.cs
+++ b/Tests/Mapsui.Rendering.Xaml.Tests/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]

--- a/Tests/Mapsui.Tests/Properties/AssemblyInfo.cs
+++ b/Tests/Mapsui.Tests/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]

--- a/Tools/VersionUpdater/Properties/AssemblyInfo.cs
+++ b/Tools/VersionUpdater/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0-alpha.4")]
+[assembly: AssemblyInformationalVersion("3.0.0-rc.2")]


### PR DESCRIPTION
We talked about tagging a new (pre-)release after all the recent fixes. This updates the version number. After it is merged, we only need to:
* set a tag
* upload the nupkgs to nuget.org

I may be able to do the first one (not sure if I have sufficient permissions), but the uploading probably needs to be done by Paul.