### PR TITLE
Fix desktop samples

### DIFF
--- a/Samples/Mapsui.Samples.Common.Desktop/Utilities.cs
+++ b/Samples/Mapsui.Samples.Common.Desktop/Utilities.cs
@@ -1,6 +1,6 @@
-﻿namespace Mapsui.Tests.Common
+﻿namespace Mapsui.Samples.Common.Desktop
 {
-    public static class Utilities
+    public static class DesktopSamplesUtilities
     {
         // When there is no explicit call to the assembly it is not loaded
         // Even if there is a project reference. Calling this method is the workaround.

--- a/Samples/Mapsui.Samples.Common/Maps/Desktop/WmsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Desktop/WmsSample.cs
@@ -6,9 +6,6 @@ namespace Mapsui.Samples.Common.Desktop
 {
     public class WmsSample : ISample
     {
-        // When there is no explicit call to the assembly it is not loaded
-        public static void LoadAssembly() { }
-
         public string Name => "2 WMS";
         public string Category => "Desktop";
 

--- a/Samples/Mapsui.Samples.Wpf/Window1.xaml.cs
+++ b/Samples/Mapsui.Samples.Wpf/Window1.xaml.cs
@@ -81,7 +81,7 @@ namespace Mapsui.Samples.Wpf
         private void FillComboBoxWithCategories()
         {
             // todo: find proper way to load assembly
-            WmsSample.LoadAssembly();
+            DesktopSamplesUtilities.LoadAssembly();
             Tests.Common.Utilities.LoadAssembly();
 
             var categories = AllSamples.GetSamples().Select(s => s.Category).Distinct().OrderBy(c => c);


### PR DESCRIPTION
Why: The desktop samples where not loaded in the wpf application
because the LoadAssembly method was inside a sample that was
moved.
Note: This is to prepare for cleanup of the desktop samples.