### PR TITLE
[3.0.x] MapView: Fix NullReferenceExceptions (related to button widgets)

### DIFF
--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -673,30 +673,21 @@ namespace Mapsui.UI.Forms
 
             if (propertyName.Equals(nameof(IsZoomButtonVisibleProperty)) || propertyName.Equals(nameof(IsZoomButtonVisible)))
             {
-                if (_mapZoomInButton != null && _mapZoomOutButton != null)
-                {
-                    _mapZoomInButton.Enabled = IsZoomButtonVisible;
-                    _mapZoomOutButton.Enabled = IsZoomButtonVisible;
-                    UpdateButtonPositions();
-                }
+                _mapZoomInButton.Enabled = IsZoomButtonVisible;
+                _mapZoomOutButton.Enabled = IsZoomButtonVisible;
+                UpdateButtonPositions();
             }
 
             if (propertyName.Equals(nameof(IsMyLocationButtonVisibleProperty)) || propertyName.Equals(nameof(IsMyLocationButtonVisible)))
             {
-                if (_mapMyLocationButton != null)
-                {
-                    _mapMyLocationButton.Enabled = IsMyLocationButtonVisible;
-                    UpdateButtonPositions();
-                }
+                _mapMyLocationButton.Enabled = IsMyLocationButtonVisible;
+                UpdateButtonPositions();
             }
 
             if (propertyName.Equals(nameof(IsNorthingButtonVisibleProperty)) || propertyName.Equals(nameof(IsNorthingButtonVisible)))
             {
-                if (_mapNorthingButton != null)
-                {
-                    _mapNorthingButton.Enabled = IsNorthingButtonVisible;
-                    UpdateButtonPositions();
-                }
+                _mapNorthingButton.Enabled = IsNorthingButtonVisible;
+                UpdateButtonPositions();
             }
 
             if (propertyName.Equals(nameof(ButtonMarginProperty)) || propertyName.Equals(nameof(ButtonMargin)))
@@ -1141,7 +1132,7 @@ namespace Mapsui.UI.Forms
             var newX = _mapControl.Width - ButtonMargin.Right - ButtonSize;
             var newY = ButtonMargin.Top;
 
-            if (IsZoomButtonVisible && _mapZoomInButton != null && _mapZoomOutButton != null)
+            if (IsZoomButtonVisible)
             {
                 _mapZoomInButton.Envelope = new Geometries.BoundingBox(newX, newY, newX + ButtonSize, newY + ButtonSize);
                 newY += ButtonSize;
@@ -1149,13 +1140,13 @@ namespace Mapsui.UI.Forms
                 newY += ButtonSize + ButtonSpacing;
             }
 
-            if (IsMyLocationButtonVisible && _mapMyLocationButton != null)
+            if (IsMyLocationButtonVisible)
             {
                 _mapMyLocationButton.Envelope = new Geometries.BoundingBox(newX, newY, newX + ButtonSize, newY + ButtonSize);
                 newY += ButtonSize + ButtonSpacing;
             }
 
-            if (IsNorthingButtonVisible && _mapNorthingButton != null)
+            if (IsNorthingButtonVisible)
             {
                 _mapNorthingButton.Envelope = new Geometries.BoundingBox(newX, newY, newX + ButtonSize, newY + ButtonSize);
             }


### PR DESCRIPTION
This fixes #1282 in a rather straightforward way: It creates the button widgets already in the MapView constructor and removes all null checks for those.

I primarily want to apply it to the 3.0 branch, but it should probably also be forward-ported to master.