### PR TITLE
Get callout to work in WPF

### DIFF
--- a/Samples/Mapsui.Samples.Wpf/Window1.xaml.cs
+++ b/Samples/Mapsui.Samples.Wpf/Window1.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using Mapsui.Logging;
+using Mapsui.Rendering.Skia;
 using Mapsui.Samples.CustomWidget;
 using Mapsui.Samples.Wpf.Utilities;
 using Mapsui.UI;
@@ -152,6 +153,9 @@ namespace Mapsui.Samples.Wpf
         {
             if (args.MapInfo?.Feature != null)
             {
+                var calloutStyle = args.MapInfo.Feature.Styles.Cast<CalloutStyle>().FirstOrDefault();
+                if (calloutStyle != null) calloutStyle.Enabled = !calloutStyle.Enabled;
+
                 FeatureInfoBorder.Visibility = Visibility.Visible;
                 FeatureInfo.Text = $"Click Info:{Environment.NewLine}{args.MapInfo.Feature.ToDisplayText()}";
             }


### PR DESCRIPTION
@charlenni  The callout functionality non-forms sample called 'Callout' did not function. It was like this for at least many months. Today I looked at it. I got it to work by looking at the way a callout is generated in Forms, but there is still a lot I don't understand. 

The sample as it was used a bitmap. A png was created. That png was generated correctly. It was added to the BitmapRegistry. In a later step this png was (or should?) be transformed to a SKImage. This did not work as it should but I am not sure how it was supposed to work. Why did we use a png here? Performance? Is a png for callout used in other samples?

I altered this sample to get it to work but perhaps it is better to repair the original sample. 