### PR TITLE
Format csprojs

### DIFF
--- a/Mapsui.Geometries/Mapsui.Geometries.csproj
+++ b/Mapsui.Geometries/Mapsui.Geometries.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Configurations>Release;Debug</Configurations>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
   </PropertyGroup>
 

--- a/Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj
+++ b/Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Configurations>Release;Debug</Configurations>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
   </PropertyGroup>
 

--- a/Mapsui.UI.Avalonia/Mapsui.UI.Avalonia.csproj
+++ b/Mapsui.UI.Avalonia/Mapsui.UI.Avalonia.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>__AVALONIA__</DefineConstants>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>__AVALONIA__</DefineConstants>
   </PropertyGroup>
+
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="BruTile" Version="4.0.0" />
     <PackageReference Include="SkiaSharp" Version="2.80.2" />

--- a/Mapsui.UI.Forms/Mapsui.UI.Forms.csproj
+++ b/Mapsui.UI.Forms/Mapsui.UI.Forms.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;__FORMS__;DEBUG;NETSTANDARD1_3</DefineConstants>
   </PropertyGroup>
@@ -37,6 +39,7 @@
     <None Remove="Images\ZoomOut.svg" />
     <None Remove="Images\MyLocationDir.svg" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Images\Close.svg" />
     <EmbeddedResource Include="Images\MyLocationStill.svg" />
@@ -49,6 +52,7 @@
     <EmbeddedResource Include="Images\ZoomOut.svg" />
     <EmbeddedResource Include="Images\MyLocationDir.svg" />
   </ItemGroup>
+
   <Import Project="..\Mapsui.UI.Shared\Mapsui.UI.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/Mapsui.UI.Uno/Mapsui.UI.Uno.csproj
+++ b/Mapsui.UI.Uno/Mapsui.UI.Uno.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.38">
+
   <!--
 	Adding project references to this project requires some manual adjustments.
 	Please see https://github.com/unoplatform/uno/issues/3909 for more details.
 	-->
+
   <PropertyGroup>
     <TargetFrameworks>uap10.0.18362;netstandard2.0;xamarinios10;xamarinmac20;MonoAndroid11.0;monoandroid10.0</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
@@ -28,13 +30,16 @@
       <DependentUpon>%(Filename)</DependentUpon>
     </Compile>
   </ItemGroup>
+
   <ItemGroup>
     <UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\Mapsui.UI.Uwp\Extensions\PointExtensions.cs" Link="Extensions\PointExtensions.cs" />
     <Compile Include="..\Mapsui.UI.Uwp\MapControl.cs" Link="MapControl.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <Folder Include="Extensions\" />
   </ItemGroup>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net5.0-windows10.0.18362.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
@@ -7,6 +8,7 @@
     <UseWinUI>true</UseWinUI>
     <DefineConstants>__WINUI__</DefineConstants>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Mapsui.UI.Uwp\MapControl.cs" Link="MapControl.cs" />
   </ItemGroup>
@@ -25,4 +27,5 @@
   </ItemGroup>
 
   <Import Project="..\Mapsui.UI.Shared\Mapsui.UI.Shared.projitems" Label="Shared" />
+
 </Project>

--- a/Samples/Mapsui.Samples.Avalonia/Mapsui.Samples.Avalonia.csproj
+++ b/Samples/Mapsui.Samples.Avalonia/Mapsui.Samples.Avalonia.csproj
@@ -1,12 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="0.10.7" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.7" />
@@ -16,6 +19,7 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.7" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\Mapsui.Geometries\Mapsui.Geometries.csproj" />
     <ProjectReference Include="..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj" />
@@ -25,4 +29,5 @@
     <ProjectReference Include="..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
     <ProjectReference Include="..\Mapsui.Samples.CustomWidget\Mapsui.Samples.CustomWidget.csproj" />
   </ItemGroup>
+
 </Project>

--- a/Samples/Mapsui.Samples.Common.Desktop/Mapsui.Samples.Common.Desktop.csproj
+++ b/Samples/Mapsui.Samples.Common.Desktop/Mapsui.Samples.Common.Desktop.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <Version>2.0.0</Version>

--- a/Samples/Mapsui.Samples.Common/Mapsui.Samples.Common.csproj
+++ b/Samples/Mapsui.Samples.Common/Mapsui.Samples.Common.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Mapsui Contributers</Authors>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
+
   <ItemGroup>
     <None Remove="EmbeddedResources\cities.geojson" />
     <None Remove="EmbeddedResources\cities.json" />
@@ -26,6 +28,7 @@
     <None Remove="MbTiles\torrejon-de-ardoz.mbtiles" />
     <None Remove="MbTiles\world.mbtiles" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="EmbeddedResources\cities.geojson" />
     <EmbeddedResource Include="EmbeddedResources\cities.json" />

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Gtk/Mapsui.Samples.Uno.Skia.Gtk.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Gtk/Mapsui.Samples.Uno.Skia.Gtk.csproj
@@ -1,23 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup Condition="exists('..\Mapsui.Samples.Uno.UWP')">
     <EmbeddedResource Include="..\Mapsui.Samples.Uno.UWP\Package.appxmanifest" LogicalName="Package.appxmanifest" />
     <Content Include="..\Mapsui.Samples.Uno.UWP\Assets\StoreLogo.png" Link="Assets\StoreLogo.png" />
     <Content Include="Assets\Fonts\uno-fluentui-assets.ttf" />
   </ItemGroup>
+
   <ItemGroup>
     <UpToDateCheckInput Include="..\Mapsui.Samples.Uno.Shared\**\*.xaml" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Uno.UI.Skia.Gtk" Version="3.10.11" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="3.10.11" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mapsui.Geometries\Mapsui.Geometries.csproj" />
     <ProjectReference Include="..\..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj" />
@@ -26,5 +31,7 @@
     <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
     <ProjectReference Include="..\..\Mapsui.Samples.CustomWidget\Mapsui.Samples.CustomWidget.csproj" />
   </ItemGroup>
+
   <Import Project="..\Mapsui.Samples.Uno.Shared\Mapsui.Samples.Uno.Shared.projitems" Label="Shared" />
+
 </Project>

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Tizen/Mapsui.Samples.Uno.Skia.Tizen.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Tizen/Mapsui.Samples.Uno.Skia.Tizen.csproj
@@ -1,21 +1,26 @@
 ﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen50</TargetFramework>
     <OutputType>Exe</OutputType>
     <DefineConstants>$(DefineConstants);__TIZEN__;</DefineConstants>
   </PropertyGroup>
+
   <ItemGroup>
     <Folder Include="lib\" />
     <Folder Include="res\" />
   </ItemGroup>
+
   <ItemGroup Condition="exists('..\Mapsui.Samples.Uno.UWP')">
     <EmbeddedResource Include="..\Mapsui.Samples.Uno.UWP\Package.appxmanifest" LogicalName="Package.appxmanifest" />
     <Content Include="..\Mapsui.Samples.Uno.UWP\Assets\StoreLogo.png" Link="Assets\StoreLogo.png" />
   </ItemGroup>
+
   <ItemGroup>
     <UpToDateCheckInput Include="..\Mapsui.Samples.Uno.Shared\**\*.xaml" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
@@ -23,6 +28,7 @@
     <PackageReference Include="Uno.UI.Skia.Tizen" Version="3.10.11" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="3.10.11" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mapsui.Geometries\Mapsui.Geometries.csproj" />
     <ProjectReference Include="..\..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj" />
@@ -31,5 +37,7 @@
     <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
     <ProjectReference Include="..\..\Mapsui.Samples.CustomWidget\Mapsui.Samples.CustomWidget.csproj" />
   </ItemGroup>
+
   <Import Project="..\Mapsui.Samples.Uno.Shared\Mapsui.Samples.Uno.Shared.projitems" Label="Shared" />
+
 </Project>

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Wpf.Host/Mapsui.Samples.Uno.Skia.Wpf.Host.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Wpf.Host/Mapsui.Samples.Uno.Skia.Wpf.Host.csproj
@@ -1,17 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Uno.UI.Skia.Wpf" Version="3.10.11" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="3.10.11" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
+
   <ItemGroup>
     <Content Include="Assets\Fonts\uno-fluentui-assets.ttf" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mapsui.Geometries\Mapsui.Geometries.csproj" />
     <ProjectReference Include="..\..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj" />
@@ -21,4 +25,5 @@
     <ProjectReference Include="..\..\Mapsui.Samples.CustomWidget\Mapsui.Samples.CustomWidget.csproj" />
     <ProjectReference Include="..\Mapsui.Samples.Uno.Skia.WPF\Mapsui.Samples.Uno.Skia.WPF.csproj" />
   </ItemGroup>
+
 </Project>

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Wpf/Mapsui.Samples.Uno.Skia.Wpf.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Wpf/Mapsui.Samples.Uno.Skia.Wpf.csproj
@@ -1,16 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Uno.UI.Skia.Wpf" Version="3.10.11" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="3.10.11" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
+
   <ItemGroup>
     <UpToDateCheckInput Include="..\Mapsui.Samples.Uno.Shared\**\*.xaml" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mapsui.Geometries\Mapsui.Geometries.csproj" />
     <ProjectReference Include="..\..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj" />
@@ -19,5 +23,7 @@
     <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
     <ProjectReference Include="..\..\Mapsui.Samples.CustomWidget\Mapsui.Samples.CustomWidget.csproj" />
   </ItemGroup>
+
   <Import Project="..\Mapsui.Samples.Uno.Shared\Mapsui.Samples.Uno.Shared.projitems" Label="Shared" />
+
 </Project>

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <MonoRuntimeDebuggerEnabled>true</MonoRuntimeDebuggerEnabled>
     <DefineConstants>$(DefineConstants);TRACE;DEBUG</DefineConstants>
@@ -15,19 +17,24 @@
 		-->
     <WasmShellILLinkerEnabled>false</WasmShellILLinkerEnabled>
   </PropertyGroup>
+
   <ItemGroup>
     <Content Include="Assets\SplashScreen.png" />
   </ItemGroup>
+
   <ItemGroup>
     <UpToDateCheckInput Include="..\Mapsui.Samples.Uno.Shared\**\*.xaml" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="WasmCSS\Fonts.css" />
     <EmbeddedResource Include="WasmScripts\AppManifest.js" />
   </ItemGroup>
+
   <ItemGroup>
     <LinkerDescriptor Include="LinkerConfig.xml" />
   </ItemGroup>
+
   <ItemGroup>
     <!--
 		This item group is required by the project template because of the
@@ -39,6 +46,7 @@
     <None Include="LinkerConfig.xml" />
     <None Include="wwwroot\web.config" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
@@ -48,6 +56,7 @@
     <PackageReference Include="Uno.Wasm.Bootstrap" Version="3.0.0" />
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.0.0" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mapsui.Core\Mapsui.Core.csproj" />
     <ProjectReference Include="..\..\..\Mapsui.Geometries\Mapsui.Geometries.csproj" />
@@ -57,5 +66,7 @@
     <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
     <ProjectReference Include="..\..\Mapsui.Samples.CustomWidget\Mapsui.Samples.CustomWidget.csproj" />
   </ItemGroup>
+
   <Import Project="..\Mapsui.Samples.Uno.Shared\Mapsui.Samples.Uno.Shared.projitems" Label="Shared" Condition="Exists('..\Mapsui.Samples.Uno.Shared\Mapsui.Samples.Uno.Shared.projitems')" />
+
 </Project>

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
@@ -28,4 +29,5 @@
     <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
     <ProjectReference Include="..\..\Mapsui.Samples.CustomWidget\Mapsui.Samples.CustomWidget.csproj" />
   </ItemGroup>
+
 </Project>

--- a/Samples/Mapsui.Samples.Wpf.Editing/Mapsui.Samples.Wpf.Editing.csproj
+++ b/Samples/Mapsui.Samples.Wpf.Editing/Mapsui.Samples.Wpf.Editing.csproj
@@ -1,13 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\Mapsui.Core\Mapsui.Core.csproj" />
     <ProjectReference Include="..\..\Mapsui.UI.Wpf\Mapsui.UI.Wpf.csproj" />
     <ProjectReference Include="..\..\Mapsui\Mapsui.csproj" />
   </ItemGroup>
+
 </Project>

--- a/Tests/Mapsui.Geometries.Tests/Mapsui.Geometries.Tests.csproj
+++ b/Tests/Mapsui.Geometries.Tests/Mapsui.Geometries.Tests.csproj
@@ -1,15 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\Mapsui.Geometries\Mapsui.Geometries.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
@@ -20,4 +24,5 @@
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
+
 </Project>

--- a/Tests/Mapsui.Rendering.Skia.Tests/Mapsui.Rendering.Skia.Tests.csproj
+++ b/Tests/Mapsui.Rendering.Skia.Tests/Mapsui.Rendering.Skia.Tests.csproj
@@ -1,21 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>DEBUG;SKIA</DefineConstants>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DefineConstants>SKIA</DefineConstants>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\Mapsui.Geometries\Mapsui.Geometries.csproj" />
     <ProjectReference Include="..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj" />
     <ProjectReference Include="..\..\Mapsui\Mapsui.csproj" />
     <ProjectReference Include="..\Mapsui.Tests.Common\Mapsui.Tests.Common.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <Content Include="Resources\Images\Original\bitmap_atlas.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -57,9 +62,11 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="BruTile" Version="4.0.0" />
@@ -72,4 +79,5 @@
     <PackageReference Include="coverlet.collector" Version="3.0.2" />
     <PackageReference Include="Svg.Skia" Version="0.5.7.1" />
   </ItemGroup>
+
 </Project>

--- a/Tests/Mapsui.Tests.Common/Mapsui.Tests.Common.csproj
+++ b/Tests/Mapsui.Tests.Common/Mapsui.Tests.Common.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup>
     <None Remove="Resources\Images\avion_silhouette.png" />
     <None Remove="Resources\Images\checkered.png" />
@@ -16,6 +18,7 @@
     <None Remove="Resources\SampleTiles\1_1_0.png" />
     <None Remove="Resources\SampleTiles\1_1_1.png" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Resources\Images\avion_silhouette.png" />
     <EmbeddedResource Include="Resources\Images\checkered.png" />
@@ -30,12 +33,14 @@
     <EmbeddedResource Include="Resources\SampleTiles\1_1_0.png" />
     <EmbeddedResource Include="Resources\SampleTiles\1_1_1.png" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\Mapsui.Geometries\Mapsui.Geometries.csproj" />
     <ProjectReference Include="..\..\Mapsui\Mapsui.csproj" />
     <ProjectReference Include="..\..\Samples\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
     <ProjectReference Include="..\..\Samples\Mapsui.Samples.CustomWidget\Mapsui.Samples.CustomWidget.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="BruTile" Version="4.0.0" />
   </ItemGroup>

--- a/Tests/Mapsui.Tests/Mapsui.Tests.csproj
+++ b/Tests/Mapsui.Tests/Mapsui.Tests.csproj
@@ -1,26 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
     <RestorePackages>true</RestorePackages>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+
   <ItemGroup>
     <None Remove="Resources\capabilities_1_1_1.xml" />
     <None Remove="Resources\capabilities_1_3_0.xml" />
     <None Remove="Resources\example.tfw" />
     <None Remove="Resources\example.tif" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\Mapsui.Rendering.Skia.Tests\File.cs">
       <Link>File.cs</Link>
     </Compile>
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\Mapsui.Geometries\Mapsui.Geometries.csproj" />
     <ProjectReference Include="..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj" />
     <ProjectReference Include="..\..\Mapsui\Mapsui.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="BruTile" Version="4.0.0" />
@@ -34,6 +39,7 @@
     <PackageReference Include="coverlet.collector" Version="3.0.2" />
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeCoverage" Version="16.11.0">
     </PackageReference>
@@ -44,6 +50,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
     <Content Include="Resources\capabilities_1_1_1.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -67,4 +74,5 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Formatting csproj to be consistent. Now all have newlines between all elements that are directly in the root element.  I did this for all sdk format csprojs and ignored all old csprojs.

There are quite a few old csprojs. I think projects that hang on to the old format have no future and we should remove all those at some point.