### PR TITLE
Downgrade sqlite to 1.6.292

### DIFF
--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Android/Mapsui.Samples.Forms.Android.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Android/Mapsui.Samples.Forms.Android.csproj
@@ -123,7 +123,7 @@
       <Version>2.80.3</Version>
     </PackageReference>
     <PackageReference Include="sqlite-net-pcl">
-      <Version>1.8.116</Version>
+      <Version>1.6.292</Version>
     </PackageReference>
     <PackageReference Include="Svg.Skia">
       <Version>0.5.7.1</Version>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Mac/Mapsui.Samples.Forms.Mac.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Mac/Mapsui.Samples.Forms.Mac.csproj
@@ -131,7 +131,7 @@
       <Version>2.80.3</Version>
     </PackageReference>
     <PackageReference Include="sqlite-net-pcl">
-      <Version>1.8.116</Version>
+      <Version>1.6.292</Version>
     </PackageReference>
     <PackageReference Include="Svg.Skia">
       <Version>0.5.7.1</Version>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.WPF/Mapsui.Samples.Forms.WPF.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.WPF/Mapsui.Samples.Forms.WPF.csproj
@@ -21,7 +21,7 @@
     </PackageReference>
     <PackageReference Include="SkiaSharp.Views.Forms.WPF" Version="2.80.3">
     </PackageReference>
-    <PackageReference Include="sqlite-net-pcl" Version="1.8.116">
+    <PackageReference Include="sqlite-net-pcl" Version="1.6.292">
     </PackageReference>
     <PackageReference Include="Svg.Skia" Version="0.5.7.1">
     </PackageReference>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.iOS/Mapsui.Samples.Forms.iOS.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.iOS/Mapsui.Samples.Forms.iOS.csproj
@@ -158,7 +158,7 @@
       <Version>5.0.0.2083</Version>
     </PackageReference>
     <PackageReference Include="sqlite-net-pcl">
-      <Version>1.8.116</Version>
+      <Version>1.6.292</Version>
     </PackageReference>
     <PackageReference Include="BruTile.MbTiles">
       <Version>4.0.0</Version>

--- a/Samples/Mapsui.Samples.Wpf/Mapsui.Samples.Wpf.csproj
+++ b/Samples/Mapsui.Samples.Wpf/Mapsui.Samples.Wpf.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BruTile.MbTiles" Version="4.0.0" />
-    <PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
+    <PackageReference Include="sqlite-net-pcl" Version="1.6.292" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I saw the upgrade in [this PR](https://github.com/Mapsui/Mapsui/pull/1203) and wondered if that could cause a problem and it did. The WPF sample throw an exception when trying to open mbtiles. Apparently there were api changes between 1.6 and 1.8. This is not according to semver but happens a lot.

BruTile.MbTiles was compiled against 1.6.292. The nuget refers to that version:
https://www.nuget.org/packages/BruTile.MbTiles/