### PR TITLE
Run full code cleanup on Mapsui and Mapsui.Core

### DIFF
--- a/Mapsui.Core/Styles/Thematics/ColorBlend.cs
+++ b/Mapsui.Core/Styles/Thematics/ColorBlend.cs
@@ -136,103 +136,49 @@ namespace Mapsui.Styles.Thematics
         /// Colors span the following with an interval of 0.25:
         /// { Color.Red, Color.Yellow, Color.Green, Color.Cyan, Color.Blue }
         /// </remarks>
-        public static ColorBlend Rainbow5
-        {
-            get
-            {
-                return new ColorBlend(
+        public static ColorBlend Rainbow5 => new ColorBlend(
                     new[] { Color.Red, Color.Yellow, Color.Green, Color.Cyan, Color.Blue },
                     new[] { 0, 0.25, 0.5, 0.75, 1 });
-            }
-        }
 
         /// <summary>
         /// Gets a linear gradient scale from black to white
         /// </summary>
-        public static ColorBlend BlackToWhite
-        {
-            get
-            {
-                return new ColorBlend(new[] { Color.Black, Color.White }, new[] { 0.0, 1.0 });
-            }
-        }
+        public static ColorBlend BlackToWhite => new ColorBlend(new[] { Color.Black, Color.White }, new[] { 0.0, 1.0 });
 
         /// <summary>
         /// Gets a linear gradient scale from white to black
         /// </summary>
-        public static ColorBlend WhiteToBlack
-        {
-            get
-            {
-                return new ColorBlend(new[] { Color.White, Color.Black }, new[] { 0.0, 1.0 });
-            }
-        }
+        public static ColorBlend WhiteToBlack => new ColorBlend(new[] { Color.White, Color.Black }, new[] { 0.0, 1.0 });
 
         /// <summary>
         /// Gets a linear gradient scale from red to green
         /// </summary>
-        public static ColorBlend RedToGreen
-        {
-            get
-            {
-                return new ColorBlend(new[] { Color.Red, Color.Green }, new[] { 0.0, 1.0 });
-            }
-        }
+        public static ColorBlend RedToGreen => new ColorBlend(new[] { Color.Red, Color.Green }, new[] { 0.0, 1.0 });
 
         /// <summary>
         /// Gets a linear gradient scale from green to red
         /// </summary>
-        public static ColorBlend GreenToRed
-        {
-            get
-            {
-                return new ColorBlend(new[] { Color.Green, Color.Red }, new[] { 0.0, 1.0 });
-            }
-        }
+        public static ColorBlend GreenToRed => new ColorBlend(new[] { Color.Green, Color.Red }, new[] { 0.0, 1.0 });
 
         /// <summary>
         /// Gets a linear gradient scale from blue to green
         /// </summary>
-        public static ColorBlend BlueToGreen
-        {
-            get
-            {
-                return new ColorBlend(new[] { Color.Blue, Color.Green }, new[] { 0.0, 1.0 });
-            }
-        }
+        public static ColorBlend BlueToGreen => new ColorBlend(new[] { Color.Blue, Color.Green }, new[] { 0.0, 1.0 });
 
         /// <summary>
         /// Gets a linear gradient scale from green to blue
         /// </summary>
-        public static ColorBlend GreenToBlue
-        {
-            get
-            {
-                return new ColorBlend(new[] { Color.Green, Color.Blue }, new[] { 0.0, 1.0 });
-            }
-        }
+        public static ColorBlend GreenToBlue => new ColorBlend(new[] { Color.Green, Color.Blue }, new[] { 0.0, 1.0 });
 
         /// <summary>
         /// Gets a linear gradient scale from red to blue
         /// </summary>
-        public static ColorBlend RedToBlue
-        {
-            get
-            {
-                return new ColorBlend(new[] { Color.Red, Color.Blue }, new[] { 0.0, 1.0 });
-            }
-        }
+        public static ColorBlend RedToBlue => new ColorBlend(new[] { Color.Red, Color.Blue }, new[] { 0.0, 1.0 });
 
         /// <summary>
         /// Gets a linear gradient scale from blue to red
         /// </summary>
-        public static ColorBlend BlueToRed
-        {
-            get
-            {
-                return new ColorBlend(new[] { Color.Blue, Color.Red }, new[] { 0.0, 1.0 });
-            }
-        }
+        public static ColorBlend BlueToRed => new ColorBlend(new[] { Color.Blue, Color.Red }, new[] { 0.0, 1.0 });
 
 
 

--- a/Mapsui.sln
+++ b/Mapsui.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31825.309
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31624.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapsui", "Mapsui\Mapsui.csproj", "{D74C052A-C07E-4B37-A898-134218ACA5C9}"
 EndProject

--- a/Mapsui/Extensions/EventWaitHandleExtensions.cs
+++ b/Mapsui/Extensions/EventWaitHandleExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace Mapsui.Extensions
 {
-    static class EventWaitHandleExtensions
+    internal static class EventWaitHandleExtensions
     {
         public static void Stop(this EventWaitHandle waitHandle)
         {

--- a/Mapsui/Extensions/StreamExtensions.cs
+++ b/Mapsui/Extensions/StreamExtensions.cs
@@ -19,7 +19,7 @@ namespace Mapsui.Extensions
         /// <returns>true if is svg stream</returns>
         public static bool IsSvg(this Stream stream)
         {
-            byte[] buffer = new byte[5];
+            var buffer = new byte[5];
 
             stream.Position = 0;
             stream.Read(buffer, 0, 5);

--- a/Mapsui/Fetcher/FeatureFetchDispatcher.cs
+++ b/Mapsui/Fetcher/FeatureFetchDispatcher.cs
@@ -9,7 +9,7 @@ using Mapsui.Styles;
 
 namespace Mapsui.Fetcher
 {
-    class FeatureFetchDispatcher<T> : IFetchDispatcher where T : IFeature
+    internal class FeatureFetchDispatcher<T> : IFetchDispatcher where T : IFeature
     {
         private FetchInfo _fetchInfo;
         private bool _busy;

--- a/Mapsui/Fetcher/FeatureFetcher.cs
+++ b/Mapsui/Fetcher/FeatureFetcher.cs
@@ -1,12 +1,12 @@
-using Mapsui.Providers;
 using System.Collections.Generic;
 using System.Linq;
 using Mapsui.Layers;
+using Mapsui.Providers;
 using Mapsui.Styles;
 
 namespace Mapsui.Fetcher
 {
-    class FeatureFetcher
+    internal class FeatureFetcher
     {
         private readonly FetchInfo _fetchInfo;
         private readonly DataArrivedDelegate _dataArrived;

--- a/Mapsui/Fetcher/FetchMachine.cs
+++ b/Mapsui/Fetcher/FetchMachine.cs
@@ -2,13 +2,13 @@
 
 namespace Mapsui.Fetcher
 {
-    class FetchMachine
+    internal class FetchMachine
     {
         private readonly List<FetchWorker> _worker = new();
 
         public FetchMachine(IFetchDispatcher fetchDispatcher, int numberOfWorkers = 4)
         {
-            for (int i = 0; i < numberOfWorkers; i++)
+            for (var i = 0; i < numberOfWorkers; i++)
             {
                 _worker.Add(new FetchWorker(fetchDispatcher));
             }

--- a/Mapsui/Fetcher/FetchWorker.cs
+++ b/Mapsui/Fetcher/FetchWorker.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Mapsui.Fetcher
 {
-    class FetchWorker
+    internal class FetchWorker
     {
         private readonly IFetchDispatcher _fetchDispatcher;
         private CancellationTokenSource _fetchLoopCancellationTokenSource;

--- a/Mapsui/Fetcher/IFetchDispatcher.cs
+++ b/Mapsui/Fetcher/IFetchDispatcher.cs
@@ -4,7 +4,7 @@ using Mapsui.Layers;
 
 namespace Mapsui.Fetcher
 {
-    interface IFetchDispatcher
+    internal interface IFetchDispatcher
     {
         bool TryTake(ref Action method);
         void SetViewport(FetchInfo fetchInfo);

--- a/Mapsui/Fetcher/TileFetchDispatcher.cs
+++ b/Mapsui/Fetcher/TileFetchDispatcher.cs
@@ -11,7 +11,7 @@ using Mapsui.Providers;
 
 namespace Mapsui.Fetcher
 {
-    class TileFetchDispatcher : IFetchDispatcher, INotifyPropertyChanged
+    internal class TileFetchDispatcher : IFetchDispatcher, INotifyPropertyChanged
     {
         private FetchInfo _fetchInfo;
         private readonly object _lockRoot = new();
@@ -57,7 +57,7 @@ namespace Mapsui.Fetcher
             lock (_lockRoot)
             {
                 UpdateIfViewportIsModified();
-                var success = _tilesToFetch.TryDequeue(out TileInfo tileInfo);
+                var success = _tilesToFetch.TryDequeue(out var tileInfo);
 
                 if (success)
                 {

--- a/Mapsui/Layers/AnimatedFeatures.cs
+++ b/Mapsui/Layers/AnimatedFeatures.cs
@@ -1,10 +1,10 @@
-using System.Diagnostics;
-using Mapsui.Geometries;
-using Mapsui.Providers;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Mapsui.Geometries;
+using Mapsui.Providers;
 
 namespace Mapsui.Layers
 {

--- a/Mapsui/Layers/AnimatedPointLayer.cs
+++ b/Mapsui/Layers/AnimatedPointLayer.cs
@@ -1,8 +1,8 @@
-using Mapsui.Fetcher;
-using Mapsui.Providers;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Mapsui.Extensions;
+using Mapsui.Fetcher;
+using Mapsui.Providers;
 
 namespace Mapsui.Layers
 {

--- a/Mapsui/Layers/BaseLayer.cs
+++ b/Mapsui/Layers/BaseLayer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using Mapsui.Fetcher;
-using Mapsui.Providers;
 using Mapsui.Styles;
 using Mapsui.Widgets;
 

--- a/Mapsui/Layers/ImageLayer.cs
+++ b/Mapsui/Layers/ImageLayer.cs
@@ -15,8 +15,6 @@
 // along with SharpMap; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
 
-using Mapsui.Fetcher;
-using Mapsui.Providers;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -24,7 +22,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Mapsui.Extensions;
+using Mapsui.Fetcher;
 using Mapsui.Logging;
+using Mapsui.Providers;
 
 namespace Mapsui.Layers
 {
@@ -80,7 +80,7 @@ namespace Mapsui.Layers
             }
         }
 
-        void StartFetchTimerElapsed(object state)
+        private void StartFetchTimerElapsed(object state)
         {
             if (_fetchInfo.Extent == null) return;
             if (double.IsNaN(_fetchInfo.Resolution)) return;

--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -1,7 +1,6 @@
-using Mapsui.Providers;
 using System.Collections.Generic;
 using Mapsui.Extensions;
-using Mapsui.Fetcher;
+using Mapsui.Providers;
 using Mapsui.Styles;
 
 namespace Mapsui.Layers

--- a/Mapsui/Layers/RasterizingLayer.cs
+++ b/Mapsui/Layers/RasterizingLayer.cs
@@ -1,7 +1,7 @@
-using System.Linq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Mapsui.Extensions;
 using Mapsui.Fetcher;
 using Mapsui.Geometries;

--- a/Mapsui/Layers/TileLayer.cs
+++ b/Mapsui/Layers/TileLayer.cs
@@ -15,20 +15,20 @@
 // along with SharpMap; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
 
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
 using BruTile;
 using BruTile.Cache;
+using Mapsui.Extensions;
 using Mapsui.Fetcher;
 using Mapsui.Geometries;
 using Mapsui.Providers;
 using Mapsui.Rendering;
 using Mapsui.Styles;
 using Mapsui.Widgets;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO;
-using System.Linq;
-using Mapsui.Extensions;
 
 namespace Mapsui.Layers
 {
@@ -151,7 +151,7 @@ namespace Mapsui.Layers
 
         private Feature ToFeature(TileInfo tileInfo)
         {
-            byte[] tileData = _tileSource.GetTile(tileInfo);
+            var tileData = _tileSource.GetTile(tileInfo);
             return new Feature { Geometry = ToGeometry(tileInfo, tileData) };
         }
 

--- a/Mapsui/Layers/TmsTileSourceBuilder.cs
+++ b/Mapsui/Layers/TmsTileSourceBuilder.cs
@@ -1,8 +1,8 @@
-using BruTile;
-using BruTile.Tms;
 using System;
 using System.Net;
 using System.Threading;
+using BruTile;
+using BruTile.Tms;
 using Mapsui.Logging;
 
 namespace Mapsui.Layers

--- a/Mapsui/Projection/AxisOrderRegistry.cs
+++ b/Mapsui/Projection/AxisOrderRegistry.cs
@@ -250,7 +250,7 @@ namespace Mapsui.Projection
                         return res;
 
                     case "EPSG":
-                        var code = Int32.Parse(identifier);
+                        var code = int.Parse(identifier);
                         if (code == 900913) code = 3857;
                         if (code < 0)
                             throw new ArgumentException("Invalid Epsg identifier");

--- a/Mapsui/Projection/GeometryTransformation.cs
+++ b/Mapsui/Projection/GeometryTransformation.cs
@@ -1,6 +1,6 @@
-using Mapsui.Geometries;
 using System;
 using System.Collections.Generic;
+using Mapsui.Geometries;
 
 namespace Mapsui.Projection
 {

--- a/Mapsui/Projection/Mercator.cs
+++ b/Mapsui/Projection/Mercator.cs
@@ -30,8 +30,8 @@ namespace Mapsui.Projection
 
         public static Point ToLonLat(double x, double y)
         {
-            double g = HalfPi - 2 * Math.Atan(1 / Math.Exp(y / Radius));
-            double latRadians = g + C1 * Math.Sin(2 * g) + C2 * Math.Sin(4 * g) + C3 * Math.Sin(6 * g) + C4 * Math.Sin(8 * g);
+            var g = HalfPi - 2 * Math.Atan(1 / Math.Exp(y / Radius));
+            var latRadians = g + C1 * Math.Sin(2 * g) + C2 * Math.Sin(4 * g) + C3 * Math.Sin(6 * g) + C4 * Math.Sin(8 * g);
 
             var lonRadians = x / Radius;
 

--- a/Mapsui/Providers/ArcGIS/CapabilitiesHelper.cs
+++ b/Mapsui/Providers/ArcGIS/CapabilitiesHelper.cs
@@ -50,8 +50,8 @@ namespace Mapsui.Providers.ArcGIS
         /// </summary>
         public int TimeOut
         {
-            get { return _timeOut; }
-            set { _timeOut = value; }
+            get => _timeOut;
+            set => _timeOut = value;
         }
 
         /// <summary>

--- a/Mapsui/Providers/ArcGIS/Dynamic/ArcGISDynamicProvider.cs
+++ b/Mapsui/Providers/ArcGIS/Dynamic/ArcGISDynamicProvider.cs
@@ -66,7 +66,7 @@ namespace Mapsui.Providers.ArcGIS.Dynamic
 
         public string Url
         {
-            get { return _url; }
+            get => _url;
             set
             {
                 _url = value;
@@ -80,14 +80,14 @@ namespace Mapsui.Providers.ArcGIS.Dynamic
         /// </summary>
         public int TimeOut
         {
-            get { return _timeOut; }
-            set { _timeOut = value; }
+            get => _timeOut;
+            set => _timeOut = value;
         }
 
         public string CRS
         {
-            get { return _crs; }
-            set { _crs = value; }
+            get => _crs;
+            set => _crs = value;
         }
 
         public IEnumerable<IFeature> GetFeatures(FetchInfo fetchInfo)

--- a/Mapsui/Providers/ArcGIS/Dynamic/ArcGISIdentify.cs
+++ b/Mapsui/Providers/ArcGIS/Dynamic/ArcGISIdentify.cs
@@ -32,8 +32,8 @@ namespace Mapsui.Providers.ArcGIS.Dynamic
         /// </summary>
         public int TimeOut
         {
-            get { return _timeOut; }
-            set { _timeOut = value; }
+            get => _timeOut;
+            set => _timeOut = value;
         }
 
         /// <summary>

--- a/Mapsui/Providers/ArcGIS/Dynamic/ArcGISLegend.cs
+++ b/Mapsui/Providers/ArcGIS/Dynamic/ArcGISLegend.cs
@@ -33,8 +33,8 @@ namespace Mapsui.Providers.ArcGIS.Dynamic
         /// </summary>
         public int TimeOut
         {
-            get { return _timeOut; }
-            set { _timeOut = value; }
+            get => _timeOut;
+            set => _timeOut = value;
         }
 
         /// <summary>

--- a/Mapsui/Providers/ArcGIS/Image/ArcGISImageServiceProvider.cs
+++ b/Mapsui/Providers/ArcGIS/Image/ArcGISImageServiceProvider.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using Mapsui.Extensions;
-using Mapsui.Fetcher;
 using Mapsui.Geometries;
 using Mapsui.Layers;
 using Mapsui.Logging;
@@ -55,7 +54,7 @@ namespace Mapsui.Providers.ArcGIS.Image
 
         public string Url
         {
-            get { return _url; }
+            get => _url;
             set
             {
                 _url = value;
@@ -92,8 +91,8 @@ namespace Mapsui.Providers.ArcGIS.Image
         /// </summary>
         public int TimeOut
         {
-            get { return _timeOut; }
-            set { _timeOut = value; }
+            get => _timeOut;
+            set => _timeOut = value;
         }
 
         public IEnumerable<IFeature> GetFeatures(FetchInfo fetchInfo)

--- a/Mapsui/Providers/ArcGIS/Image/TimeInfo.cs
+++ b/Mapsui/Providers/ArcGIS/Image/TimeInfo.cs
@@ -9,21 +9,9 @@ namespace Mapsui.Providers.ArcGIS.Image
         public long[]? timeExtent { get; set; }
         public TimeReference? timeReference { get; set; }
 
-        public DateTime? StartDate
-        {
-            get
-            {
-                return timeExtent.Length == 2 ? ConvertUnixTimeStamp(timeExtent[0]) : ConvertUnixTimeStamp(0);
-            }
-        }
+        public DateTime? StartDate => timeExtent.Length == 2 ? ConvertUnixTimeStamp(timeExtent[0]) : ConvertUnixTimeStamp(0);
 
-        public DateTime? EndDate
-        {
-            get
-            {
-                return timeExtent.Length == 2 ? ConvertUnixTimeStamp(timeExtent[1]) : ConvertUnixTimeStamp(0);
-            }
-        }
+        public DateTime? EndDate => timeExtent.Length == 2 ? ConvertUnixTimeStamp(timeExtent[1]) : ConvertUnixTimeStamp(0);
 
         public static DateTime? ConvertUnixTimeStamp(long unixTimeStamp)
         {

--- a/Mapsui/Providers/GeoTiffProvider.cs
+++ b/Mapsui/Providers/GeoTiffProvider.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Mapsui.Extensions;
-using Mapsui.Fetcher;
 using Mapsui.Geometries;
 using Mapsui.Layers;
 using Mapsui.Styles;
@@ -217,7 +216,7 @@ namespace Mapsui.Providers
 
         public bool? IsCrsSupported(string crs)
         {
-            return String.Equals(crs.Trim(), CRS.Trim(), StringComparison.CurrentCultureIgnoreCase);
+            return string.Equals(crs.Trim(), CRS.Trim(), StringComparison.CurrentCultureIgnoreCase);
         }
     }
 }

--- a/Mapsui/Providers/IProvider.cs
+++ b/Mapsui/Providers/IProvider.cs
@@ -15,9 +15,8 @@
 // along with SharpMap; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
 
-using Mapsui.Geometries;
 using System.Collections.Generic;
-using Mapsui.Fetcher;
+using Mapsui.Geometries;
 using Mapsui.Layers;
 
 namespace Mapsui.Providers

--- a/Mapsui/Providers/MemoryProvider.cs
+++ b/Mapsui/Providers/MemoryProvider.cs
@@ -15,10 +15,10 @@
 // along with SharpMap; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
 
-using Mapsui.Geometries;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Mapsui.Geometries;
 using Mapsui.Geometries.WellKnownBinary;
 using Mapsui.Geometries.WellKnownText;
 using Mapsui.Layers;
@@ -61,7 +61,7 @@ namespace Mapsui.Providers
         /// </summary>
         public string CRS { get; set; } = "";
 
-        BoundingBox _boundingBox;
+        private readonly BoundingBox _boundingBox;
 
         public MemoryProvider()
         {

--- a/Mapsui/Providers/Shapefile/DbaseReader.cs
+++ b/Mapsui/Providers/Shapefile/DbaseReader.cs
@@ -95,7 +95,7 @@ namespace Mapsui.Providers.Shapefile
         /// <typeparam name="T">datatype to be indexed</typeparam>
         /// <param name="columnId">Column to index</param>
         /// <returns></returns>
-        public BinaryTree<T, UInt32> CreateDbfIndex<T>(int columnId) where T : IComparable<T>
+        public BinaryTree<T, uint> CreateDbfIndex<T>(int columnId) where T : IComparable<T>
         {
             var tree = new BinaryTree<T, uint>();
             for (uint i = 0; i < ((_numberOfRecords > 10000) ? 10000 : _numberOfRecords); i++)
@@ -159,15 +159,15 @@ namespace Mapsui.Providers.Shapefile
             _fileEncoding = GetDbaseLanguageDriver(_br.ReadByte()); //Read and parse Language driver
             _fs.Seek(32, SeekOrigin.Begin); //Move past the reserved bytes
 
-            int numberOfColumns = (_headerLength - 31) / 32; // calculate the number of DataColumns in the header
+            var numberOfColumns = (_headerLength - 31) / 32; // calculate the number of DataColumns in the header
             _dbaseColumns = new DbaseField[numberOfColumns];
-            for (int i = 0; i < _dbaseColumns.Length; i++)
+            for (var i = 0; i < _dbaseColumns.Length; i++)
             {
                 _dbaseColumns[i] = new DbaseField
                 {
                     ColumnName = Encoding.UTF7.GetString((_br.ReadBytes(11))).Replace("\0", "").Trim()
                 };
-                char fieldtype = _br.ReadChar();
+                var fieldtype = _br.ReadChar();
                 switch (fieldtype)
                 {
                     case 'L':
@@ -201,11 +201,11 @@ namespace Mapsui.Providers.Shapefile
                 //If the double-type doesn't have any decimals, make the type an integer
                 if (_dbaseColumns[i].Decimals == 0 && _dbaseColumns[i].DataType == typeof(double))
                     if (_dbaseColumns[i].Length <= 2)
-                        _dbaseColumns[i].DataType = typeof(Int16);
+                        _dbaseColumns[i].DataType = typeof(short);
                     else if (_dbaseColumns[i].Length <= 4)
-                        _dbaseColumns[i].DataType = typeof(Int32);
+                        _dbaseColumns[i].DataType = typeof(int);
                     else
-                        _dbaseColumns[i].DataType = typeof(Int64);
+                        _dbaseColumns[i].DataType = typeof(long);
                 _fs.Seek(_fs.Position + 14, 0);
             }
             _headerIsParsed = true;
@@ -363,11 +363,11 @@ namespace Mapsui.Providers.Shapefile
         {
             var tab = new DataTable();
             // all of common, non "base-table" fields implemented
-            tab.Columns.Add("ColumnName", typeof(String));
-            tab.Columns.Add("ColumnSize", typeof(Int32));
-            tab.Columns.Add("ColumnOrdinal", typeof(Int32));
-            tab.Columns.Add("NumericPrecision", typeof(Int16));
-            tab.Columns.Add("NumericScale", typeof(Int16));
+            tab.Columns.Add("ColumnName", typeof(string));
+            tab.Columns.Add("ColumnSize", typeof(int));
+            tab.Columns.Add("ColumnOrdinal", typeof(int));
+            tab.Columns.Add("NumericPrecision", typeof(short));
+            tab.Columns.Add("NumericScale", typeof(short));
             tab.Columns.Add("DataType", typeof(Type));
             tab.Columns.Add("AllowDBNull", typeof(bool));
             tab.Columns.Add("IsReadOnly", typeof(bool));
@@ -377,12 +377,12 @@ namespace Mapsui.Providers.Shapefile
             tab.Columns.Add("IsAutoIncrement", typeof(bool));
             tab.Columns.Add("IsLong", typeof(bool));
 
-            foreach (DbaseField dbf in _dbaseColumns)
+            foreach (var dbf in _dbaseColumns)
                 tab.Columns.Add(dbf.ColumnName, dbf.DataType);
 
-            for (int i = 0; i < _dbaseColumns.Length; i++)
+            for (var i = 0; i < _dbaseColumns.Length; i++)
             {
-                DataRow r = tab.NewRow();
+                var r = tab.NewRow();
                 r["ColumnName"] = _dbaseColumns[i].ColumnName;
                 r["ColumnSize"] = _dbaseColumns[i].Length;
                 r["ColumnOrdinal"] = i;
@@ -416,7 +416,7 @@ namespace Mapsui.Providers.Shapefile
                 throw ((new ArgumentException("Column index out of range")));
 
             _fs.Seek(_headerLength + oid * _recordLength, 0);
-            for (int i = 0; i < colid; i++)
+            for (var i = 0; i < colid; i++)
                 _br.BaseStream.Seek(_dbaseColumns[i].Length, SeekOrigin.Current);
 
             return ReadDbfValue(_dbaseColumns[colid]);
@@ -470,32 +470,32 @@ namespace Mapsui.Providers.Shapefile
                         return _fileEncoding.GetString(_br.ReadBytes(dbf.Length)).Replace("\0", "").Trim();
                     return _encoding.GetString(_br.ReadBytes(dbf.Length)).Replace("\0", "").Trim();
                 case "System.Double":
-                    string temp = Encoding.UTF7.GetString(_br.ReadBytes(dbf.Length)).Replace("\0", "").Trim();
+                    var temp = Encoding.UTF7.GetString(_br.ReadBytes(dbf.Length)).Replace("\0", "").Trim();
                     if (double.TryParse(temp, NumberStyles.Float, CultureInfo.InvariantCulture, out var dbl))
                         return dbl;
                     return DBNull.Value;
                 case "System.Int16":
-                    string temp16 = Encoding.UTF7.GetString((_br.ReadBytes(dbf.Length))).Replace("\0", "").Trim();
+                    var temp16 = Encoding.UTF7.GetString((_br.ReadBytes(dbf.Length))).Replace("\0", "").Trim();
                     if (short.TryParse(temp16, NumberStyles.Float, CultureInfo.InvariantCulture, out var i16))
                         return i16;
                     return DBNull.Value;
                 case "System.Int32":
-                    string temp32 = Encoding.UTF7.GetString((_br.ReadBytes(dbf.Length))).Replace("\0", "").Trim();
+                    var temp32 = Encoding.UTF7.GetString((_br.ReadBytes(dbf.Length))).Replace("\0", "").Trim();
                     if (int.TryParse(temp32, NumberStyles.Float, CultureInfo.InvariantCulture, out var i32))
                         return i32;
                     return DBNull.Value;
                 case "System.Int64":
-                    string temp64 = Encoding.UTF7.GetString((_br.ReadBytes(dbf.Length))).Replace("\0", "").Trim();
+                    var temp64 = Encoding.UTF7.GetString((_br.ReadBytes(dbf.Length))).Replace("\0", "").Trim();
                     if (long.TryParse(temp64, NumberStyles.Float, CultureInfo.InvariantCulture, out var i64))
                         return i64;
                     return DBNull.Value;
                 case "System.Single":
-                    string temp4 = Encoding.UTF8.GetString((_br.ReadBytes(dbf.Length)));
+                    var temp4 = Encoding.UTF8.GetString((_br.ReadBytes(dbf.Length)));
                     if (float.TryParse(temp4, NumberStyles.Float, CultureInfo.InvariantCulture, out var f))
                         return f;
                     return DBNull.Value;
                 case "System.Boolean":
-                    char tempChar = _br.ReadChar();
+                    var tempChar = _br.ReadChar();
                     return (tempChar == 'T') || (tempChar == 't') || (tempChar == 'Y') || (tempChar == 'y');
                 case "System.DateTime":
                     // Mono has not yet implemented DateTime.TryParseExact

--- a/Mapsui/Providers/Shapefile/Indexing/BinaryTree.cs
+++ b/Mapsui/Providers/Shapefile/Indexing/BinaryTree.cs
@@ -53,13 +53,13 @@ namespace Mapsui.Providers.Shapefile.Indexing
 
         public static bool operator >(Node<T, TU> lhs, Node<T, TU> rhs)
         {
-            int res = lhs.Item.Value.CompareTo(rhs.Item.Value);
+            var res = lhs.Item.Value.CompareTo(rhs.Item.Value);
             return res > 0;
         }
 
         public static bool operator <(Node<T, TU> lhs, Node<T, TU> rhs)
         {
-            int res = lhs.Item.Value.CompareTo(rhs.Item.Value);
+            var res = lhs.Item.Value.CompareTo(rhs.Item.Value);
             return res < 0;
         }
     }
@@ -191,7 +191,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
                 if (root.LeftNode != null)
                 {
                     if (root.LeftNode.Item.Value.CompareTo(value) > 0)
-                        foreach (ItemValue item in ScanFind(value, root.LeftNode))
+                        foreach (var item in ScanFind(value, root.LeftNode))
                         {
                             yield return item;
                         }
@@ -206,7 +206,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
                 if (root.RightNode != null)
                 {
                     if (root.RightNode.Item.Value.CompareTo(value) > 0)
-                        foreach (ItemValue item in ScanFind(value, root.RightNode))
+                        foreach (var item in ScanFind(value, root.RightNode))
                         {
                             yield return item;
                         }
@@ -237,7 +237,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
                 if (root.RightNode != null)
                 {
                     if (string.Compare(root.RightNode.Item.Value.ToString().Substring(0, val.Length).ToUpper(), val, StringComparison.Ordinal) > 0)
-                        foreach (ItemValue item in ScanString(val, root.RightNode))
+                        foreach (var item in ScanString(val, root.RightNode))
                         {
                             yield return item;
                         }
@@ -252,7 +252,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
                 if (root.LeftNode != null)
                 {
                     if (root.LeftNode.Item.Value.CompareTo(min) > 0)
-                        foreach (ItemValue item in ScanBetween(min, max, root.LeftNode))
+                        foreach (var item in ScanBetween(min, max, root.LeftNode))
                         {
                             yield return item;
                         }
@@ -267,7 +267,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
                 if (root.RightNode != null)
                 {
                     if (root.RightNode.Item.Value.CompareTo(min) > 0)
-                        foreach (ItemValue item in ScanBetween(min, max, root.RightNode))
+                        foreach (var item in ScanBetween(min, max, root.RightNode))
                         {
                             yield return item;
                         }
@@ -279,7 +279,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
         {
             if (root.LeftNode != null)
             {
-                foreach (ItemValue item in ScanInOrder(root.LeftNode))
+                foreach (var item in ScanInOrder(root.LeftNode))
                 {
                     yield return item;
                 }
@@ -289,7 +289,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
 
             if (root.RightNode != null)
             {
-                foreach (ItemValue item in ScanInOrder(root.RightNode))
+                foreach (var item in ScanInOrder(root.RightNode))
                 {
                     yield return item;
                 }

--- a/Mapsui/Providers/Shapefile/Indexing/SpatialIndexing.cs
+++ b/Mapsui/Providers/Shapefile/Indexing/SpatialIndexing.cs
@@ -78,27 +78,27 @@ namespace Mapsui.Providers.Shapefile.Indexing
             _depth = depth;
 
             _box = objList[0].Box;
-            for (int i = 0; i < objList.Count; i++)
+            for (var i = 0; i < objList.Count; i++)
                 _box = _box.Join(objList[i].Box);
 
             // test our build heuristic - if passes, make children
             if (depth < heurdata.Maxdepth && objList.Count > heurdata.Mintricnt &&
                 (objList.Count > heurdata.Tartricnt || ErrorMetric(_box) > heurdata.Minerror))
             {
-                List<BoxObjects>[] objBuckets = new List<BoxObjects>[2]; // buckets of geometries
+                var objBuckets = new List<BoxObjects>[2]; // buckets of geometries
                 objBuckets[0] = new List<BoxObjects>();
                 objBuckets[1] = new List<BoxObjects>();
 
-                uint longAxis = _box.LongestAxis; // longest axis
+                var longAxis = _box.LongestAxis; // longest axis
                 double geoAverage = 0; // geometric average - midpoint of ALL the objects
 
                 // go through all bbox and calculate the average of the midpoints
                 double fraction = 1.0f / objList.Count;
-                for (int i = 0; i < objList.Count; i++)
+                for (var i = 0; i < objList.Count; i++)
                     geoAverage += objList[i].Box.Centroid[longAxis] * fraction;
 
                 // bucket bbox based on their midpoint's side of the geo average in the longest axis
-                for (int i = 0; i < objList.Count; i++)
+                for (var i = 0; i < objList.Count; i++)
                     objBuckets[geoAverage > objList[i].Box.Centroid[longAxis] ? 1 : 0].Add(objList[i]);
 
                 //If objects couldn't be split, just store them at the leaf
@@ -169,7 +169,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
         /// <returns></returns>
         private static QuadTree ReadNode(uint depth, ref BinaryReader br)
         {
-            QuadTree node = new QuadTree
+            var node = new QuadTree
             {
                 _depth = depth,
                 Box = new BoundingBox(br.ReadDouble(), br.ReadDouble(), br.ReadDouble(), br.ReadDouble())
@@ -177,11 +177,11 @@ namespace Mapsui.Providers.Shapefile.Indexing
             var isLeaf = br.ReadBoolean();
             if (isLeaf)
             {
-                int featureCount = br.ReadInt32();
+                var featureCount = br.ReadInt32();
                 node._objList = new List<BoxObjects>();
-                for (int i = 0; i < featureCount; i++)
+                for (var i = 0; i < featureCount; i++)
                 {
-                    BoxObjects box = new BoxObjects
+                    var box = new BoxObjects
                     {
                         Box = new BoundingBox(
                             br.ReadDouble(), br.ReadDouble(),
@@ -205,8 +205,8 @@ namespace Mapsui.Providers.Shapefile.Indexing
         /// <param name="filename"></param>
         public void SaveIndex(string filename)
         {
-            FileStream fs = new FileStream(filename, FileMode.Create);
-            BinaryWriter bw = new BinaryWriter(fs);
+            var fs = new FileStream(filename, FileMode.Create);
+            var bw = new BinaryWriter(fs);
             bw.Write(Indexfileversion); //Save index version
             SaveNode(this, ref bw);
             bw.Close();
@@ -229,7 +229,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
             if (node.IsLeaf)
             {
                 sw.Write(node._objList.Count); //Write number of features at node
-                for (int i = 0; i < node._objList.Count; i++) //Write each feature box
+                for (var i = 0; i < node._objList.Count; i++) //Write each feature box
                 {
                     sw.Write(node._objList[i].Box.Min.X);
                     sw.Write(node._objList[i].Box.Min.Y);
@@ -313,7 +313,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
         /// <returns></returns>
         public double ErrorMetric(BoundingBox box)
         {
-            Point temp = new Point(1, 1) + (box.Max - box.Min);
+            var temp = new Point(1, 1) + (box.Max - box.Min);
             return temp.X * temp.Y;
         }
 
@@ -323,7 +323,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
         /// <param name="box">BoundingBox to intersect with</param>
         public Collection<uint> Search(BoundingBox box)
         {
-            Collection<uint> objectlist = new Collection<uint>();
+            var objectlist = new Collection<uint>();
             IntersectTreeRecursive(box, this, ref objectlist);
             return objectlist;
         }
@@ -338,7 +338,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
         {
             if (node.IsLeaf) //Leaf has been reached
             {
-                foreach (BoxObjects boxObject in node._objList)
+                foreach (var boxObject in node._objList)
                 {
                     if (box.Intersects(boxObject.Box))
                         list.Add(boxObject.Id);

--- a/Mapsui/Providers/Shapefile/ShapeFile.cs
+++ b/Mapsui/Providers/Shapefile/ShapeFile.cs
@@ -184,7 +184,7 @@ namespace Mapsui.Providers.Shapefile
             _fileBasedIndex = (fileBasedIndex) && File.Exists(Path.ChangeExtension(filename, ".shx"));
 
             //Initialize DBF
-            string dbfFile = Path.ChangeExtension(filename, ".dbf");
+            var dbfFile = Path.ChangeExtension(filename, ".dbf");
             if (File.Exists(dbfFile))
                 _dbaseFile = new DbaseReader(dbfFile);
             //Parse shape header
@@ -366,13 +366,13 @@ namespace Mapsui.Providers.Shapefile
                 try
                 {
                     //Use the spatial index to get a list of features whose BoundingBox intersects bbox
-                    Collection<uint> objectList = GetObjectIDsInViewPrivate(bbox);
+                    var objectList = GetObjectIDsInViewPrivate(bbox);
                     if (objectList.Count == 0) //no features found. Return an empty set
                         return new Collection<IGeometry>();
 
                     var geometries = new Collection<IGeometry>();
 
-                    for (int i = 0; i < objectList.Count; i++)
+                    for (var i = 0; i < objectList.Count; i++)
                     {
                         var g = GetGeometryPrivate(objectList[i]);
                         if (g != null) geometries.Add(g);
@@ -445,7 +445,7 @@ namespace Mapsui.Providers.Shapefile
         {
             if (FilterDelegate != null) //Apply filtering
             {
-                IGeometryFeature fdr = GetFeature(oid);
+                var fdr = GetFeature(oid);
                 return fdr?.Geometry;
             }
 
@@ -515,7 +515,7 @@ namespace Mapsui.Providers.Shapefile
                 throw (new ApplicationException("Invalid Shapefile Index (.shx)"));
 
             _brShapeIndex.BaseStream.Seek(24, 0); //seek to File Length
-            int indexFileSize = SwapByteOrder(_brShapeIndex.ReadInt32());
+            var indexFileSize = SwapByteOrder(_brShapeIndex.ReadInt32());
             //Read file length as big-endian. The length is based on 16bit words
             _featureCount = (2 * indexFileSize - 100) / 8;
             //Calculate FeatureCount. Each feature takes up 8 bytes. The header is 100 bytes
@@ -537,7 +537,7 @@ namespace Mapsui.Providers.Shapefile
         /// </summary>
         private void ParseProjection()
         {
-            string projFile = Path.GetDirectoryName(Filename) + "\\" + Path.GetFileNameWithoutExtension(Filename) +
+            var projFile = Path.GetDirectoryName(Filename) + "\\" + Path.GetFileNameWithoutExtension(Filename) +
                               ".prj";
             if (File.Exists(projFile))
             {
@@ -565,7 +565,7 @@ namespace Mapsui.Providers.Shapefile
             var offsetOfRecord = new int[_featureCount];
             _brShapeIndex.BaseStream.Seek(100, 0); //skip the header
 
-            for (int x = 0; x < _featureCount; ++x)
+            for (var x = 0; x < _featureCount; ++x)
             {
                 offsetOfRecord[x] = 2 * SwapByteOrder(_brShapeIndex.ReadInt32()); //Read shape data position // ibuffer);
                 _brShapeIndex.BaseStream.Seek(_brShapeIndex.BaseStream.Position + 4, 0); //Skip content length
@@ -591,7 +591,7 @@ namespace Mapsui.Providers.Shapefile
         /// <returns>Byte Order swapped int32</returns>
         private int SwapByteOrder(int i)
         {
-            byte[] buffer = BitConverter.GetBytes(i);
+            var buffer = BitConverter.GetBytes(i);
             Array.Reverse(buffer, 0, buffer.Length);
             return BitConverter.ToInt32(buffer, 0);
         }
@@ -616,7 +616,7 @@ namespace Mapsui.Providers.Shapefile
                 }
             }
 
-            QuadTree tree = CreateSpatialIndex();
+            var tree = CreateSpatialIndex();
             tree.SaveIndex(filename + ".sidx");
             return tree;
         }
@@ -684,24 +684,24 @@ namespace Mapsui.Providers.Shapefile
         /// <returns></returns>
         private IEnumerable<BoundingBox> GetAllFeatureBoundingBoxes()
         {
-            int[] offsetOfRecord = ReadIndex(); //Read the whole .idx file
+            var offsetOfRecord = ReadIndex(); //Read the whole .idx file
 
             if (_shapeType == ShapeType.Point)
             {
-                for (int a = 0; a < _featureCount; ++a)
+                for (var a = 0; a < _featureCount; ++a)
                 {
                     _fsShapeFile.Seek(offsetOfRecord[a] + 8, 0); //skip record number and content length
                     if ((ShapeType)_brShapeFile.ReadInt32() != ShapeType.Null)
                     {
-                        double x = _brShapeFile.ReadDouble();
-                        double y = _brShapeFile.ReadDouble();
+                        var x = _brShapeFile.ReadDouble();
+                        var y = _brShapeFile.ReadDouble();
                         yield return new BoundingBox(x, y, x, y);
                     }
                 }
             }
             else
             {
-                for (int a = 0; a < _featureCount; ++a)
+                for (var a = 0; a < _featureCount; ++a)
                 {
                     _fsShapeFile.Seek(offsetOfRecord[a] + 8, 0); //skip record number and content length
                     if ((ShapeType)_brShapeFile.ReadInt32() != ShapeType.Null)
@@ -733,10 +733,10 @@ namespace Mapsui.Providers.Shapefile
             {
                 _brShapeFile.BaseStream.Seek(32 + _brShapeFile.BaseStream.Position, 0); //skip min/max box
                 var feature = new MultiPoint();
-                int nPoints = _brShapeFile.ReadInt32(); // get the number of points
+                var nPoints = _brShapeFile.ReadInt32(); // get the number of points
                 if (nPoints == 0)
                     return null;
-                for (int i = 0; i < nPoints; i++)
+                for (var i = 0; i < nPoints; i++)
                     feature.Points.Add(new Point(_brShapeFile.ReadDouble(), _brShapeFile.ReadDouble()));
 
                 return feature;
@@ -747,14 +747,14 @@ namespace Mapsui.Providers.Shapefile
             {
                 _brShapeFile.BaseStream.Seek(32 + _brShapeFile.BaseStream.Position, 0); //skip min/max box
 
-                int nParts = _brShapeFile.ReadInt32(); // get number of parts (segments)
+                var nParts = _brShapeFile.ReadInt32(); // get number of parts (segments)
                 if (nParts == 0)
                     return null;
-                int nPoints = _brShapeFile.ReadInt32(); // get number of points
+                var nPoints = _brShapeFile.ReadInt32(); // get number of points
 
                 var segments = new int[nParts + 1];
                 //Read in the segment indexes
-                for (int b = 0; b < nParts; b++)
+                for (var b = 0; b < nParts; b++)
                     segments[b] = _brShapeFile.ReadInt32();
                 //add end point
                 segments[nParts] = nPoints;
@@ -762,10 +762,10 @@ namespace Mapsui.Providers.Shapefile
                 if ((int)_shapeType % 10 == 3)
                 {
                     var multiLineString = new MultiLineString();
-                    for (int lineId = 0; lineId < nParts; lineId++)
+                    for (var lineId = 0; lineId < nParts; lineId++)
                     {
                         var line = new LineString();
-                        for (int i = segments[lineId]; i < segments[lineId + 1]; i++)
+                        for (var i = segments[lineId]; i < segments[lineId + 1]; i++)
                             line.Vertices.Add(new Point(_brShapeFile.ReadDouble(), _brShapeFile.ReadDouble()));
                         multiLineString.LineStrings.Add(line);
                     }
@@ -777,16 +777,16 @@ namespace Mapsui.Providers.Shapefile
                 {
                     // First read all the rings
                     var rings = new List<LinearRing>();
-                    for (int ringId = 0; ringId < nParts; ringId++)
+                    for (var ringId = 0; ringId < nParts; ringId++)
                     {
                         var ring = new LinearRing();
-                        for (int i = segments[ringId]; i < segments[ringId + 1]; i++)
+                        for (var i = segments[ringId]; i < segments[ringId + 1]; i++)
                             ring.Vertices.Add(new Point(_brShapeFile.ReadDouble(), _brShapeFile.ReadDouble()));
                         rings.Add(ring);
                     }
                     var isCounterClockWise = new bool[rings.Count];
-                    int polygonCount = 0;
-                    for (int i = 0; i < rings.Count; i++)
+                    var polygonCount = 0;
+                    for (var i = 0; i < rings.Count; i++)
                     {
                         isCounterClockWise[i] = rings[i].IsCCW();
                         if (!isCounterClockWise[i])
@@ -796,7 +796,7 @@ namespace Mapsui.Providers.Shapefile
                     {
                         var poly = new Polygon { ExteriorRing = rings[0] };
                         if (rings.Count > 1)
-                            for (int i = 1; i < rings.Count; i++)
+                            for (var i = 1; i < rings.Count; i++)
                                 poly.InteriorRings.Add(rings[i]);
                         return poly;
                     }

--- a/Mapsui/Providers/StackedLabelProvider.cs
+++ b/Mapsui/Providers/StackedLabelProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Mapsui.Fetcher;
 using Mapsui.Geometries;
 using Mapsui.Layers;
 using Mapsui.Styles;

--- a/Mapsui/Providers/TileProvider.cs
+++ b/Mapsui/Providers/TileProvider.cs
@@ -17,15 +17,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using BruTile;
 using BruTile.Cache;
-using Mapsui.Geometries;
-using System.IO;
-using System.Threading.Tasks;
 using Mapsui.Extensions;
-using Mapsui.Fetcher;
+using Mapsui.Geometries;
 using Mapsui.Layers;
 using Mapsui.Logging;
 
@@ -33,9 +32,9 @@ namespace Mapsui.Providers
 {
     public class TileProvider : IProvider<IFeature>
     {
-        readonly ITileSource _source;
-        readonly MemoryCache<byte[]> _bitmaps = new(100, 200);
-        readonly List<TileIndex> _queue = new();
+        private readonly ITileSource _source;
+        private readonly MemoryCache<byte[]> _bitmaps = new(100, 200);
+        private readonly List<TileIndex> _queue = new();
 
         public BoundingBox GetExtent()
         {
@@ -58,7 +57,7 @@ namespace Mapsui.Providers
 
             ICollection<WaitHandle> waitHandles = new List<WaitHandle>();
 
-            foreach (TileInfo info in infos)
+            foreach (var info in infos)
             {
                 if (_bitmaps.Find(info.Index) != null) continue;
                 if (_queue.Contains(info.Index)) continue;
@@ -71,9 +70,9 @@ namespace Mapsui.Providers
             WaitHandle.WaitAll(waitHandles.ToArray());
 
             var features = new Features();
-            foreach (TileInfo info in infos)
+            foreach (var info in infos)
             {
-                byte[] bitmap = _bitmaps.Find(info.Index);
+                var bitmap = _bitmaps.Find(info.Index);
                 if (bitmap == null) continue;
                 IRaster raster = new Raster(new MemoryStream(bitmap), new BoundingBox(info.Extent.MinX, info.Extent.MinY, info.Extent.MaxX, info.Extent.MaxY));
                 var feature = new Feature

--- a/Mapsui/Providers/TransformingProvider.cs
+++ b/Mapsui/Providers/TransformingProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Mapsui.Extensions;
-using Mapsui.Fetcher;
 using Mapsui.Geometries;
 using Mapsui.Layers;
 using Mapsui.Projection;

--- a/Mapsui/Providers/Wfs/Utilities/FeatureTypeInfo.cs
+++ b/Mapsui/Providers/Wfs/Utilities/FeatureTypeInfo.cs
@@ -40,10 +40,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <summary>
         /// Gets the elements associated to the feature.
         /// </summary>
-        public List<ElementInfo> Elements
-        {
-            get { return _elements; }
-        }
+        public List<ElementInfo> Elements => _elements;
 
         /// <summary>
         /// Gets or sets the name of the featuretype.
@@ -52,8 +49,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <value>The name.</value>
         public string Name
         {
-            get { return _name; }
-            set { _name = value; }
+            get => _name;
+            set => _name = value;
         }
 
         /// <summary>
@@ -64,8 +61,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <value>The prefix.</value>
         public string Prefix
         {
-            get { return _prefix; }
-            set { _prefix = value; }
+            get => _prefix;
+            set => _prefix = value;
         }
 
         /// <summary>
@@ -74,17 +71,14 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public string FeatureTypeNamespace
         {
-            get { return _featureTypeNamespace; }
-            set { _featureTypeNamespace = value; }
+            get => _featureTypeNamespace;
+            set => _featureTypeNamespace = value;
         }
 
         /// <summary>
         /// Gets the qualified name of the featuretype (with namespace URI).
         /// </summary>
-        internal string QualifiedName
-        {
-            get { return _featureTypeNamespace + _name; }
-        }
+        internal string QualifiedName => _featureTypeNamespace + _name;
 
         /// <summary>
         /// Gets or sets the service URI for WFS 'GetFeature' request.
@@ -92,8 +86,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public string ServiceUri
         {
-            get { return _serviceUri; }
-            set { _serviceUri = value; }
+            get => _serviceUri;
+            set => _serviceUri = value;
         }
 
         /// <summary>
@@ -102,8 +96,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public GeometryInfo Geometry
         {
-            get { return _geometry; }
-            set { _geometry = value; }
+            get => _geometry;
+            set => _geometry = value;
         }
 
         /// <summary>
@@ -111,8 +105,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public BoundingBox BBox
         {
-            get { return _boundingBox; }
-            set { _boundingBox = value; }
+            get => _boundingBox;
+            set => _boundingBox = value;
         }
 
         /// <summary>
@@ -120,8 +114,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public string SRID
         {
-            get { return _srid; }
-            set { _srid = value; }
+            get => _srid;
+            set => _srid = value;
         }
 
         //Coordinates can be included in a single string, but there is no 
@@ -135,8 +129,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public string DecimalDel
         {
-            get { return _decimalDel; }
-            set { _decimalDel = value; }
+            get => _decimalDel;
+            set => _decimalDel = value;
         }
 
         /// <summary>
@@ -144,8 +138,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public string Cs
         {
-            get { return _cs; }
-            set { _cs = value; }
+            get => _cs;
+            set => _cs = value;
         }
 
         /// <summary>
@@ -153,8 +147,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public string Ts
         {
-            get { return _ts; }
-            set { _ts = value; }
+            get => _ts;
+            set => _ts = value;
         }
 
 

--- a/Mapsui/Providers/Wfs/Utilities/GeometryFactories.cs
+++ b/Mapsui/Providers/Wfs/Utilities/GeometryFactories.cs
@@ -42,8 +42,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         internal int[] AxisOrder
         {
-            get { return _axisOrder; }
-            set { _axisOrder = value; }
+            get => _axisOrder;
+            set => _axisOrder = value;
         }
 
         /// <summary>
@@ -109,11 +109,11 @@ namespace Mapsui.Providers.Wfs.Utilities
         {
             if (!reader.Read()) return null;
 
-            string name = reader.LocalName;
-            string coordinateString = reader.ReadElementString();
+            var name = reader.LocalName;
+            var coordinateString = reader.ReadElementString();
             var vertices = new Collection<Point>();
             string[][] coordinateValues;
-            int i = 0;
+            var i = 0;
 
             if (name.Equals("coordinates"))
             {
@@ -128,7 +128,7 @@ namespace Mapsui.Providers.Wfs.Utilities
                 var evens = coords.Where((s, idx) => idx % 2 != 0);
                 coordinateValues = odds.Zip(evens, (odd, even) => new[] { odd, even }).ToArray();
             }
-            int length = coordinateValues.Length;
+            var length = coordinateValues.Length;
 
             while (i < length)
             {
@@ -200,7 +200,7 @@ namespace Mapsui.Providers.Wfs.Utilities
 
                     if (!ServiceExceptionNode.Matches(reader)) continue;
 
-                    string errorMessage = reader.ReadInnerXml();
+                    var errorMessage = reader.ReadInnerXml();
                     Trace.TraceError("A service exception occured: " + errorMessage);
                     throw new Exception("A service exception occured: " + errorMessage);
                 }
@@ -280,7 +280,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         private void InitializeSeparators()
         {
-            string decimalDel = string.IsNullOrEmpty(FeatureTypeInfo.DecimalDel) ? ":" : FeatureTypeInfo.DecimalDel;
+            var decimalDel = string.IsNullOrEmpty(FeatureTypeInfo.DecimalDel) ? ":" : FeatureTypeInfo.DecimalDel;
             _cs = string.IsNullOrEmpty(FeatureTypeInfo.Cs) ? "," : FeatureTypeInfo.Cs;
             _ts = string.IsNullOrEmpty(FeatureTypeInfo.Ts) ? " " : FeatureTypeInfo.Ts;
             _formatInfo.NumberDecimalSeparator = decimalDel;
@@ -337,7 +337,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         {
             IPathNode pointNode = new PathNode(Gmlns, "Point", (NameTable)XmlReader.NameTable);
             var labelValues = new Dictionary<string, string>();
-            bool geomFound = false;
+            var geomFound = false;
 
             try
             {
@@ -403,7 +403,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         {
             IPathNode lineStringNode = new PathNode(Gmlns, "LineString", (NameTable)XmlReader.NameTable);
             var labelValues = new Dictionary<string, string>();
-            bool geomFound = false;
+            var geomFound = false;
 
             try
             {
@@ -478,7 +478,7 @@ namespace Mapsui.Providers.Wfs.Utilities
             IPathNode innerBoundaryNodeAlt = new AlternativePathNodesCollection(innerBoundaryNode, interiorNode);
             IPathNode linearRingNode = new PathNode(Gmlns, "LinearRing", (NameTable)XmlReader.NameTable);
             var labelValues = new Dictionary<string, string>();
-            bool geomFound = false;
+            var geomFound = false;
 
             try
             {
@@ -559,7 +559,7 @@ namespace Mapsui.Providers.Wfs.Utilities
             IPathNode multiPointNode = new PathNode(Gmlns, "MultiPoint", (NameTable)XmlReader.NameTable);
             IPathNode pointMemberNode = new PathNode(Gmlns, "pointMember", (NameTable)XmlReader.NameTable);
             var labelValues = new Dictionary<string, string>();
-            bool geomFound = false;
+            var geomFound = false;
 
             try
             {
@@ -572,7 +572,7 @@ namespace Mapsui.Providers.Wfs.Utilities
                     {
                         var multiPoint = new MultiPoint();
                         GeometryFactory geomFactory = new PointFactory(GeomReader, FeatureTypeInfo) { AxisOrder = AxisOrder }; ;
-                        Collection<Geometry> points = geomFactory.CreateGeometries(features);
+                        var points = geomFactory.CreateGeometries(features);
 
                         foreach (var geometry in points)
                         {
@@ -640,7 +640,7 @@ namespace Mapsui.Providers.Wfs.Utilities
             IPathNode curveMemberNode = new PathNode(Gmlns, "curveMember", (NameTable)XmlReader.NameTable);
             IPathNode lineStringMemberNodeAlt = new AlternativePathNodesCollection(lineStringMemberNode, curveMemberNode);
             var labelValues = new Dictionary<string, string>();
-            bool geomFound = false;
+            var geomFound = false;
 
             try
             {
@@ -654,7 +654,7 @@ namespace Mapsui.Providers.Wfs.Utilities
                     {
                         var multiLineString = new MultiLineString();
                         GeometryFactory geomFactory = new LineStringFactory(GeomReader, FeatureTypeInfo) { AxisOrder = AxisOrder };
-                        Collection<Geometry> lineStrings = geomFactory.CreateGeometries(features);
+                        var lineStrings = geomFactory.CreateGeometries(features);
 
                         foreach (var geometry in lineStrings)
                         {
@@ -721,7 +721,7 @@ namespace Mapsui.Providers.Wfs.Utilities
             IPathNode polygonMemberNodeAlt = new AlternativePathNodesCollection(polygonMemberNode, surfaceMemberNode);
             IPathNode linearRingNode = new PathNode(Gmlns, "LinearRing", (NameTable)XmlReader.NameTable);
             var labelValues = new Dictionary<string, string>();
-            bool geomFound = false;
+            var geomFound = false;
 
             try
             {
@@ -734,7 +734,7 @@ namespace Mapsui.Providers.Wfs.Utilities
                     {
                         var multiPolygon = new MultiPolygon();
                         GeometryFactory geomFactory = new PolygonFactory(GeomReader, FeatureTypeInfo) { AxisOrder = AxisOrder };
-                        Collection<Geometry> polygons = geomFactory.CreateGeometries(features);
+                        var polygons = geomFactory.CreateGeometries(features);
 
                         foreach (var geometry in polygons)
                         {
@@ -802,7 +802,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         {
             GeometryFactory geomFactory = null;
 
-            string geometryTypeString = string.Empty;
+            var geometryTypeString = string.Empty;
 
             if (_quickGeometries) _multiGeometries = false;
 
@@ -863,7 +863,7 @@ namespace Mapsui.Providers.Wfs.Utilities
                     }
                     if (ServiceExceptionNode.Matches(XmlReader))
                     {
-                        string serviceException = XmlReader.ReadInnerXml();
+                        var serviceException = XmlReader.ReadInnerXml();
                         Trace.TraceError("A service exception occured: " + serviceException);
                         throw new Exception("A service exception occured: " + serviceException);
                     }

--- a/Mapsui/Providers/Wfs/Utilities/HttpClientUtil.cs
+++ b/Mapsui/Providers/Wfs/Utilities/HttpClientUtil.cs
@@ -29,8 +29,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public string Url
         {
-            get { return _url; }
-            set { _url = value; }
+            get => _url;
+            set => _url = value;
         }
 
         /// <summary>
@@ -38,8 +38,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public string ProxyUrl
         {
-            get { return _proxyUrl; }
-            set { _proxyUrl = value; }
+            get => _proxyUrl;
+            set => _proxyUrl = value;
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public byte[] PostData
         {
-            set { _postData = value; }
+            set => _postData = value;
         }
 
         /// <summary>
@@ -55,8 +55,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public ICredentials Credentials
         {
-            get { return _credentials; }
-            set { _credentials = value; }
+            get => _credentials;
+            set => _credentials = value;
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace Mapsui.Providers.Wfs.Utilities
                 {
                     _webRequest.ContentLength = _postData.Length;
                     _webRequest.Method = WebRequestMethods.Http.Post;
-                    using (Stream requestStream = _webRequest.GetRequestStream())
+                    using (var requestStream = _webRequest.GetRequestStream())
                     {
                         requestStream.Write(_postData, 0, _postData.Length);
                     }

--- a/Mapsui/Providers/Wfs/Utilities/OGCFilter_FE1_1_0.cs
+++ b/Mapsui/Providers/Wfs/Utilities/OGCFilter_FE1_1_0.cs
@@ -41,8 +41,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public List<IFilter> Filters
         {
-            get { return _filters; }
-            set { _filters = value; }
+            get => _filters;
+            set => _filters = value;
         }
 
         /// <summary>
@@ -50,8 +50,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public JunctorEnum Junctor
         {
-            get { return _junctor; }
-            set { _junctor = value; }
+            get => _junctor;
+            set => _junctor = value;
         }
 
 
@@ -95,7 +95,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         {
             var filterBuilder = new StringBuilder();
             filterBuilder.Append("<" + _junctor + ">");
-            foreach (IFilter filter in Filters)
+            foreach (var filter in Filters)
                 filterBuilder.Append(filter.Encode());
             filterBuilder.Append("</" + _junctor + ">");
             return filterBuilder.ToString();

--- a/Mapsui/Providers/Wfs/Utilities/PathNode.cs
+++ b/Mapsui/Providers/Wfs/Utilities/PathNode.cs
@@ -26,18 +26,12 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <summary>
         /// Gets the namespace URI of the element-node
         /// </summary>
-        internal string XmlElementNsUri
-        {
-            get { return _xmlElementNsUri; }
-        }
+        internal string XmlElementNsUri => _xmlElementNsUri;
 
         /// <summary>
         /// Gets the local name of the element-node
         /// </summary>
-        internal string XmlElementNodeName
-        {
-            get { return _xmlElementNodeName; }
-        }
+        internal string XmlElementNodeName => _xmlElementNodeName;
 
 
 
@@ -80,8 +74,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public bool IsActive
         {
-            get { return _isActive; }
-            set { _isActive = value; }
+            get => _isActive;
+            set => _isActive = value;
         }
 
     }
@@ -114,7 +108,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <param name="reader">An XmlReader instance</param>
         public bool Matches(XmlReader reader)
         {
-            foreach (IPathNode pathNode in _pathNodes)
+            foreach (var pathNode in _pathNodes)
                 if (pathNode.Matches(reader)) return true;
             return false;
         }
@@ -125,10 +119,10 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         public bool IsActive
         {
-            get { return _pathNodes[0].IsActive; }
+            get => _pathNodes[0].IsActive;
             set
             {
-                foreach (IPathNode pathNode in _pathNodes)
+                foreach (var pathNode in _pathNodes)
                     pathNode.IsActive = value;
             }
         }

--- a/Mapsui/Providers/Wfs/Utilities/WFS1_0_0_XPathTextResources.cs
+++ b/Mapsui/Providers/Wfs/Utilities/WFS1_0_0_XPathTextResources.cs
@@ -19,70 +19,42 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <summary>
         /// Gets an XPath string addressing the SRID of a FeatureType in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_SRS
-        {
-            get { return "/wfs:WFS_Capabilities/wfs:FeatureTypeList/wfs:FeatureType[_PARAMCOMP_(wfs:Name, $_param1)]/wfs:SRS"; }
-        }
+        public string XPATH_SRS => "/wfs:WFS_Capabilities/wfs:FeatureTypeList/wfs:FeatureType[_PARAMCOMP_(wfs:Name, $_param1)]/wfs:SRS";
 
         /// <summary>
         /// Gets an XPath string addressing the bounding box of a featuretype in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_BBOX
-        {
-            get { return "/wfs:WFS_Capabilities/wfs:FeatureTypeList/wfs:FeatureType[_PARAMCOMP_(wfs:Name, $_param1)]/wfs:LatLongBoundingBox"; }
-        }
+        public string XPATH_BBOX => "/wfs:WFS_Capabilities/wfs:FeatureTypeList/wfs:FeatureType[_PARAMCOMP_(wfs:Name, $_param1)]/wfs:LatLongBoundingBox";
 
         /// <summary>
         /// Gets an XPath string addressing the URI of 'GetFeature'in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_GETFEATURERESOURCE
-        {
-            get { return "/wfs:WFS_Capabilities/wfs:Capability/wfs:Request/wfs:GetFeature/wfs:DCPType/wfs:HTTP/wfs:Post/@onlineResource"; }
-        }
+        public string XPATH_GETFEATURERESOURCE => "/wfs:WFS_Capabilities/wfs:Capability/wfs:Request/wfs:GetFeature/wfs:DCPType/wfs:HTTP/wfs:Post/@onlineResource";
 
         /// <summary>
         /// Gets an XPath string addressing the URI of 'DescribeFeatureType'in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_DESCRIBEFEATURETYPERESOURCE
-        {
-            get
-            {
-                return
-                    "/wfs:WFS_Capabilities/wfs:Capability/wfs:Request/wfs:DescribeFeatureType/wfs:DCPType/wfs:HTTP/wfs:Post/@onlineResource";
-            }
-        }
+        public string XPATH_DESCRIBEFEATURETYPERESOURCE => "/wfs:WFS_Capabilities/wfs:Capability/wfs:Request/wfs:DescribeFeatureType/wfs:DCPType/wfs:HTTP/wfs:Post/@onlineResource";
 
         /// <summary>
         /// Gets an XPath string addressing the 'minx'-attribute of a featuretype's bounding box in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_BOUNDINGBOXMINX
-        {
-            get { return "@minx"; }
-        }
+        public string XPATH_BOUNDINGBOXMINX => "@minx";
 
         /// <summary>
         /// Gets an XPath string addressing the 'maxx'-attribute of a featuretype's bounding box in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_BOUNDINGBOXMAXX
-        {
-            get { return "@maxx"; }
-        }
+        public string XPATH_BOUNDINGBOXMAXX => "@maxx";
 
         /// <summary>
         /// Gets an XPath string addressing the 'miny'-attribute of a featuretype's bounding box in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_BOUNDINGBOXMINY
-        {
-            get { return "@miny"; }
-        }
+        public string XPATH_BOUNDINGBOXMINY => "@miny";
 
         /// <summary>
         /// Gets an XPath string addressing the 'maxy'-attribute of a featuretype's bounding box in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_BOUNDINGBOXMAXY
-        {
-            get { return "@maxy"; }
-        }
+        public string XPATH_BOUNDINGBOXMAXY => "@maxy";
 
 
 

--- a/Mapsui/Providers/Wfs/Utilities/WFS1_1_0_XPathTextResources.cs
+++ b/Mapsui/Providers/Wfs/Utilities/WFS1_1_0_XPathTextResources.cs
@@ -15,90 +15,66 @@ namespace Mapsui.Providers.Wfs.Utilities
         // GetCapabilities WFS 1.1.0                                          //
         ////////////////////////////////////////////////////////////////////////
 
-        private static string _XPATH_BBOX =
+        private static readonly string _XPATH_BBOX =
             "/wfs:WFS_Capabilities/wfs:FeatureTypeList/wfs:FeatureType[_PARAMCOMP_(wfs:Name, $_param1)]/ows:WGS84BoundingBox";
 
-        private static string _XPATH_BOUNDINGBOXMAXX = "ows:UpperCorner/text()";
-        private static string _XPATH_BOUNDINGBOXMAXY = "ows:UpperCorner/text()";
-        private static string _XPATH_BOUNDINGBOXMINX = "ows:LowerCorner/text()";
-        private static string _XPATH_BOUNDINGBOXMINY = "ows:LowerCorner/text()";
+        private static readonly string _XPATH_BOUNDINGBOXMAXX = "ows:UpperCorner/text()";
+        private static readonly string _XPATH_BOUNDINGBOXMAXY = "ows:UpperCorner/text()";
+        private static readonly string _XPATH_BOUNDINGBOXMINX = "ows:LowerCorner/text()";
+        private static readonly string _XPATH_BOUNDINGBOXMINY = "ows:LowerCorner/text()";
 
-        private static string _XPATH_DESCRIBEFEATURETYPERESOURCE =
+        private static readonly string _XPATH_DESCRIBEFEATURETYPERESOURCE =
             "/wfs:WFS_Capabilities/ows:OperationsMetadata/ows:Operation[@name='DescribeFeatureType']/ows:DCP/ows:HTTP/ows:Post/@xlink:href";
 
-        private static string _XPATH_GETFEATURERESOURCE =
+        private static readonly string _XPATH_GETFEATURERESOURCE =
             "/wfs:WFS_Capabilities/ows:OperationsMetadata/ows:Operation[@name='GetFeature']/ows:DCP/ows:HTTP/ows:Post/@xlink:href";
 
-        private static string _XPATH_SRS =
+        private static readonly string _XPATH_SRS =
             "/wfs:WFS_Capabilities/wfs:FeatureTypeList/wfs:FeatureType[_PARAMCOMP_(wfs:Name, $_param1)]/wfs:DefaultSRS";
 
         /// <summary>
         /// Gets an XPath string addressing the SRID of a featuretype in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_SRS
-        {
-            get { return _XPATH_SRS; }
-        }
+        public string XPATH_SRS => _XPATH_SRS;
 
         /// <summary>
         /// Gets an XPath string addressing the bounding box of a featuretype in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_BBOX
-        {
-            get { return _XPATH_BBOX; }
-        }
+        public string XPATH_BBOX => _XPATH_BBOX;
 
         /// <summary>
         /// Gets an XPath string addressing the URI of 'GetFeature'in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_GETFEATURERESOURCE
-        {
-            get { return _XPATH_GETFEATURERESOURCE; }
-        }
+        public string XPATH_GETFEATURERESOURCE => _XPATH_GETFEATURERESOURCE;
 
         /// <summary>
         /// Gets an XPath string addressing the URI of 'DescribeFeatureType'in 'GetCapabilities'.
         /// </summary>
-        public string XPATH_DESCRIBEFEATURETYPERESOURCE
-        {
-            get { return _XPATH_DESCRIBEFEATURETYPERESOURCE; }
-        }
+        public string XPATH_DESCRIBEFEATURETYPERESOURCE => _XPATH_DESCRIBEFEATURETYPERESOURCE;
 
         /// <summary>
         /// Gets an XPath string addressing the lower corner of a featuretype's bounding box in 'GetCapabilities'
         /// for extracting 'minx'.
         /// </summary>
-        public string XPATH_BOUNDINGBOXMINX
-        {
-            get { return _XPATH_BOUNDINGBOXMINX; }
-        }
+        public string XPATH_BOUNDINGBOXMINX => _XPATH_BOUNDINGBOXMINX;
 
         /// <summary>
         /// Gets an XPath string addressing the lower corner of a featuretype's bounding box in 'GetCapabilities'
         /// for extracting 'miny'.
         /// </summary>
-        public string XPATH_BOUNDINGBOXMINY
-        {
-            get { return _XPATH_BOUNDINGBOXMINY; }
-        }
+        public string XPATH_BOUNDINGBOXMINY => _XPATH_BOUNDINGBOXMINY;
 
         /// <summary>
         /// Gets an XPath string addressing the upper corner of a featuretype's bounding box in 'GetCapabilities'
         /// for extracting 'maxx'.
         /// </summary>
-        public string XPATH_BOUNDINGBOXMAXX
-        {
-            get { return _XPATH_BOUNDINGBOXMAXX; }
-        }
+        public string XPATH_BOUNDINGBOXMAXX => _XPATH_BOUNDINGBOXMAXX;
 
         /// <summary>
         /// Gets an XPath string addressing the upper corner of a featuretype's bounding box in 'GetCapabilities'
         /// for extracting 'maxy'.
         /// </summary>
-        public string XPATH_BOUNDINGBOXMAXY
-        {
-            get { return _XPATH_BOUNDINGBOXMAXY; }
-        }
+        public string XPATH_BOUNDINGBOXMAXY => _XPATH_BOUNDINGBOXMAXY;
 
 
     }

--- a/Mapsui/Providers/Wfs/Utilities/WFS_1_0_0_TextResources.cs
+++ b/Mapsui/Providers/Wfs/Utilities/WFS_1_0_0_TextResources.cs
@@ -2,12 +2,12 @@
 // This file can be redistributed and/or modified under the terms of the GNU Lesser General Public License.
 
 using System.Collections.Generic;
-using Mapsui.Geometries;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Web;
 using System.Xml;
+using Mapsui.Geometries;
 using Mapsui.Utilities;
 
 // ReSharper disable InconsistentNaming
@@ -51,7 +51,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         public string GetFeatureGETRequest(WfsFeatureTypeInfo featureTypeInfo, List<string> labelProperties,
                                            BoundingBox? boundingBox, IFilter? filter)
         {
-            string qualification = string.IsNullOrEmpty(featureTypeInfo.Prefix)
+            var qualification = string.IsNullOrEmpty(featureTypeInfo.Prefix)
                                        ? string.Empty
                                        : featureTypeInfo.Prefix + ":";
 
@@ -87,7 +87,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         public byte[] GetFeaturePOSTRequest(WfsFeatureTypeInfo featureTypeInfo, List<string> labelProperties,
                                             BoundingBox boundingBox, IFilter filter)
         {
-            string qualification = string.IsNullOrEmpty(featureTypeInfo.Prefix)
+            var qualification = string.IsNullOrEmpty(featureTypeInfo.Prefix)
                                        ? string.Empty
                                        : featureTypeInfo.Prefix + ":";
 

--- a/Mapsui/Providers/Wfs/Utilities/WFS_1_1_0_TextResources.cs
+++ b/Mapsui/Providers/Wfs/Utilities/WFS_1_1_0_TextResources.cs
@@ -2,12 +2,12 @@
 // This file can be redistributed and/or modified under the terms of the GNU Lesser General Public License.
 
 using System.Collections.Generic;
-using Mapsui.Geometries;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Web;
 using System.Xml;
+using Mapsui.Geometries;
 using Mapsui.Utilities;
 
 // ReSharper disable InconsistentNaming
@@ -50,7 +50,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         public string GetFeatureGETRequest(WfsFeatureTypeInfo featureTypeInfo, List<string> labelProperties,
                                            BoundingBox? boundingBox, IFilter? filter)
         {
-            string qualification = string.IsNullOrEmpty(featureTypeInfo.Prefix)
+            var qualification = string.IsNullOrEmpty(featureTypeInfo.Prefix)
                 ? string.Empty
                 : featureTypeInfo.Prefix + ":";
 
@@ -92,7 +92,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         public byte[] GetFeaturePOSTRequest(WfsFeatureTypeInfo featureTypeInfo, List<string> labelProperties,
                                             BoundingBox boundingBox, IFilter filter)
         {
-            string qualification = string.IsNullOrEmpty(featureTypeInfo.Prefix)
+            var qualification = string.IsNullOrEmpty(featureTypeInfo.Prefix)
                                        ? string.Empty
                                        : featureTypeInfo.Prefix + ":";
 

--- a/Mapsui/Providers/Wfs/Utilities/WFS_XPathTextResourcesBase.cs
+++ b/Mapsui/Providers/Wfs/Utilities/WFS_XPathTextResourcesBase.cs
@@ -12,147 +12,108 @@ namespace Mapsui.Providers.Wfs.Utilities
         // Prefixes                                                           //
         ////////////////////////////////////////////////////////////////////////
 
-        private static string _XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY =
+        private static readonly string _XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY =
             // _param1 = TargetNs 
             // _param2 = Value of the type-attribute 
             "//xs:element[_PARAMCOMPWITHTARGETNS_(@type, $_param1, $_param2)]/@name";
 
-        private static string _XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY_ANONYMOUSTYPE =
+        private static readonly string _XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY_ANONYMOUSTYPE =
             "//xs:element[starts-with(@ref,'gml:')]/ancestor::xs:complexType[1]/ancestor::xs:element[1]/@name";
 
-        private static string _XPATH_GEOMETRY_ELEMREF_GMLELEMENTQUERY =
+        private static readonly string _XPATH_GEOMETRY_ELEMREF_GMLELEMENTQUERY =
             "descendant::xs:element[starts-with(@ref,'gml:')]/@ref";
 
-        private static string _XPATH_GEOMETRYELEMENT_BYTYPEATTRIBUTEQUERY =
+        private static readonly string _XPATH_GEOMETRYELEMENT_BYTYPEATTRIBUTEQUERY =
             "//xs:element[starts-with(@type,'gml:')]";
 
-        private static string _XPATH_GEOMETRYELEMENTCOMPLEXTYPE_BYELEMREFQUERY =
+        private static readonly string _XPATH_GEOMETRYELEMENTCOMPLEXTYPE_BYELEMREFQUERY =
             "//xs:element[starts-with(@ref,'gml:')]/ancestor::xs:complexType[1]";
 
-        private static string _XPATH_NAMEATTRIBUTEQUERY = "@name";
+        private static readonly string _XPATH_NAMEATTRIBUTEQUERY = "@name";
 
-        private static string _XPATH_TARGETNS =
+        private static readonly string _XPATH_TARGETNS =
             "/xs:schema/@targetNamespace";
 
-        private static string _XPATH_TYPEATTRIBUTEQUERY = "@type";
-        private string _NSFEATURETYPEPREFIX = "feature";
-        private string _NSGML = "http://www.opengis.net/gml";
-        private string _NSGMLPREFIX = "gml";
-        private string _NSOGC = "http://www.opengis.net/ogc";
+        private static readonly string _XPATH_TYPEATTRIBUTEQUERY = "@type";
+        private readonly string _NSFEATURETYPEPREFIX = "feature";
+        private readonly string _NSGML = "http://www.opengis.net/gml";
+        private readonly string _NSGMLPREFIX = "gml";
+        private readonly string _NSOGC = "http://www.opengis.net/ogc";
 
-        private string _NSOGCPREFIX = "ogc";
-        private string _NSOWS = "http://www.opengis.net/ows";
-        private string _NSOWSPREFIX = "ows";
-        private string _NSSCHEMA = "http://www.w3.org/2001/XMLSchema";
-        private string _NSSCHEMAPREFIX = "xs";
-        private string _NSWFS = "http://www.opengis.net/wfs";
-        private string _NSWFSPREFIX = "wfs";
-        private string _NSXLINK = "http://www.w3.org/1999/xlink";
-        private string _NSXLINKPREFIX = "xlink";
+        private readonly string _NSOGCPREFIX = "ogc";
+        private readonly string _NSOWS = "http://www.opengis.net/ows";
+        private readonly string _NSOWSPREFIX = "ows";
+        private readonly string _NSSCHEMA = "http://www.w3.org/2001/XMLSchema";
+        private readonly string _NSSCHEMAPREFIX = "xs";
+        private readonly string _NSWFS = "http://www.opengis.net/wfs";
+        private readonly string _NSWFSPREFIX = "wfs";
+        private readonly string _NSXLINK = "http://www.w3.org/1999/xlink";
+        private readonly string _NSXLINKPREFIX = "xlink";
 
         /// <summary>
         /// Prefix used for OGC namespace
         /// </summary>
-        public string NSOGCPREFIX
-        {
-            get { return _NSOGCPREFIX; }
-        }
+        public string NSOGCPREFIX => _NSOGCPREFIX;
 
         /// <summary>
         /// OGC namespace URI 
         /// </summary>
-        public string NSOGC
-        {
-            get { return _NSOGC; }
-        }
+        public string NSOGC => _NSOGC;
 
         /// <summary>
         /// Prefix used for XLink namespace
         /// </summary>
-        public string NSXLINKPREFIX
-        {
-            get { return _NSXLINKPREFIX; }
-        }
+        public string NSXLINKPREFIX => _NSXLINKPREFIX;
 
         /// <summary>
         /// XLink namespace URI 
         /// </summary>
-        public string NSXLINK
-        {
-            get { return _NSXLINK; }
-        }
+        public string NSXLINK => _NSXLINK;
 
         /// <summary>
         /// Prefix used for feature namespace
         /// </summary>
-        public string NSFEATURETYPEPREFIX
-        {
-            get { return _NSFEATURETYPEPREFIX; }
-        }
+        public string NSFEATURETYPEPREFIX => _NSFEATURETYPEPREFIX;
 
         /// <summary>
         /// Prefix used for WFS namespace
         /// </summary>
-        public string NSWFSPREFIX
-        {
-            get { return _NSWFSPREFIX; }
-        }
+        public string NSWFSPREFIX => _NSWFSPREFIX;
 
         /// <summary>
         /// WFS namespace URI 
         /// </summary>
-        public string NSWFS
-        {
-            get { return _NSWFS; }
-        }
+        public string NSWFS => _NSWFS;
 
         /// <summary>
         /// Prefix used for GML namespace
         /// </summary>
-        public string NSGMLPREFIX
-        {
-            get { return _NSGMLPREFIX; }
-        }
+        public string NSGMLPREFIX => _NSGMLPREFIX;
 
         /// <summary>
         /// GML namespace URI 
         /// </summary>
-        public string NSGML
-        {
-            get { return _NSGML; }
-        }
+        public string NSGML => _NSGML;
 
         /// <summary>
         /// Prefix used for OWS namespace
         /// </summary>
-        public string NSOWSPREFIX
-        {
-            get { return _NSOWSPREFIX; }
-        }
+        public string NSOWSPREFIX => _NSOWSPREFIX;
 
         /// <summary>
         /// OWS namespace URI 
         /// </summary>
-        public string NSOWS
-        {
-            get { return _NSOWS; }
-        }
+        public string NSOWS => _NSOWS;
 
         /// <summary>
         /// Prefix used for XML schema namespace
         /// </summary>
-        public string NSSCHEMAPREFIX
-        {
-            get { return _NSSCHEMAPREFIX; }
-        }
+        public string NSSCHEMAPREFIX => _NSSCHEMAPREFIX;
 
         /// <summary>
         /// XML schema namespace URI 
         /// </summary>
-        public string NSSCHEMA
-        {
-            get { return _NSSCHEMA; }
-        }
+        public string NSSCHEMA => _NSSCHEMA;
 
         ////////////////////////////////////////////////////////////////////////
         // XPath                                                              //                      
@@ -162,74 +123,50 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <summary>
         /// Gets an XPath string addressing the target namespace in 'DescribeFeatureType'.
         /// </summary>
-        public string XPATH_TARGETNS
-        {
-            get { return _XPATH_TARGETNS; }
-        }
+        public string XPATH_TARGETNS => _XPATH_TARGETNS;
 
         /// <summary>
         /// Gets an XPath string addressing an element with a 'gml'-prefixed type-attribute in 'DescribeFeatureType'.
         /// This for querying the geometry element of a featuretype in the most simple manner.
         /// </summary>
-        public string XPATH_GEOMETRYELEMENT_BYTYPEATTRIBUTEQUERY
-        {
-            get { return _XPATH_GEOMETRYELEMENT_BYTYPEATTRIBUTEQUERY; }
-        }
+        public string XPATH_GEOMETRYELEMENT_BYTYPEATTRIBUTEQUERY => _XPATH_GEOMETRYELEMENT_BYTYPEATTRIBUTEQUERY;
 
         /// <summary>
         /// Gets an XPath string addressing a name-attribute.
         /// </summary>
-        public string XPATH_NAMEATTRIBUTEQUERY
-        {
-            get { return _XPATH_NAMEATTRIBUTEQUERY; }
-        }
+        public string XPATH_NAMEATTRIBUTEQUERY => _XPATH_NAMEATTRIBUTEQUERY;
 
         /// <summary>
         ///  Gets an XPath string addressing a type-attribute.
         /// </summary>
-        public string XPATH_TYPEATTRIBUTEQUERY
-        {
-            get { return _XPATH_TYPEATTRIBUTEQUERY; }
-        }
+        public string XPATH_TYPEATTRIBUTEQUERY => _XPATH_TYPEATTRIBUTEQUERY;
 
         /// <summary>
         /// Gets an XPath string addressing a complex type hosting an element with a 'gml'-prefixed ref-attribute in 'DescribeFeatureType'.
         /// This for querying the geometry element of a featuretype. 
         /// Step1: Finding the complex type with a geometry element from GML specification. 
         /// </summary>
-        public string XPATH_GEOMETRYELEMENTCOMPLEXTYPE_BYELEMREFQUERY
-        {
-            get { return _XPATH_GEOMETRYELEMENTCOMPLEXTYPE_BYELEMREFQUERY; }
-        }
+        public string XPATH_GEOMETRYELEMENTCOMPLEXTYPE_BYELEMREFQUERY => _XPATH_GEOMETRYELEMENTCOMPLEXTYPE_BYELEMREFQUERY;
 
         /// <summary>
         /// Gets an XPath string addressing the name of an element having a type-attribute referencing 
         /// a complex type hosting an element with a 'gml'-prefixed ref-attribute in 'DescribeFeatureType'.
         /// Step2: Finding the name of the featuretype's element with a named complex type hosting the GML geometry.
         /// </summary>
-        public string XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY
-        {
-            get { return _XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY; }
-        }
+        public string XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY => _XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY;
 
         /// <summary>
         /// Gets an XPath string addressing the name of an element described by an anonymous complex type 
         /// hosting an element with a 'gml'-prefixed ref-attribute in 'DescribeFeatureType'.
         /// Step2Alt: Finding the name of the featuretype's element with an anonymous complex type hosting the GML geometry.
         /// </summary>
-        public string XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY_ANONYMOUSTYPE
-        {
-            get { return _XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY_ANONYMOUSTYPE; }
-        }
+        public string XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY_ANONYMOUSTYPE => _XPATH_GEOMETRY_ELEMREF_GEOMNAMEQUERY_ANONYMOUSTYPE;
 
         /// <summary>
         /// Gets an XPath string addressing the 'gml'-prefixed  ref-attribute of an element.
         /// This is for querying the name of the GML geometry element.
         /// </summary>
-        public string XPATH_GEOMETRY_ELEMREF_GMLELEMENTQUERY
-        {
-            get { return _XPATH_GEOMETRY_ELEMREF_GMLELEMENTQUERY; }
-        }
+        public string XPATH_GEOMETRY_ELEMREF_GMLELEMENTQUERY => _XPATH_GEOMETRY_ELEMREF_GMLELEMENTQUERY;
 
     }
 }

--- a/Mapsui/Providers/Wfs/WFSProvider.cs
+++ b/Mapsui/Providers/Wfs/WFSProvider.cs
@@ -1,8 +1,6 @@
 // WFS provider by Peter Robineau (peter.robineau@gmx.at)
 // This file can be redistributed and/or modified under the terms of the GNU Lesser General Public License.
 
-using Mapsui.Geometries;
-using Mapsui.Providers.Wfs.Utilities;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -10,9 +8,10 @@ using System.Globalization;
 using System.Net;
 using System.Xml.XPath;
 using Mapsui.Extensions;
-using Mapsui.Fetcher;
+using Mapsui.Geometries;
 using Mapsui.Layers;
 using Mapsui.Projection;
+using Mapsui.Providers.Wfs.Utilities;
 using Mapsui.Providers.Wfs.Xml;
 using Mapsui.Utilities;
 
@@ -82,17 +81,14 @@ namespace Mapsui.Providers.Wfs
         /// </summary>
         public IXPathQueryManager GetCapabilitiesCache
         {
-            get { return _featureTypeInfoQueryManager; }
-            set { _featureTypeInfoQueryManager = value; }
+            get => _featureTypeInfoQueryManager;
+            set => _featureTypeInfoQueryManager = value;
         }
 
         /// <summary>
         /// Gets feature metadata 
         /// </summary>
-        public WfsFeatureTypeInfo FeatureTypeInfo
-        {
-            get { return _featureTypeInfo; }
-        }
+        public WfsFeatureTypeInfo FeatureTypeInfo => _featureTypeInfo;
 
         /// <summary>
         /// Gets or sets a value indicating the axis order
@@ -102,13 +98,11 @@ namespace Mapsui.Providers.Wfs
         /// <para/>If not set explictly, <see cref="AxisOrderRegistry"/> is asked for a value based on <see cref="SRID"/>.</remarks>
         public int[] AxisOrder
         {
-            get
-            {
+            get =>
                 //https://docs.geoserver.org/stable/en/user/services/wfs/axis_order.html#wfs-basics-axis
-                return _axisOrder ?? (_wfsVersion == WFSVersionEnum.WFS_1_0_0
+                _axisOrder ?? (_wfsVersion == WFSVersionEnum.WFS_1_0_0
                     ? new[] { 0, 1 }
                     : new AxisOrderRegistry()[CRS]);
-            }
             set
             {
                 if (value != null)
@@ -134,8 +128,8 @@ namespace Mapsui.Providers.Wfs
         /// </summary>
         public bool QuickGeometries
         {
-            get { return _quickGeometries; }
-            set { _quickGeometries = value; }
+            get => _quickGeometries;
+            set => _quickGeometries = value;
         }
 
         /// <summary>
@@ -145,8 +139,8 @@ namespace Mapsui.Providers.Wfs
         /// </summary>
         public bool MultiGeometries
         {
-            get { return _multiGeometries; }
-            set { _multiGeometries = value; }
+            get => _multiGeometries;
+            set => _multiGeometries = value;
         }
 
         /// <summary>
@@ -156,8 +150,8 @@ namespace Mapsui.Providers.Wfs
         /// </summary>
         public bool GetFeatureGetRequest
         {
-            get { return _getFeatureGetRequest; }
-            set { _getFeatureGetRequest = value; }
+            get => _getFeatureGetRequest;
+            set => _getFeatureGetRequest = value;
         }
 
         /// <summary>
@@ -165,8 +159,8 @@ namespace Mapsui.Providers.Wfs
         /// </summary>
         public IFilter OgcFilter
         {
-            get { return _ogcFilter; }
-            set { _ogcFilter = value; }
+            get => _ogcFilter;
+            set => _ogcFilter = value;
         }
 
         /// <summary>
@@ -174,8 +168,8 @@ namespace Mapsui.Providers.Wfs
         /// </summary>
         public List<string> Labels
         {
-            get { return _labels; }
-            set { _labels = value; }
+            get => _labels;
+            set => _labels = value;
         }
 
         /// <summary>
@@ -183,8 +177,8 @@ namespace Mapsui.Providers.Wfs
         /// </summary>
         public ICredentials Credentials
         {
-            get { return _httpClientUtil.Credentials; }
-            set { _httpClientUtil.Credentials = value; }
+            get => _httpClientUtil.Credentials;
+            set => _httpClientUtil.Credentials = value;
         }
 
         /// <summary>
@@ -192,8 +186,8 @@ namespace Mapsui.Providers.Wfs
         /// </summary>
         public string ProxyUrl
         {
-            get { return _httpClientUtil.ProxyUrl; }
-            set { _httpClientUtil.ProxyUrl = value; }
+            get => _httpClientUtil.ProxyUrl;
+            set => _httpClientUtil.ProxyUrl = value;
         }
 
         /// <summary>
@@ -392,7 +386,7 @@ namespace Mapsui.Providers.Wfs
 
             var features = new Features();
 
-            string geometryTypeString = _featureTypeInfo.Geometry.GeometryType;
+            var geometryTypeString = _featureTypeInfo.Geometry.GeometryType;
 
             GeometryFactory geomFactory = null;
 
@@ -510,8 +504,8 @@ namespace Mapsui.Providers.Wfs
 
         public string CRS
         {
-            get { return ProjectionHelper.EpsgPrefix + _featureTypeInfo.SRID; }
-            set { _featureTypeInfo.SRID = value.Substring(ProjectionHelper.EpsgPrefix.Length); }
+            get => ProjectionHelper.EpsgPrefix + _featureTypeInfo.SRID;
+            set => _featureTypeInfo.SRID = value.Substring(ProjectionHelper.EpsgPrefix.Length);
         }
 
         public void Dispose()
@@ -543,7 +537,7 @@ namespace Mapsui.Providers.Wfs
                 _featureTypeInfo.Prefix = _nsPrefix;
                 _featureTypeInfo.Name = _featureType;
 
-                string featureQueryName = string.IsNullOrEmpty(_nsPrefix)
+                var featureQueryName = string.IsNullOrEmpty(_nsPrefix)
                                               ? _featureType
                                               : _nsPrefix + ":" + _featureType;
 
@@ -574,7 +568,7 @@ namespace Mapsui.Providers.Wfs
                         _featureTypeInfo.ServiceUri.Remove(_featureTypeInfo.ServiceUri.Length - 1);
 
                 /* URI for DescribeFeatureType request */
-                string describeFeatureTypeUri = _featureTypeInfoQueryManager.GetValueFromNode
+                var describeFeatureTypeUri = _featureTypeInfoQueryManager.GetValueFromNode
                     (_featureTypeInfoQueryManager.Compile(_textResources.XPATH_DESCRIBEFEATURETYPERESOURCE));
                 /* If no DescribeFeatureType URI could be found, try GetCapabilities URI */
                 if (describeFeatureTypeUri == null) describeFeatureTypeUri = _getCapabilitiesUri;
@@ -590,7 +584,7 @@ namespace Mapsui.Providers.Wfs
                 _featureTypeInfo.SRID = srid;
 
                 /* Bounding Box */
-                IXPathQueryManager bboxQuery = _featureTypeInfoQueryManager.GetXPathQueryManagerInContext(
+                var bboxQuery = _featureTypeInfoQueryManager.GetXPathQueryManagerInContext(
                     _featureTypeInfoQueryManager.Compile(_textResources.XPATH_BBOX),
                     new[] { new DictionaryEntry("_param1", featureQueryName) });
 
@@ -672,7 +666,7 @@ namespace Mapsui.Providers.Wfs
                 }
 
                 //Continue with a clone in order to preserve the 'GetCapabilities' response
-                IXPathQueryManager describeFeatureTypeQueryManager = _featureTypeInfoQueryManager.Clone();
+                var describeFeatureTypeQueryManager = _featureTypeInfoQueryManager.Clone();
 
                 /******************************/
                 /* DescribeFeatureType request /
@@ -689,20 +683,20 @@ namespace Mapsui.Providers.Wfs
                 describeFeatureTypeQueryManager.AddNamespace(_textResources.NSGMLPREFIX, _textResources.NSGML);
 
                 /* Get target namespace */
-                string targetNs = describeFeatureTypeQueryManager.GetValueFromNode(
+                var targetNs = describeFeatureTypeQueryManager.GetValueFromNode(
                     describeFeatureTypeQueryManager.Compile(_textResources.XPATH_TARGETNS));
                 if (targetNs != null)
                     _featureTypeInfo.FeatureTypeNamespace = targetNs;
 
                 /* Get geometry */
-                string geomType = _geometryType == GeometryTypeEnum.Unknown ? null : _geometryType.ToString();
+                var geomType = _geometryType == GeometryTypeEnum.Unknown ? null : _geometryType.ToString();
                 string geomName = null;
 
                 /* The easiest way to get geometry info, just ask for the 'gml'-prefixed type-attribute... 
                    Simple, but effective in 90% of all cases...this is the standard GeoServer creates.*/
                 /* example: <xs:element nillable = "false" name = "the_geom" maxOccurs = "1" type = "gml:MultiPolygonPropertyType" minOccurs = "0" /> */
                 /* Try to get context of the geometry element by asking for a 'gml:*' type-attribute */
-                IXPathQueryManager geomQuery = describeFeatureTypeQueryManager.GetXPathQueryManagerInContext(
+                var geomQuery = describeFeatureTypeQueryManager.GetXPathQueryManagerInContext(
                     describeFeatureTypeQueryManager.Compile(_textResources.XPATH_GEOMETRYELEMENT_BYTYPEATTRIBUTEQUERY));
                 if (geomQuery != null)
                 {
@@ -744,7 +738,7 @@ namespace Mapsui.Providers.Wfs
                     if (geomQuery != null)
                     {
                         /* Ask for the name of the complextype - use the local context*/
-                        string geomComplexTypeName = geomQuery.GetValueFromNode(geomQuery.Compile(_textResources.XPATH_NAMEATTRIBUTEQUERY));
+                        var geomComplexTypeName = geomQuery.GetValueFromNode(geomQuery.Compile(_textResources.XPATH_NAMEATTRIBUTEQUERY));
 
                         if (geomComplexTypeName != null)
                         {
@@ -856,7 +850,7 @@ namespace Mapsui.Providers.Wfs
         {
             if (featureType.Contains(":"))
             {
-                string[] split = featureType.Split(':');
+                var split = featureType.Split(':');
                 _nsPrefix = split[0];
                 _featureType = split[1];
             }

--- a/Mapsui/Providers/Wfs/Xml/XPathQueryManager.cs
+++ b/Mapsui/Providers/Wfs/Xml/XPathQueryManager.cs
@@ -329,7 +329,7 @@ namespace Mapsui.Providers.Wfs.Xml
 
         private void InitializeCustomContext(CustomQueryContext paramContext)
         {
-            IDictionary<string, string> namespaces = paramContext.GetNamespacesInScope(XmlNamespaceScope.ExcludeXml);
+            var namespaces = paramContext.GetNamespacesInScope(XmlNamespaceScope.ExcludeXml);
             _paramContext = new CustomQueryContext((NameTable)paramContext.NameTable);
             _paramContext.AddNamespace(namespaces);
         }
@@ -369,10 +369,7 @@ namespace Mapsui.Providers.Wfs.Xml
             /// <summary>
             /// Method from XsltContext.
             /// </summary>
-            public override bool Whitespace
-            {
-                get { return true; }
-            }
+            public override bool Whitespace => true;
 
             /// <summary>
             /// This method adds a list of namespaces to use in the custom context.
@@ -380,7 +377,7 @@ namespace Mapsui.Providers.Wfs.Xml
             /// <param name="namespaces">A list of namespaces</param>
             public void AddNamespace(IDictionary<string, string> namespaces)
             {
-                foreach (string ns in namespaces.Keys)
+                foreach (var ns in namespaces.Keys)
                     AddNamespace(ns, namespaces[ns]);
             }
 
@@ -421,7 +418,7 @@ namespace Mapsui.Providers.Wfs.Xml
             /// <param name="name">The name of the variable</param>
             public override IXsltContextVariable ResolveVariable(string prefix, string name)
             {
-                object param = GetParam(name);
+                var param = GetParam(name);
                 if (param != null)
                     return new ParamFunctionVar(param);
                 return null;
@@ -443,8 +440,8 @@ namespace Mapsui.Providers.Wfs.Xml
             /// <param name="parameters">A list of parameters</param>
             public void AddParam(DictionaryEntry[] parameters)
             {
-                int length = parameters.Length;
-                for (int i = 0; i < length; i++)
+                var length = parameters.Length;
+                for (var i = 0; i < length; i++)
                     _argumentList.AddParam(parameters[i].Key.ToString(),
                                            string.Empty, parameters[i].Value.ToString());
             }
@@ -495,34 +492,22 @@ namespace Mapsui.Providers.Wfs.Xml
             /// <summary>
             /// Gets the argument types.
             /// </summary>
-            public XPathResultType[] ArgTypes
-            {
-                get { return _argTypes; }
-            }
+            public XPathResultType[] ArgTypes => _argTypes;
 
             /// <summary>
             /// Gets the return type.
             /// </summary>
-            public XPathResultType ReturnType
-            {
-                get { return _returnType; }
-            }
+            public XPathResultType ReturnType => _returnType;
 
             /// <summary>
             /// Gets the minimum number of arguments allowed.
             /// </summary>
-            public int Minargs
-            {
-                get { return _minArgs; }
-            }
+            public int Minargs => _minArgs;
 
             /// <summary>
             /// Gets the maximum number of arguments allowed.
             /// </summary>
-            public int Maxargs
-            {
-                get { return _maxArgs; }
-            }
+            public int Maxargs => _maxArgs;
 
 
 
@@ -618,7 +603,7 @@ namespace Mapsui.Providers.Wfs.Xml
             {
                 if (args.Contains(":"))
                 {
-                    string prefix = args.Substring(0, args.IndexOf(":", StringComparison.Ordinal));
+                    var prefix = args.Substring(0, args.IndexOf(":", StringComparison.Ordinal));
                     string ns;
                     if (!string.IsNullOrEmpty((ns = xsltContext.LookupNamespace(prefix))))
                         args = args.Replace(prefix + ":", ns);
@@ -640,7 +625,7 @@ namespace Mapsui.Providers.Wfs.Xml
             /// <summary>
             /// The name to use when embedding the function in an XPath expression.
             /// </summary>
-            public new static readonly string FunctionName = "_PARAMCOMPWITHTARGETNS_";
+            public static readonly new string FunctionName = "_PARAMCOMPWITHTARGETNS_";
 
 
 
@@ -684,7 +669,7 @@ namespace Mapsui.Providers.Wfs.Xml
             {
                 if (args.Contains(":"))
                 {
-                    string prefix = args.Substring(0, args.IndexOf(":", StringComparison.Ordinal));
+                    var prefix = args.Substring(0, args.IndexOf(":", StringComparison.Ordinal));
                     string ns;
                     if (!string.IsNullOrEmpty((ns = docContext.LookupNamespace(prefix))))
                         return args.Replace(prefix + ":", ns);
@@ -729,26 +714,17 @@ namespace Mapsui.Providers.Wfs.Xml
             /// <summary>
             /// Method implementing IXsltContextVariable
             /// </summary>
-            public bool IsLocal
-            {
-                get { return true; }
-            }
+            public bool IsLocal => true;
 
             /// <summary>
             /// Method implementing IXsltContextVariable
             /// </summary>
-            public bool IsParam
-            {
-                get { return true; }
-            }
+            public bool IsParam => true;
 
             /// <summary>
             /// Method implementing IXsltContextVariable
             /// </summary>
-            public XPathResultType VariableType
-            {
-                get { return XPathResultType.Any; }
-            }
+            public XPathResultType VariableType => XPathResultType.Any;
 
         }
 

--- a/Mapsui/Providers/Wfs/Xml/XPathQueryManager_CompiledExpressionsDecorator.cs
+++ b/Mapsui/Providers/Wfs/Xml/XPathQueryManager_CompiledExpressionsDecorator.cs
@@ -72,7 +72,7 @@ namespace Mapsui.Providers.Wfs.Xml
         public override IXPathQueryManager GetXPathQueryManagerInContext(XPathExpression xPath,
                                                                          DictionaryEntry[]? queryParameters = null)
         {
-            IXPathQueryManager xPathQueryManager = (queryParameters == null)
+            var xPathQueryManager = (queryParameters == null)
                                                        ? XPathQueryManager.GetXPathQueryManagerInContext(xPath)
                                                        : XPathQueryManager.GetXPathQueryManagerInContext(xPath,
                                                                                                           queryParameters);

--- a/Mapsui/Providers/Wms/Client.cs
+++ b/Mapsui/Providers/Wms/Client.cs
@@ -295,7 +295,7 @@ namespace Mapsui.Providers.Wms
                 if (WmsVersion != "1.0.0" && WmsVersion != "1.1.0" && WmsVersion != "1.1.1" && WmsVersion != "1.3.0")
                     throw new ApplicationException("WMS Version " + WmsVersion + " not supported");
 
-                _nsmgr.AddNamespace(String.Empty, "http://www.opengis.net/wms");
+                _nsmgr.AddNamespace(string.Empty, "http://www.opengis.net/wms");
                 _nsmgr.AddNamespace("sm", WmsVersion == "1.3.0" ? "http://www.opengis.net/wms" : "");
                 _nsmgr.AddNamespace("xlink", "http://www.w3.org/1999/xlink");
                 _nsmgr.AddNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
@@ -338,7 +338,7 @@ namespace Mapsui.Providers.Wms
             if (xnlKeywords != null)
             {
                 _serviceDescription.Keywords = new string[xnlKeywords.Count];
-                for (int i = 0; i < xnlKeywords.Count; i++)
+                for (var i = 0; i < xnlKeywords.Count; i++)
                     ServiceDescription.Keywords[i] = xnlKeywords[i].InnerText;
             }
             //Contact information
@@ -387,7 +387,7 @@ namespace Mapsui.Providers.Wms
             var layerNodes = xnCapability.SelectNodes("sm:Layer", _nsmgr);
             if (layerNodes != null && layerNodes.Count > 1)
             {
-                List<WmsServerLayer> layers = new List<WmsServerLayer>();
+                var layers = new List<WmsServerLayer>();
                 foreach (XmlNode l in layerNodes)
                 {
                     layers.Add(ParseLayer(l));
@@ -401,13 +401,13 @@ namespace Mapsui.Providers.Wms
             }
             else
             {
-                XmlNode xnLayer = xnCapability.SelectSingleNode("sm:Layer", _nsmgr);
+                var xnLayer = xnCapability.SelectSingleNode("sm:Layer", _nsmgr);
                 if (xnLayer == null)
                     throw new Exception("No layer tag found in Service Description");
                 Layer = ParseLayer(xnLayer);
             }
 
-            XmlNode xnException = xnCapability.SelectSingleNode("sm:Exception", _nsmgr);
+            var xnException = xnCapability.SelectSingleNode("sm:Exception", _nsmgr);
             if (xnException != null)
                 ParseExceptions(xnException);
 
@@ -420,11 +420,11 @@ namespace Mapsui.Providers.Wms
         /// <param name="xnlExceptionNode"></param>
         private void ParseExceptions(XmlNode xnlExceptionNode)
         {
-            XmlNodeList xnlFormats = xnlExceptionNode.SelectNodes("sm:Format", _nsmgr);
+            var xnlFormats = xnlExceptionNode.SelectNodes("sm:Format", _nsmgr);
             if (xnlFormats != null)
             {
                 _exceptionFormats = new string[xnlFormats.Count];
-                for (int i = 0; i < xnlFormats.Count; i++)
+                for (var i = 0; i < xnlFormats.Count; i++)
                 {
                     _exceptionFormats[i] = xnlFormats[i].InnerText;
                 }
@@ -437,10 +437,10 @@ namespace Mapsui.Providers.Wms
         /// <param name="xmlRequestNode"></param>
         private void ParseRequest(XmlNode xmlRequestNode)
         {
-            XmlNode xnGetMap = xmlRequestNode.SelectSingleNode("sm:GetMap", _nsmgr);
+            var xnGetMap = xmlRequestNode.SelectSingleNode("sm:GetMap", _nsmgr);
             ParseGetMapRequest(xnGetMap);
 
-            XmlNode xnGetFeatureInfo = xmlRequestNode.SelectSingleNode("sm:GetFeatureInfo", _nsmgr);
+            var xnGetFeatureInfo = xmlRequestNode.SelectSingleNode("sm:GetFeatureInfo", _nsmgr);
             if (xnGetFeatureInfo == null)
                 return;
 
@@ -449,11 +449,11 @@ namespace Mapsui.Providers.Wms
 
         private void ParseGetFeatureInfo(XmlNode getFeatureInfoRequestNodes)
         {
-            XmlNode xnlHttp = getFeatureInfoRequestNodes.SelectSingleNode("sm:DCPType/sm:HTTP", _nsmgr);
+            var xnlHttp = getFeatureInfoRequestNodes.SelectSingleNode("sm:DCPType/sm:HTTP", _nsmgr);
             if (xnlHttp != null && xnlHttp.HasChildNodes)
             {
                 GetFeatureInfoRequests = new WmsOnlineResource[xnlHttp.ChildNodes.Count];
-                for (int i = 0; i < xnlHttp.ChildNodes.Count; i++)
+                for (var i = 0; i < xnlHttp.ChildNodes.Count; i++)
                 {
                     var wor = new WmsOnlineResource
                     {
@@ -479,11 +479,11 @@ namespace Mapsui.Providers.Wms
         /// <param name="getMapRequestNodes"></param>
         private void ParseGetMapRequest(XmlNode getMapRequestNodes)
         {
-            XmlNode xnlHttp = getMapRequestNodes.SelectSingleNode("sm:DCPType/sm:HTTP", _nsmgr);
+            var xnlHttp = getMapRequestNodes.SelectSingleNode("sm:DCPType/sm:HTTP", _nsmgr);
             if (xnlHttp != null && xnlHttp.HasChildNodes)
             {
                 GetMapRequests = new WmsOnlineResource[xnlHttp.ChildNodes.Count];
-                for (int i = 0; i < xnlHttp.ChildNodes.Count; i++)
+                for (var i = 0; i < xnlHttp.ChildNodes.Count; i++)
                 {
                     var wor = new WmsOnlineResource
                     {
@@ -530,13 +530,13 @@ namespace Mapsui.Providers.Wms
             if (xnlKeywords != null)
             {
                 wmsServerLayer.Keywords = new string[xnlKeywords.Count];
-                for (int i = 0; i < xnlKeywords.Count; i++)
+                for (var i = 0; i < xnlKeywords.Count; i++)
                     wmsServerLayer.Keywords[i] = xnlKeywords[i].InnerText;
             }
 
             wmsServerLayer.CRS = ParseCrses(xmlLayer);
 
-            XmlNodeList xnlBoundingBox = xmlLayer.SelectNodes("sm:BoundingBox", _nsmgr);
+            var xnlBoundingBox = xmlLayer.SelectNodes("sm:BoundingBox", _nsmgr);
             if (xnlBoundingBox != null)
             {
                 wmsServerLayer.BoundingBoxes = new Dictionary<string, BoundingBox>();
@@ -559,7 +559,7 @@ namespace Mapsui.Providers.Wms
             if (xnlStyle != null)
             {
                 wmsServerLayer.Style = new WmsLayerStyle[xnlStyle.Count];
-                for (int i = 0; i < xnlStyle.Count; i++)
+                for (var i = 0; i < xnlStyle.Count; i++)
                 {
                     node = xnlStyle[i].SelectSingleNode("sm:Name", _nsmgr);
                     wmsServerLayer.Style[i].Name = node?.InnerText;
@@ -585,17 +585,19 @@ namespace Mapsui.Providers.Wms
                     node = xnlStyle[i].SelectSingleNode("sm:StyleSheetURL", _nsmgr);
                     if (node != null)
                     {
-                        wmsServerLayer.Style[i].StyleSheetUrl = new WmsOnlineResource();
-                        wmsServerLayer.Style[i].StyleSheetUrl.OnlineResource =
-                            node.SelectSingleNode("sm:OnlineResource", _nsmgr).Attributes["xlink:href"].InnerText;
+                        wmsServerLayer.Style[i].StyleSheetUrl = new WmsOnlineResource
+                        {
+                            OnlineResource =
+                            node.SelectSingleNode("sm:OnlineResource", _nsmgr).Attributes["xlink:href"].InnerText
+                        };
                     }
                 }
             }
-            XmlNodeList xnlLayers = xmlLayer.SelectNodes("sm:Layer", _nsmgr);
+            var xnlLayers = xmlLayer.SelectNodes("sm:Layer", _nsmgr);
             if (xnlLayers != null)
             {
                 wmsServerLayer.ChildLayers = new WmsServerLayer[xnlLayers.Count];
-                for (int i = 0; i < xnlLayers.Count; i++)
+                for (var i = 0; i < xnlLayers.Count; i++)
                     wmsServerLayer.ChildLayers[i] = ParseLayer(xnlLayers[i]);
             }
             node = xmlLayer.SelectSingleNode("sm:LatLonBoundingBox", _nsmgr);
@@ -615,17 +617,17 @@ namespace Mapsui.Providers.Wms
         {
             var crses = new List<string>();
 
-            XmlNodeList xnlSrs = xmlLayer.SelectNodes("sm:SRS", _nsmgr);
+            var xnlSrs = xmlLayer.SelectNodes("sm:SRS", _nsmgr);
             if (xnlSrs != null)
             {
-                for (int i = 0; i < xnlSrs.Count; i++)
+                for (var i = 0; i < xnlSrs.Count; i++)
                     crses.Add(xnlSrs[i].InnerText);
             }
 
-            XmlNodeList xnlCrs = xmlLayer.SelectNodes("sm:CRS", _nsmgr);
+            var xnlCrs = xmlLayer.SelectNodes("sm:CRS", _nsmgr);
             if (xnlCrs != null)
             {
-                for (int i = 0; i < xnlCrs.Count; i++)
+                for (var i = 0; i < xnlCrs.Count; i++)
                     crses.Add(xnlCrs[i].InnerText);
             }
 

--- a/Mapsui/Providers/Wms/WmsProvider.cs
+++ b/Mapsui/Providers/Wms/WmsProvider.cs
@@ -188,7 +188,7 @@ namespace Mapsui.Providers.Wms
                 return true;
             }
 
-            foreach (Client.WmsServerLayer childlayer in layer.ChildLayers)
+            foreach (var childlayer in layer.ChildLayers)
             {
                 if (FindLayer(childlayer, name, out result))
                     return true;
@@ -389,7 +389,7 @@ namespace Mapsui.Providers.Wms
             var legendUrls = new List<string>();
             if (LayerList != null && LayerList.Count > 0)
             {
-                foreach (string layer in LayerList)
+                foreach (var layer in LayerList)
                 {
                     if (FindLayer(_wmsClient.Layer, layer, out var result))
                     {
@@ -451,7 +451,7 @@ namespace Mapsui.Providers.Wms
         public bool? IsCrsSupported(string crs)
         {
             if (_wmsClient == null) return null;
-            return _wmsClient.Layer.CRS.FirstOrDefault(item => String.Equals(item.Trim(), crs.Trim(), StringComparison.CurrentCultureIgnoreCase)) != null;
+            return _wmsClient.Layer.CRS.FirstOrDefault(item => string.Equals(item.Trim(), crs.Trim(), StringComparison.CurrentCultureIgnoreCase)) != null;
         }
 
 

--- a/Mapsui/Rendering/RenderFetchStrategy.cs
+++ b/Mapsui/Rendering/RenderFetchStrategy.cs
@@ -26,7 +26,7 @@ namespace Mapsui.Rendering
             // to improve performance, convert the resolutions to a list so they can be walked up by
             // simply decrementing an index when the level index needs to change
             var resolutions = schema.Resolutions.OrderByDescending(pair => pair.Value.UnitsPerPixel).ToList();
-            for (int i = 0; i < resolutions.Count; i++)
+            for (var i = 0; i < resolutions.Count; i++)
             {
                 if (level == resolutions[i].Key)
                 {

--- a/Mapsui/Rendering/VisibleFeatureIterator.cs
+++ b/Mapsui/Rendering/VisibleFeatureIterator.cs
@@ -1,10 +1,9 @@
-using Mapsui.Layers;
-using Mapsui.Providers;
-using Mapsui.Styles;
-using Mapsui.Styles.Thematics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Mapsui.Layers;
+using Mapsui.Styles;
+using Mapsui.Styles.Thematics;
 
 namespace Mapsui.Rendering
 {

--- a/Mapsui/Utilities/ConcurrentHashSet.cs
+++ b/Mapsui/Utilities/ConcurrentHashSet.cs
@@ -263,8 +263,10 @@ namespace ConcurrentCollections
         /// successfully; false if it already exists.</returns>
         /// <exception cref="T:System.OverflowException">The <see cref="ConcurrentHashSet{T}"/>
         /// contains too many items.</exception>
-        public bool Add(T item) =>
-            AddInternal(item, _comparer.GetHashCode(item), true);
+        public bool Add(T item)
+        {
+            return AddInternal(item, _comparer.GetHashCode(item), true);
+        }
 
         /// <summary>
         /// Removes all items from the <see cref="ConcurrentHashSet{T}"/>.
@@ -329,7 +331,7 @@ namespace ConcurrentCollections
             {
                 var tables = _tables;
 
-                GetBucketAndLockNo(hashcode, out int bucketNo, out int lockNo, tables.Buckets.Length, tables.Locks.Length);
+                GetBucketAndLockNo(hashcode, out var bucketNo, out var lockNo, tables.Buckets.Length, tables.Locks.Length);
 
                 lock (tables.Locks[lockNo])
                 {
@@ -367,7 +369,10 @@ namespace ConcurrentCollections
             }
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
 
         /// <summary>Returns an enumerator that iterates through the <see
         /// cref="ConcurrentHashSet{T}"/>.</summary>
@@ -395,7 +400,10 @@ namespace ConcurrentCollections
             }
         }
 
-        void ICollection<T>.Add(T item) => Add(item);
+        void ICollection<T>.Add(T item)
+        {
+            Add(item);
+        }
 
         bool ICollection<T>.IsReadOnly => false;
 
@@ -429,7 +437,10 @@ namespace ConcurrentCollections
             }
         }
 
-        bool ICollection<T>.Remove(T item) => TryRemove(item);
+        bool ICollection<T>.Remove(T item)
+        {
+            return TryRemove(item);
+        }
 
         private void InitializeFromCollection(IEnumerable<T> collection)
         {
@@ -450,7 +461,7 @@ namespace ConcurrentCollections
             {
                 var tables = _tables;
 
-                GetBucketAndLockNo(hashcode, out int bucketNo, out int lockNo, tables.Buckets.Length, tables.Locks.Length);
+                GetBucketAndLockNo(hashcode, out var bucketNo, out var lockNo, tables.Buckets.Length, tables.Locks.Length);
 
                 var resizeDesired = false;
                 var lockTaken = false;
@@ -641,7 +652,7 @@ namespace ConcurrentCollections
                     while (current != null)
                     {
                         var next = current.Next;
-                        GetBucketAndLockNo(current.Hashcode, out int newBucketNo, out int newLockNo, newBuckets.Length, newLocks.Length);
+                        GetBucketAndLockNo(current.Hashcode, out var newBucketNo, out var newLockNo, newBuckets.Length, newLocks.Length);
 
                         newBuckets[newBucketNo] = new Node(current.Item, current.Hashcode, newBuckets[newBucketNo]);
 


### PR DESCRIPTION
Last week I have been adding more fixers step by step to see what they did and if I could accept it. I now added them all. There are still 4 that I can not add. They are moved back down if I close and open the profile again. I think this is because they apply to Visual Basic, bad design to allow adding them in the first place.  So the image below is the full profile. The MR applies them to Mapsui and Mapsui.Core. I think this can be applied to everything else like this. So, that simplifies things a lot, we can just go for full cleanup. After that there are the issues that can be seen in the messages. There are a lot more now because of the null references, we will just have to work on it. 

![image](https://user-images.githubusercontent.com/963462/139525407-56264cdb-8000-4131-b0da-4a8db0a476b5.png)

btw, if we go for this full cleanup it would make sense to have build errors or warnings on this, and perhaps pre commit hooks. If anyone knows anything about this let me know.

