### PR TITLE
iOS System Memory Workaround

### DIFF
--- a/NuSpec/Mapsui.Forms.nuspec
+++ b/NuSpec/Mapsui.Forms.nuspec
@@ -22,12 +22,19 @@
       <group targetFramework="netstandard2.0">
         <dependency id="Mapsui" version="$version$"/>
         <dependency id="Xamarin.Forms" version="[5.0.0.2083,6.0)" />
-        <dependency id="SkiaSharp.Views.Forms" version="[2.80.2,3.0.0)" />
+        <dependency id="SkiaSharp.Views.Forms" version="[2.80.2,3.0.0)" />		
+      </group>
+	  <group targetFramework="xamarinios1.0">
+        <dependency id="Mapsui" version="$version$"/>
+        <dependency id="Xamarin.Forms" version="[5.0.0.2083,6.0)" />
+        <dependency id="SkiaSharp.Views.Forms" version="[2.80.2,3.0.0)" />		
       </group>
     </dependencies>
 
   </metadata>
   <files>
+	<file src="Mapsui.Forms.targets" target="build/xamarinios1.0/Mapsui.Forms.targets" />	
     <file src="../Mapsui.UI.Forms/bin/Release/netstandard2.0/Mapsui.UI.Forms.dll" target="lib/netstandard2.0/" />
+	<file src="../Mapsui.UI.Forms/bin/Release/netstandard2.0/Mapsui.UI.Forms.dll" target="lib/xamarinios1.0/" />
   </files>
 </package>

--- a/NuSpec/Mapsui.Forms.targets
+++ b/NuSpec/Mapsui.Forms.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+	<PackageReference Include="System.Memory" Version="4.5.4" IncludeAssets="None" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This should fix https://github.com/Mapsui/Mapsui/issues/1216

by including a target in Xamarin.Ios that creates this PackageReference

<PackageReference Include="System.Memory" Version="4.5.4" IncludeAssets="None" />

Avoiding that the Developer using Mapsui has to do it himself
