### PR TITLE
Nullable fixes in skia rendering

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,7 @@
 
   <ItemGroup>
 	  <Compile Include="$(MSBuildThisFileDirectory)/Nullable.cs" />
+	  <Compile Include="$(MSBuildThisFileDirectory)/InitProperty.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Unix'">

--- a/InitProperty.cs
+++ b/InitProperty.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+#if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal class IsExternalInit{}
+#endif
+}

--- a/Mapsui.Core/IReadOnlyViewport.cs
+++ b/Mapsui.Core/IReadOnlyViewport.cs
@@ -31,7 +31,7 @@ namespace Mapsui
         /// This MRect is horizontally and vertically aligned, even if the viewport
         /// is rotated. So this MRect perhaps contain parts, that are not visible.
         /// </remarks>
-        MRect Extent { get; }
+        MRect? Extent { get; }
 
         /// <summary>
         /// Width of viewport in screen pixels
@@ -111,6 +111,6 @@ namespace Mapsui
         /// If viewport is rotated, this corner points are not horizontally or vertically
         /// aligned.
         /// </remarks>
-        MQuad WindowExtent { get; }
+        MQuad? WindowExtent { get; }
     }
 }

--- a/Mapsui.Core/Layers/FetchInfo.cs
+++ b/Mapsui.Core/Layers/FetchInfo.cs
@@ -6,13 +6,13 @@
 
         public FetchInfo(FetchInfo fetchInfo)
         {
-            Extent = new MRect(fetchInfo.Extent);
+            Extent = fetchInfo.Extent != null ? new MRect(fetchInfo.Extent) : null;
             Resolution = fetchInfo.Resolution;
             CRS = fetchInfo.CRS;
             ChangeType = fetchInfo.ChangeType;
         }
 
-        public MRect Extent { get; set; }
+        public MRect? Extent { get; set; }
         public double Resolution { get; set; }
         public string? CRS { get; set; }
         public ChangeType ChangeType { get; set; }

--- a/Mapsui.Core/Layers/IFeature.cs
+++ b/Mapsui.Core/Layers/IFeature.cs
@@ -9,6 +9,6 @@ namespace Mapsui.Layers
         ICollection<IStyle> Styles { get; }
         object this[string key] { get; set; }
         IEnumerable<string> Fields { get; }
-        MRect BoundingBox { get; }
+        MRect? BoundingBox { get; }
     }
 }

--- a/Mapsui.Core/Layers/IFeature.cs
+++ b/Mapsui.Core/Layers/IFeature.cs
@@ -7,7 +7,7 @@ namespace Mapsui.Layers
     {
         IDictionary<IStyle, object> RenderedGeometry { get; }
         ICollection<IStyle> Styles { get; }
-        object this[string key] { get; set; }
+        object? this[string key] { get; set; }
         IEnumerable<string> Fields { get; }
         MRect? BoundingBox { get; }
     }

--- a/Mapsui.Core/Layers/LayerCollectionChangedEventArgs.cs
+++ b/Mapsui.Core/Layers/LayerCollectionChangedEventArgs.cs
@@ -5,9 +5,9 @@ namespace Mapsui.Layers
 {
     public class LayerCollectionChangedEventArgs : EventArgs
     {
-        public IEnumerable<ILayer> AddedLayers { get; }
-        public IEnumerable<ILayer> RemovedLayers { get; }
-        public IEnumerable<ILayer> MovedLayers { get; }
+        public IEnumerable<ILayer>? AddedLayers { get; }
+        public IEnumerable<ILayer>? RemovedLayers { get; }
+        public IEnumerable<ILayer>? MovedLayers { get; }
 
         public LayerCollectionChangedEventArgs(IEnumerable<ILayer>? added = null, IEnumerable<ILayer>? removed = null, IEnumerable<ILayer>? moved = null)
         {

--- a/Mapsui.Core/MRect.cs
+++ b/Mapsui.Core/MRect.cs
@@ -336,12 +336,12 @@ namespace Mapsui
         /// <param name="box1"></param>
         /// <param name="box2"></param>
         /// <returns></returns>
-        public static MRect Join(MRect? box1, MRect? box2)
+        public static MRect? Join(MRect? box1, MRect? box2)
         {
             if ((box1 == null) && (box2 == null))
                 return null;
             if (box1 == null)
-                return box2.Clone();
+                return box2!.Clone();
             return box1.Join(box2);
         }
 
@@ -350,7 +350,7 @@ namespace Mapsui
         /// </summary>
         /// <param name="boxes">Boxes to join</param>
         /// <returns>Combined MRect</returns>
-        public static MRect Join(MRect[]? boxes)
+        public static MRect? Join(MRect[]? boxes)
         {
             if (boxes == null) return null;
             if (boxes.Length == 1) return boxes[0];

--- a/Mapsui.Core/MRect.cs
+++ b/Mapsui.Core/MRect.cs
@@ -30,8 +30,6 @@ namespace Mapsui
     /// </remarks>
     public class MRect : IEquatable<MRect>
     {
-        public MRect() { }
-
         public MRect(MRect rect) : this(
             rect.Min.X,
             rect.Min.Y,
@@ -69,9 +67,6 @@ namespace Mapsui
         /// </summary>
         public MRect(IEnumerable<MRect> rects)
         {
-            Max = null;
-            Min = null;
-
             foreach (var rect in rects)
             {
                 Min ??= rect.Min.Clone();
@@ -82,6 +77,9 @@ namespace Mapsui
                 Max.X = Math.Max(rect.Max.X, Max.X);
                 Max.Y = Math.Max(rect.Max.Y, Max.Y);
             }
+
+            if (this.Min == null) throw new ArgumentException("Empty Collection", nameof(rects));
+            if (this.Max == null) throw new ArgumentException("Empty Collection", nameof(rects));
         }
 
         public double MinX => Min.X;

--- a/Mapsui.Core/Map.cs
+++ b/Mapsui.Core/Map.cs
@@ -136,7 +136,7 @@ namespace Mapsui
         /// Gets the extent of the map based on the extent of all the layers in the layers collection
         /// </summary>
         /// <returns>Full map extent</returns>
-        public MRect Envelope
+        public MRect? Envelope
         {
             get
             {

--- a/Mapsui.Core/Navigator.cs
+++ b/Mapsui.Core/Navigator.cs
@@ -24,7 +24,7 @@ namespace Mapsui
             set => _defaultDuration = value < 0 ? 0 : value;
         }
 
-        public EventHandler<ChangeType> Navigated { get; set; }
+        public EventHandler<ChangeType>? Navigated { get; set; }
 
         public Navigator(Map map, IViewport viewport)
         {

--- a/Mapsui.Core/Rendering/IRenderInfo.cs
+++ b/Mapsui.Core/Rendering/IRenderInfo.cs
@@ -6,8 +6,8 @@ namespace Mapsui.Rendering
 {
     public interface IRenderInfo
     {
-        MapInfo GetMapInfo(double screenX, double screenY, IReadOnlyViewport viewport, IEnumerable<ILayer> layers, int margin = 0);
-        MapInfo GetMapInfo(MPoint screenPosition, IReadOnlyViewport viewport, IEnumerable<ILayer> layers, int margin = 0);
+        MapInfo? GetMapInfo(double screenX, double screenY, IReadOnlyViewport viewport, IEnumerable<ILayer> layers, int margin = 0);
+        MapInfo? GetMapInfo(MPoint screenPosition, IReadOnlyViewport viewport, IEnumerable<ILayer> layers, int margin = 0);
 
     }
 }

--- a/Mapsui.Core/Styles/Brush.cs
+++ b/Mapsui.Core/Styles/Brush.cs
@@ -22,12 +22,12 @@ namespace Mapsui.Styles
             FillStyle = brush.FillStyle;
         }
 
-        public Color Color { get; set; }
+        public Color? Color { get; set; }
 
         // todo: 
         // Perhaps rename to something like SecondaryColor. The 'Color' 
         // field is itself a background in many cases. This is confusing
-        public Color Background { get; set; }
+        public Color? Background { get; set; }
 
         /// <summary>
         /// This identifies bitmap in the BitmapRegistry
@@ -57,9 +57,12 @@ namespace Mapsui.Styles
             return Equals(brush);
         }
 
-        public bool Equals(Brush brush)
+        public bool Equals(Brush? brush)
         {
-            if ((Color == null) ^ (brush.Color == null))
+            if (brush is null)
+                return false;
+
+            if ((Color is null) ^ (brush.Color is null))
             {
                 return false;
             }
@@ -73,7 +76,7 @@ namespace Mapsui.Styles
 
         public override int GetHashCode()
         {
-            return Color == null ? 0 : Color.GetHashCode();
+            return Color is null ? 0 : Color.GetHashCode();
         }
 
         public static bool operator ==(Brush brush1, Brush brush2)

--- a/Mapsui.Core/Styles/CalloutStyle.cs
+++ b/Mapsui.Core/Styles/CalloutStyle.cs
@@ -124,7 +124,7 @@ namespace Mapsui.Styles
         /// <summary>
         /// MRect relative to offset point
         /// </summary>
-        public MRect MRect = new();
+        public MRect? MRect;
 
         /// <summary>
         /// Gets or sets the rotation of the Callout in degrees (clockwise is positive)
@@ -324,7 +324,7 @@ namespace Mapsui.Styles
         /// <summary>
         /// Content of Callout title label
         /// </summary>
-        public string Title
+        public string? Title
         {
             get => _title;
             set
@@ -340,7 +340,7 @@ namespace Mapsui.Styles
         /// <summary>
         /// Font color to render title
         /// </summary>
-        public Color TitleFontColor
+        public Color? TitleFontColor
         {
             get => _titleFontColor;
             set
@@ -369,7 +369,7 @@ namespace Mapsui.Styles
         /// <summary>
         /// Content of Callout subtitle label
         /// </summary>
-        public string Subtitle
+        public string? Subtitle
         {
             get => _subtitle;
             set
@@ -385,7 +385,7 @@ namespace Mapsui.Styles
         /// <summary>
         /// Font color to render subtitle
         /// </summary>
-        public Color SubtitleFontColor
+        public Color? SubtitleFontColor
         {
             get => _subtitleFontColor;
             set

--- a/Mapsui.Core/Styles/Color.cs
+++ b/Mapsui.Core/Styles/Color.cs
@@ -98,7 +98,7 @@ namespace Mapsui.Styles
         /// </summary>
         /// <param name="from">String with HTML color representation or function like rgb() or hsl()</param>
         /// <returns>Converted Mapsui Color</returns>
-        public static Color FromString(string from)
+        public static Color? FromString(string from)
         {
             Color? result = null;
 

--- a/Mapsui.Core/Styles/Pen.cs
+++ b/Mapsui.Core/Styles/Pen.cs
@@ -61,8 +61,11 @@ namespace Mapsui.Styles
             return Equals(pen);
         }
 
-        public bool Equals(Pen pen)
+        public bool Equals(Pen? pen)
         {
+            if (pen == null)
+                return false;
+
             // ReSharper disable once CompareOfFloatsByEqualityOperator
             if (Width != pen.Width) return false;
 

--- a/Mapsui.Core/Styles/Sprite.cs
+++ b/Mapsui.Core/Styles/Sprite.cs
@@ -8,7 +8,7 @@
         public int Width { get; }
         public int Height { get; }
         public float PixelRatio { get; }
-        public object Data { get; set; }
+        public object? Data { get; set; }
 
         public Sprite(int atlas, int x, int y, int width, int height, float pixelRatio)
         {

--- a/Mapsui.Core/Styles/VectorStyle.cs
+++ b/Mapsui.Core/Styles/VectorStyle.cs
@@ -12,19 +12,19 @@ namespace Mapsui.Styles
         /// <summary>
         /// Line style for line geometries
         /// </summary>
-        public Pen Line { get; set; }
+        public Pen? Line { get; set; }
 
         /// <summary>
         /// Outline style for line and polygon geometries
         /// </summary>
-        public Pen Outline { get; set; }
+        public Pen? Outline { get; set; }
 
         /// <summary>
         /// Fill style for Polygon geometries
         /// </summary>
-        public Brush Fill { get; set; }
+        public Brush? Fill { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is VectorStyle style))
             {
@@ -40,32 +40,32 @@ namespace Mapsui.Styles
                 return false;
             }
 
-            if ((Line == null) ^ (vectorStyle.Line == null))
+            if ((Line is null) ^ (vectorStyle.Line is null))
             {
                 return false;
             }
 
-            if (Line != null && !Line.Equals(vectorStyle.Line))
+            if (Line is not null && !Line.Equals(vectorStyle.Line))
             {
                 return false;
             }
 
-            if ((Outline == null) ^ (vectorStyle.Outline == null))
+            if ((Outline is null) ^ (vectorStyle.Outline is null))
             {
                 return false;
             }
 
-            if (Outline != null && !Outline.Equals(vectorStyle.Outline))
+            if (Outline is not null && !Outline.Equals(vectorStyle.Outline))
             {
                 return false;
             }
 
-            if ((Fill == null) ^ (vectorStyle.Fill == null))
+            if ((Fill is null) ^ (vectorStyle.Fill is null))
             {
                 return false;
             }
 
-            if (Fill != null && !Fill.Equals(vectorStyle.Fill))
+            if (Fill is not null && !Fill.Equals(vectorStyle.Fill))
             {
                 return false;
             }
@@ -75,9 +75,9 @@ namespace Mapsui.Styles
 
         public override int GetHashCode()
         {
-            return (Line == null ? 0 : Line.GetHashCode())
-                ^ (Outline == null ? 0 : Outline.GetHashCode())
-                ^ (Fill == null ? 0 : Fill.GetHashCode())
+            return (Line is null ? 0 : Line.GetHashCode())
+                ^ (Outline is null ? 0 : Outline.GetHashCode())
+                ^ (Fill is null ? 0 : Fill.GetHashCode())
                 ^ base.GetHashCode();
         }
 

--- a/Mapsui.Core/UI/IViewportLimiter.cs
+++ b/Mapsui.Core/UI/IViewportLimiter.cs
@@ -16,7 +16,7 @@ namespace Mapsui.UI
         /// </summary>
         MinMax? ZoomLimits { get; set; }
 
-        void Limit(IViewport viewport, IReadOnlyList<double> mapResolutions, MRect mapEnvelope);
+        void Limit(IViewport viewport, IReadOnlyList<double> mapResolutions, MRect? mapEnvelope);
 
         double LimitResolution(double resolution, double screenWidth, double screenHeight,
             IReadOnlyList<double> mapResolutions, MRect mapEnvelope);

--- a/Mapsui.Core/UI/ViewportLimiterKeepWithin.cs
+++ b/Mapsui.Core/UI/ViewportLimiterKeepWithin.cs
@@ -22,7 +22,7 @@ namespace Mapsui.UI
         /// </summary>
         public MinMax? ZoomLimits { get; set; }
 
-        private MinMax GetExtremes(IReadOnlyList<double>? resolutions)
+        private MinMax? GetExtremes(IReadOnlyList<double>? resolutions)
         {
             if (resolutions == null || resolutions.Count == 0) return null;
             resolutions = resolutions.OrderByDescending(r => r).ToList();

--- a/Mapsui.Core/UI/ViewportLimiterWithoutLimits.cs
+++ b/Mapsui.Core/UI/ViewportLimiterWithoutLimits.cs
@@ -17,7 +17,7 @@ namespace Mapsui.UI
             return resolution;
         }
 
-        public void LimitExtent(IViewport viewport, MRect mapEnvelope)
+        public void LimitExtent(IViewport viewport, MRect? mapEnvelope)
         {
         }
     }

--- a/Mapsui.Core/Widgets/ScaleBar/ScaleBarWidget.cs
+++ b/Mapsui.Core/Widgets/ScaleBar/ScaleBarWidget.cs
@@ -34,8 +34,8 @@ namespace Mapsui.Widgets.ScaleBar
     /// </summary>
     public class ScaleBarWidget : Widget, INotifyPropertyChanged
     {
-        private readonly Map _map;
-        private readonly ITransformation _transformation;
+        private readonly Map? _map;
+        private readonly ITransformation? _transformation;
         // Instead of using this property we could initialize _transformation with ProjectionDefaults.Transformation
         // in the constructor but in that way the overriding of ProjectionDefaults.Transformation would not have 
         // effect if it was set after the ScaleBarWidget was constructed.
@@ -50,7 +50,7 @@ namespace Mapsui.Widgets.ScaleBar
         private static readonly Font DefaultFont = new() { FontFamily = "Arial", Size = 10 };
 
 
-        public ScaleBarWidget(Map map, ITransformation transformation = null)
+        public ScaleBarWidget(Map map, ITransformation? transformation = null)
         {
             _map = map;
             _transformation = transformation;
@@ -224,12 +224,12 @@ namespace Mapsui.Widgets.ScaleBar
             }
         }
 
-        private IUnitConverter _secondaryUnitConverter;
+        private IUnitConverter? _secondaryUnitConverter;
 
         /// <summary>
         /// Secondary unit converter for lower text if ScaleBarMode is Both. Default is ImperialUnitConverter.
         /// </summary>
-        public IUnitConverter SecondaryUnitConverter
+        public IUnitConverter? SecondaryUnitConverter
         {
             get => _secondaryUnitConverter;
             set
@@ -278,7 +278,7 @@ namespace Mapsui.Widgets.ScaleBar
         /// Length of lower scalebar
         /// Text of lower scalebar
         /// </returns>
-        public (float scaleBarLength1, string scaleBarText1, float scaleBarLength2, string scaleBarText2)
+        public (float scaleBarLength1, string? scaleBarText1, float scaleBarLength2, string? scaleBarText2)
             GetScaleBarLengthAndText(IReadOnlyViewport viewport)
         {
             if (_map == null) return (0, null, 0, null);
@@ -289,7 +289,7 @@ namespace Mapsui.Widgets.ScaleBar
             (length1, text1) = CalculateScaleBarLengthAndValue(_map, Transformation, viewport, MaxWidth, UnitConverter);
 
             float length2;
-            string text2;
+            string? text2;
 
             if (SecondaryUnitConverter != null)
                 (length2, text2) = CalculateScaleBarLengthAndValue(_map, Transformation, viewport, MaxWidth, SecondaryUnitConverter);
@@ -307,7 +307,7 @@ namespace Mapsui.Widgets.ScaleBar
         /// <param name="scaleBarLength2">Length of lower scalebar</param>
         /// <param name="stroke">Width of line</param>
         /// <returns>Array with pairs of Points. First is always the start point, the second is the end point.</returns>
-        public MPoint[] GetScaleBarLinePositions(IReadOnlyViewport viewport, float scaleBarLength1, float scaleBarLength2, float stroke)
+        public MPoint[]? GetScaleBarLinePositions(IReadOnlyViewport viewport, float scaleBarLength1, float scaleBarLength2, float stroke)
         {
             MPoint[]? points = null;
 

--- a/Mapsui.Geometries/BoundingBox.cs
+++ b/Mapsui.Geometries/BoundingBox.cs
@@ -349,7 +349,7 @@ namespace Mapsui.Geometries
         /// <param name="box1"></param>
         /// <param name="box2"></param>
         /// <returns></returns>
-        public static BoundingBox Join(BoundingBox? box1, BoundingBox? box2)
+        public static BoundingBox? Join(BoundingBox? box1, BoundingBox? box2)
         {
             if ((box1 == null) && (box2 == null))
                 return null;
@@ -363,7 +363,7 @@ namespace Mapsui.Geometries
         /// </summary>
         /// <param name="boxes">Boxes to join</param>
         /// <returns>Combined BoundingBox</returns>
-        public static BoundingBox Join(BoundingBox[]? boxes)
+        public static BoundingBox? Join(BoundingBox[]? boxes)
         {
             if (boxes == null) return null;
             if (boxes.Length == 1) return boxes[0];

--- a/Mapsui.Geometries/BoundingBox.cs
+++ b/Mapsui.Geometries/BoundingBox.cs
@@ -335,7 +335,7 @@ namespace Mapsui.Geometries
         /// </summary>
         /// <param name="box">Boundingbox to join with</param>
         /// <returns>Boundingbox containing both boundingboxes</returns>
-        public BoundingBox Join(BoundingBox? box)
+        public BoundingBox? Join(BoundingBox? box)
         {
             if (box == null)
                 return Clone();
@@ -379,7 +379,7 @@ namespace Mapsui.Geometries
         ///     Increases the size of the boundingbox by the givent amount in all directions
         /// </summary>
         /// <param name="amount">Amount to grow in all directions</param>
-        public BoundingBox Grow(double amount)
+        public BoundingBox? Grow(double amount)
         {
             var box = Clone();
             box.Min.X -= amount;
@@ -395,7 +395,7 @@ namespace Mapsui.Geometries
         /// </summary>
         /// <param name="amountInX">Amount to grow in horizontal direction</param>
         /// <param name="amountInY">Amount to grow in vertical direction</param>
-        public BoundingBox Grow(double amountInX, double amountInY)
+        public BoundingBox? Grow(double amountInX, double amountInY)
         {
             var box = Clone();
             box.Min.X -= amountInX;
@@ -496,7 +496,7 @@ namespace Mapsui.Geometries
         ///     Creates a copy of the BoundingBox
         /// </summary>
         /// <returns></returns>
-        public BoundingBox Clone()
+        public BoundingBox? Clone()
         {
             return new BoundingBox(Min.X, Min.Y, Max.X, Max.Y);
         }

--- a/Mapsui.Geometries/Geometry.cs
+++ b/Mapsui.Geometries/Geometry.cs
@@ -61,7 +61,7 @@ namespace Mapsui.Geometries
         }
 
         [Obsolete("Use the BoundingBox field instead")]
-        public BoundingBox GetBoundingBox()
+        public BoundingBox? GetBoundingBox()
         {
             return BoundingBox;
         }
@@ -70,7 +70,7 @@ namespace Mapsui.Geometries
         ///     The minimum bounding box for this <see cref="Geometry" />, returned as a <see cref="Geometries.BoundingBox" />.
         /// </summary>
         /// <returns></returns>
-        public abstract BoundingBox BoundingBox { get; }
+        public abstract BoundingBox? BoundingBox { get; }
 
         /// <summary>
         ///     Exports this <see cref="Geometry" /> to a specific well-known text representation of <see cref="Geometry" />.

--- a/Mapsui.Geometries/GeometryCollection.cs
+++ b/Mapsui.Geometries/GeometryCollection.cs
@@ -112,7 +112,7 @@ namespace Mapsui.Geometries
         }
 
         [Obsolete("Use the BoundingBox field instead")]
-        public new BoundingBox GetBoundingBox()
+        public new BoundingBox? GetBoundingBox()
         {
             return BoundingBox;
         }

--- a/Mapsui.Geometries/GeometryCollection.cs
+++ b/Mapsui.Geometries/GeometryCollection.cs
@@ -121,7 +121,7 @@ namespace Mapsui.Geometries
         ///     The minimum bounding box for this Geometry, returned as a BoundingBox.
         /// </summary>
         /// <returns></returns>
-        public override BoundingBox BoundingBox
+        public override BoundingBox? BoundingBox
         {
             get
             {

--- a/Mapsui.Geometries/IGeometry.cs
+++ b/Mapsui.Geometries/IGeometry.cs
@@ -35,10 +35,10 @@ namespace Mapsui.Geometries
         ///     The minimum <see cref="Geometries.BoundingBox" /> for this <see cref="Geometry" />.
         /// </summary>
         /// <returns><see cref="Geometries.BoundingBox" /> for this <see cref="Geometry" /></returns>
-        BoundingBox BoundingBox { get; }
+        BoundingBox? BoundingBox { get; }
 
         [Obsolete("Use the BoundingBox field instead")]
-        BoundingBox GetBoundingBox();
+        BoundingBox? GetBoundingBox();
 
         /// <summary>
         ///     Exports this <see cref="Geometry" /> to a specific well-known text representation of <see cref="Geometry" />.

--- a/Mapsui.Geometries/IRaster.cs
+++ b/Mapsui.Geometries/IRaster.cs
@@ -6,6 +6,6 @@ namespace Mapsui.Geometries
     {
         MemoryStream Data { get; }
         long TickFetched { get; }
-        new BoundingBox BoundingBox { get; }
+        new BoundingBox? BoundingBox { get; }
     }
 }

--- a/Mapsui.Geometries/LineString.cs
+++ b/Mapsui.Geometries/LineString.cs
@@ -135,7 +135,7 @@ namespace Mapsui.Geometries
         ///     The minimum bounding box for this Geometry.
         /// </summary>
         /// <returns>BoundingBox for this geometry</returns>
-        public override BoundingBox BoundingBox
+        public override BoundingBox? BoundingBox
         {
             get
             {

--- a/Mapsui.Geometries/MultiLineString.cs
+++ b/Mapsui.Geometries/MultiLineString.cs
@@ -139,7 +139,7 @@ namespace Mapsui.Geometries
         ///     The minimum bounding box for this Geometry.
         /// </summary>
         /// <returns></returns>
-        public override BoundingBox BoundingBox
+        public override BoundingBox? BoundingBox
         {
             get
             {

--- a/Mapsui.Geometries/MultiPoint.cs
+++ b/Mapsui.Geometries/MultiPoint.cs
@@ -103,7 +103,7 @@ namespace Mapsui.Geometries
         ///     The minimum bounding box for this Geometry.
         /// </summary>
         /// <returns></returns>
-        public override BoundingBox BoundingBox
+        public override BoundingBox? BoundingBox
         {
             get
             {

--- a/Mapsui.Geometries/MultiPolygon.cs
+++ b/Mapsui.Geometries/MultiPolygon.cs
@@ -113,7 +113,7 @@ namespace Mapsui.Geometries
         }
 
         [Obsolete("Use the BoundingBox field instead")]
-        public new BoundingBox GetBoundingBox()
+        public new BoundingBox? GetBoundingBox()
         {
             return BoundingBox;
         }

--- a/Mapsui.Geometries/MultiPolygon.cs
+++ b/Mapsui.Geometries/MultiPolygon.cs
@@ -121,7 +121,7 @@ namespace Mapsui.Geometries
         ///     Returns the bounding box of the object
         /// </summary>
         /// <returns>bounding box</returns>
-        public override BoundingBox BoundingBox
+        public override BoundingBox? BoundingBox
         {
             get
             {

--- a/Mapsui.Geometries/Point.cs
+++ b/Mapsui.Geometries/Point.cs
@@ -297,7 +297,7 @@ namespace Mapsui.Geometries
         ///     The minimum bounding box for this Geometry.
         /// </summary>
         /// <returns></returns>
-        public override BoundingBox BoundingBox => _isEmpty ? null : new BoundingBox(X, Y, X, Y);
+        public override BoundingBox? BoundingBox => _isEmpty ? null : new BoundingBox(X, Y, X, Y);
 
         /// <summary>
         ///     Calculates a new point by rotating this point clockwise about the specified center point

--- a/Mapsui.Geometries/Polygon.cs
+++ b/Mapsui.Geometries/Polygon.cs
@@ -108,7 +108,7 @@ namespace Mapsui.Geometries
         ///     Returns the bounding box of the object
         /// </summary>
         /// <returns>bounding box</returns>
-        public override BoundingBox BoundingBox
+        public override BoundingBox? BoundingBox
         {
             get
             {

--- a/Mapsui.Geometries/Raster.cs
+++ b/Mapsui.Geometries/Raster.cs
@@ -7,9 +7,9 @@ namespace Mapsui.Geometries
 {
     public class Raster : Geometry, IRaster
     {
-        private readonly BoundingBox _boundingBox;
+        private readonly BoundingBox? _boundingBox;
 
-        public Raster(MemoryStream data, BoundingBox box)
+        public Raster(MemoryStream data, BoundingBox? box)
         {
             Data = data;
             _boundingBox = box;
@@ -19,7 +19,7 @@ namespace Mapsui.Geometries
         public MemoryStream Data { get; }
         public long TickFetched { get; }
 
-        public override BoundingBox BoundingBox => _boundingBox;
+        public override BoundingBox? BoundingBox => _boundingBox;
 
         public new string AsText()
         {

--- a/Mapsui.Rendering.Skia/BitmapHelper.cs
+++ b/Mapsui.Rendering.Skia/BitmapHelper.cs
@@ -9,7 +9,7 @@ namespace Mapsui.Rendering.Skia
 {
     public static class BitmapHelper
     {
-        public static BitmapInfo LoadBitmap(object bitmapStream)
+        public static BitmapInfo? LoadBitmap(object bitmapStream)
         {
             // todo: Our BitmapRegistry stores not only bitmaps. Perhaps we should store a class in it
             // which has all information. So we should have a SymbolImageRegistry in which we store a

--- a/Mapsui.Rendering.Skia/BitmapHelper.cs
+++ b/Mapsui.Rendering.Skia/BitmapHelper.cs
@@ -9,7 +9,7 @@ namespace Mapsui.Rendering.Skia
 {
     public static class BitmapHelper
     {
-        public static BitmapInfo? LoadBitmap(object bitmapStream)
+        public static BitmapInfo? LoadBitmap(object? bitmapStream)
         {
             // todo: Our BitmapRegistry stores not only bitmaps. Perhaps we should store a class in it
             // which has all information. So we should have a SymbolImageRegistry in which we store a

--- a/Mapsui.Rendering.Skia/BitmapInfo.cs
+++ b/Mapsui.Rendering.Skia/BitmapInfo.cs
@@ -17,7 +17,7 @@ namespace Mapsui.Rendering.Skia
 
         public BitmapType Type { get; private set; }
 
-        public SKImage Bitmap
+        public SKImage? Bitmap
         {
             get
             {
@@ -33,7 +33,7 @@ namespace Mapsui.Rendering.Skia
             }
         }
 
-        public SKSvg Svg
+        public SKSvg? Svg
         {
             get
             {
@@ -49,7 +49,7 @@ namespace Mapsui.Rendering.Skia
             }
         }
 
-        public Sprite Sprite
+        public Sprite? Sprite
         {
             get
             {

--- a/Mapsui.Rendering.Skia/BitmapInfo.cs
+++ b/Mapsui.Rendering.Skia/BitmapInfo.cs
@@ -22,7 +22,7 @@ namespace Mapsui.Rendering.Skia
             get
             {
                 if (Type == BitmapType.Bitmap)
-                    return (SKImage)_data;
+                    return _data as SKImage;
                 else
                     return null;
             }
@@ -38,7 +38,7 @@ namespace Mapsui.Rendering.Skia
             get
             {
                 if (Type == BitmapType.Svg)
-                    return (SKSvg)_data;
+                    return _data as SKSvg;
                 else
                     return null;
             }
@@ -54,7 +54,7 @@ namespace Mapsui.Rendering.Skia
             get
             {
                 if (Type == BitmapType.Sprite)
-                    return (Sprite)_data;
+                    return _data as Sprite;
                 else
                     return null;
             }
@@ -74,11 +74,11 @@ namespace Mapsui.Rendering.Skia
                 switch (Type)
                 {
                     case BitmapType.Bitmap:
-                        return Bitmap.Width;
+                        return Bitmap?.Width ?? 0;
                     case BitmapType.Svg:
-                        return Svg.Picture.CullRect.Width;
+                        return Svg?.Picture?.CullRect.Width ?? 0;
                     case BitmapType.Sprite:
-                        return ((Sprite)_data).Width;
+                        return Sprite?.Width ?? 0;
                     default:
                         return 0;
                 }
@@ -92,11 +92,11 @@ namespace Mapsui.Rendering.Skia
                 switch (Type)
                 {
                     case BitmapType.Bitmap:
-                        return Bitmap.Height;
+                        return Bitmap?.Height ?? 0;
                     case BitmapType.Svg:
-                        return Svg.Picture.CullRect.Height;
+                        return Svg?.Picture?.CullRect.Height ?? 0;
                     case BitmapType.Sprite:
-                        return ((Sprite)_data).Height;
+                        return Sprite?.Height ?? 0;
                     default:
                         return 0;
                 }

--- a/Mapsui.Rendering.Skia/ImageStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/ImageStyleRenderer.cs
@@ -24,6 +24,9 @@ namespace Mapsui.Rendering.Skia
             switch (bitmap.Type)
             {
                 case BitmapType.Bitmap:
+                    if (bitmap.Bitmap == null)
+                        return;
+
                     BitmapRenderer.Draw(canvas, bitmap.Bitmap,
                         (float)destination.X, (float)destination.Y,
                         rotation,
@@ -31,6 +34,9 @@ namespace Mapsui.Rendering.Skia
                         opacity: opacity, scale: (float)symbolStyle.SymbolScale);
                     break;
                 case BitmapType.Svg:
+                    if (bitmap.Svg == null)
+                        return;
+
                     SvgRenderer.Draw(canvas, bitmap.Svg,
                         (float)destination.X, (float)destination.Y,
                         rotation,
@@ -38,18 +44,22 @@ namespace Mapsui.Rendering.Skia
                         opacity: opacity, scale: (float)symbolStyle.SymbolScale);
                     break;
                 case BitmapType.Sprite:
+                    if (bitmap.Sprite == null)
+                        return;
+
                     var sprite = bitmap.Sprite;
                     if (sprite.Data == null)
                     {
                         var bitmapAtlas = symbolCache.GetOrCreate(sprite.Atlas);
-                        sprite.Data = bitmapAtlas.Bitmap.Subset(new SKRectI(sprite.X, sprite.Y, sprite.X + sprite.Width,
+                        sprite.Data = bitmapAtlas.Bitmap?.Subset(new SKRectI(sprite.X, sprite.Y, sprite.X + sprite.Width,
                             sprite.Y + sprite.Height));
                     }
-                    BitmapRenderer.Draw(canvas, (SKImage)sprite.Data,
-                        (float)destination.X, (float)destination.Y,
-                        rotation,
-                        (float)offsetX, (float)offsetY,
-                        opacity: opacity, scale: (float)symbolStyle.SymbolScale);
+                    if (sprite.Data is SKImage skImage)
+                        BitmapRenderer.Draw(canvas, skImage,
+                            (float)destination.X, (float)destination.Y,
+                            rotation,
+                            (float)offsetX, (float)offsetY,
+                            opacity: opacity, scale: (float)symbolStyle.SymbolScale);
                     break;
             }
         }

--- a/Mapsui.Rendering.Skia/LineStringRenderer.cs
+++ b/Mapsui.Rendering.Skia/LineStringRenderer.cs
@@ -14,6 +14,9 @@ namespace Mapsui.Rendering.Skia
         {
             if (style is LabelStyle labelStyle)
             {
+                if (feature.BoundingBox == null)
+                    return;
+
                 var center = viewport.WorldToScreen(feature.BoundingBox.Centroid);
                 LabelRenderer.Draw(canvas, labelStyle, feature, center.ToPoint(), opacity);
             }
@@ -33,7 +36,7 @@ namespace Mapsui.Rendering.Skia
                 float[]? dashArray = null;
                 float dashOffset = 0;
 
-                if (vectorStyle != null)
+                if (vectorStyle is not null)
                 {
                     lineWidth = (float)vectorStyle.Line.Width;
                     lineColor = vectorStyle.Line.Color;

--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -65,12 +65,12 @@ namespace Mapsui.Rendering.Skia
         {
             if (!viewport.HasSize) return;
 
-            if (background != null) canvas.Clear(background.ToSkia());
+            if (background is not null) canvas.Clear(background.ToSkia());
             Render(canvas, viewport, layers);
             Render(canvas, viewport, widgets, 1);
         }
 
-        public MemoryStream RenderToBitmapStream(IReadOnlyViewport viewport, IEnumerable<ILayer> layers, Color? background = null, float pixelDensity = 1)
+        public MemoryStream? RenderToBitmapStream(IReadOnlyViewport viewport, IEnumerable<ILayer> layers, Color? background = null, float pixelDensity = 1)
         {
             try
             {
@@ -83,7 +83,7 @@ namespace Mapsui.Rendering.Skia
                 using var surface = SKSurface.Create(imageInfo);
                 if (surface == null) return null;
                 // Not sure if this is needed here:
-                if (background != null) surface.Canvas.Clear(background.ToSkia());
+                if (background is not null) surface.Canvas.Clear(background.ToSkia());
                 surface.Canvas.Scale(pixelDensity, pixelDensity);
                 Render(surface.Canvas, viewport, layers);
                 using var image = surface.Snapshot();
@@ -137,7 +137,7 @@ namespace Mapsui.Rendering.Skia
                 if (counter >= numberToRemove) break;
                 var textureInfo = tileCache[key];
                 tileCache.Remove(key);
-                textureInfo.Bitmap.Dispose();
+                textureInfo.Bitmap?.Dispose();
                 counter++;
             }
         }
@@ -208,7 +208,7 @@ namespace Mapsui.Rendering.Skia
             WidgetRenderer.Render(canvas, viewport, widgets, WidgetRenders, layerOpacity);
         }
 
-        public MapInfo GetMapInfo(double x, double y, IReadOnlyViewport viewport, IEnumerable<ILayer> layers, int margin = 0)
+        public MapInfo? GetMapInfo(double x, double y, IReadOnlyViewport viewport, IEnumerable<ILayer> layers, int margin = 0)
         {
             // todo: use margin to increase the pixel area
             // todo: We will need to select on style instead of layer
@@ -289,7 +289,7 @@ namespace Mapsui.Rendering.Skia
             return result;
         }
 
-        public MapInfo GetMapInfo(MPoint screenPosition, IReadOnlyViewport viewport, IEnumerable<ILayer> layers, int margin = 0)
+        public MapInfo? GetMapInfo(MPoint screenPosition, IReadOnlyViewport viewport, IEnumerable<ILayer> layers, int margin = 0)
         {
             return GetMapInfo(screenPosition.X, screenPosition.Y, viewport, layers, margin);
         }

--- a/Mapsui.Rendering.Skia/PolygonRenderer.cs
+++ b/Mapsui.Rendering.Skia/PolygonRenderer.cs
@@ -173,7 +173,7 @@ namespace Mapsui.Rendering.Skia
             }
         }
 
-        private static SKImage GetImage(SymbolCache symbolCache, int bitmapId)
+        private static SKImage? GetImage(SymbolCache symbolCache, int bitmapId)
         {
             var bitmapInfo = symbolCache.GetOrCreate(bitmapId);
             if (bitmapInfo.Type == BitmapType.Bitmap)

--- a/Mapsui.Rendering.Skia/SkiaWidgets/ScaleBarWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/ScaleBarWidgetRenderer.cs
@@ -31,23 +31,23 @@ namespace Mapsui.Rendering.Skia.SkiaWidgets
             // Update paints with new values
             _paintScaleBar.Color = scaleBar.TextColor.ToSkia(layerOpacity);
             _paintScaleBar.StrokeWidth = scaleBar.StrokeWidth * scaleBar.Scale;
-            _paintScaleBarStroke.Color = scaleBar.Halo.ToSkia(layerOpacity);
+            _paintScaleBarStroke!.Color = scaleBar.Halo.ToSkia(layerOpacity);
             _paintScaleBarStroke.StrokeWidth = scaleBar.StrokeWidthHalo * scaleBar.Scale;
-            _paintScaleText.Color = scaleBar.TextColor.ToSkia(layerOpacity);
+            _paintScaleText!.Color = scaleBar.TextColor.ToSkia(layerOpacity);
             _paintScaleText.StrokeWidth = scaleBar.StrokeWidth * scaleBar.Scale;
             _paintScaleText.Typeface = SKTypeface.FromFamilyName(scaleBar.Font.FontFamily,
                 SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
             _paintScaleText.TextSize = (float)scaleBar.Font.Size * scaleBar.Scale;
-            _paintScaleTextStroke.Color = scaleBar.Halo.ToSkia(layerOpacity);
+            _paintScaleTextStroke!.Color = scaleBar.Halo.ToSkia(layerOpacity);
             _paintScaleTextStroke.StrokeWidth = scaleBar.StrokeWidthHalo / 2 * scaleBar.Scale;
             _paintScaleTextStroke.Typeface = SKTypeface.FromFamilyName(scaleBar.Font.FontFamily,
                 SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
             _paintScaleTextStroke.TextSize = (float)scaleBar.Font.Size * scaleBar.Scale;
 
             float scaleBarLength1;
-            string scaleBarText1;
+            string? scaleBarText1;
             float scaleBarLength2;
-            string scaleBarText2;
+            string? scaleBarText2;
 
             (scaleBarLength1, scaleBarText1, scaleBarLength2, scaleBarText2) = scaleBar.GetScaleBarLengthAndText(viewport);
 

--- a/Mapsui.Rendering.Skia/SkiaWidgets/ScaleBarWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/ScaleBarWidgetRenderer.cs
@@ -76,7 +76,7 @@ namespace Mapsui.Rendering.Skia.SkiaWidgets
             var points = scaleBar.GetScaleBarLinePositions(viewport, scaleBarLength1, scaleBarLength2, scaleBar.StrokeWidthHalo);
 
             // BoundingBox for scale bar
-            var envelop = new MRect();
+            MRect? envelop = null;
 
             if (points != null)
             {
@@ -117,7 +117,7 @@ namespace Mapsui.Rendering.Skia.SkiaWidgets
             canvas.DrawText(scaleBarText1, posX1, posY1 - textSize1.Top, _paintScaleTextStroke);
             canvas.DrawText(scaleBarText1, posX1, posY1 - textSize1.Top, _paintScaleText);
 
-            envelop = envelop.Join(new MRect(posX1, posY1, posX1 + textSize1.Width, posY1 + textSize1.Height));
+            envelop = envelop?.Join(new MRect(posX1, posY1, posX1 + textSize1.Width, posY1 + textSize1.Height));
 
             if (scaleBar.ScaleBarMode == ScaleBarMode.Both && scaleBar.SecondaryUnitConverter != null)
             {
@@ -128,7 +128,7 @@ namespace Mapsui.Rendering.Skia.SkiaWidgets
                 canvas.DrawText(scaleBarText2, posX2, posY2 - textSize2.Top, _paintScaleTextStroke);
                 canvas.DrawText(scaleBarText2, posX2, posY2 - textSize2.Top, _paintScaleText);
 
-                envelop = envelop.Join(new MRect(posX2, posY2, posX2 + textSize2.Width, posY2 + textSize2.Height));
+                envelop = envelop?.Join(new MRect(posX2, posY2, posX2 + textSize2.Width, posY2 + textSize2.Height));
             }
 
             scaleBar.Envelope = envelop;

--- a/Mapsui.Rendering.Skia/SymbolStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SymbolStyleRenderer.cs
@@ -66,7 +66,7 @@ namespace Mapsui.Rendering.Skia
             }
         }
 
-        private static SKPaint CreateLinePaint(Pen outline, float opacity)
+        private static SKPaint? CreateLinePaint(Pen outline, float opacity)
         {
             if (outline == null) return null;
 
@@ -81,7 +81,7 @@ namespace Mapsui.Rendering.Skia
             };
         }
 
-        private static SKPaint CreateFillPaint(Brush fill, float opacity)
+        private static SKPaint? CreateFillPaint(Brush fill, float opacity)
         {
             if (fill == null) return null;
 

--- a/Mapsui.Rendering.Skia/SymbolStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SymbolStyleRenderer.cs
@@ -66,9 +66,9 @@ namespace Mapsui.Rendering.Skia
             }
         }
 
-        private static SKPaint? CreateLinePaint(Pen outline, float opacity)
+        private static SKPaint? CreateLinePaint(Pen? outline, float opacity)
         {
-            if (outline == null) return null;
+            if (outline is null) return null;
 
             return new SKPaint
             {
@@ -81,9 +81,9 @@ namespace Mapsui.Rendering.Skia
             };
         }
 
-        private static SKPaint? CreateFillPaint(Brush fill, float opacity)
+        private static SKPaint? CreateFillPaint(Brush? fill, float opacity)
         {
-            if (fill == null) return null;
+            if (fill is null) return null;
 
             return new SKPaint
             {

--- a/Mapsui.UI.Forms/Objects/Callout.cs
+++ b/Mapsui.UI.Forms/Objects/Callout.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Mapsui.Extensions;
 using Xamarin.Forms;
+using CalloutStyle = Mapsui.Styles.CalloutStyle;
 
 namespace Mapsui.UI.Forms
 {
@@ -186,12 +187,7 @@ namespace Mapsui.UI.Forms
 
         public Callout(Pin pin)
         {
-            if (pin == null)
-            {
-                throw new ArgumentNullException("Pin shouldn't be null");
-            }
-
-            _pin = pin;
+            _pin = pin ?? throw new ArgumentNullException("Pin shouldn't be null");;
             if (_pin.Feature != null)
                 Feature = (Feature)_pin.Feature.Copy();
             else
@@ -564,9 +560,9 @@ namespace Mapsui.UI.Forms
         /// </summary>
         private void UpdateContent()
         {
-            CalloutStyle style = (CalloutStyle)Feature.Styles.Where((s) => s is CalloutStyle).FirstOrDefault();
+            CalloutStyle? style = Feature.Styles.Where((s) => s is CalloutStyle).FirstOrDefault() as CalloutStyle;
 
-            if (style == null)
+            if (style is null)
             {
                 style = new CalloutStyle();
                 Feature.Styles.Add(style);
@@ -597,9 +593,9 @@ namespace Mapsui.UI.Forms
         /// </summary>
         private void UpdateCalloutStyle()
         {
-            CalloutStyle style = (CalloutStyle)Feature.Styles.Where((s) => s is CalloutStyle).FirstOrDefault();
+            CalloutStyle? style = Feature.Styles.Where((s) => s is CalloutStyle).FirstOrDefault() as CalloutStyle;
 
-            if (style == null)
+            if (style is null)
             {
                 style = new CalloutStyle();
                 Feature.Styles.Add(style);

--- a/Mapsui.UI.Forms/Objects/Circle.cs
+++ b/Mapsui.UI.Forms/Objects/Circle.cs
@@ -73,13 +73,16 @@ namespace Mapsui.UI.Forms
                     UpdateFeature();
                     break;
                 case nameof(FillColor):
-                    ((VectorStyle)Feature.Styles.First()).Fill = new Styles.Brush(FillColor.ToMapsui());
+                    if (Feature != null)
+                        ((VectorStyle)Feature.Styles.First()).Fill = new Styles.Brush(FillColor.ToMapsui());
                     break;
                 case nameof(StrokeWidth):
-                    ((VectorStyle)Feature.Styles.First()).Outline.Width = StrokeWidth;
+                    if (Feature != null)
+                        ((VectorStyle)Feature.Styles.First()).Outline.Width = StrokeWidth;
                     break;
                 case nameof(StrokeColor):
-                    ((VectorStyle)Feature.Styles.First()).Outline.Color = StrokeColor.ToMapsui();
+                    if (Feature != null)
+                        ((VectorStyle)Feature.Styles.First()).Outline.Color = StrokeColor.ToMapsui();
                     break;
             }
         }
@@ -129,7 +132,7 @@ namespace Mapsui.UI.Forms
                 exteriorRing.Vertices.Add(new Geometries.Point(radius * Math.Sin(angleRad) + centerX, radius * Math.Cos(angleRad) + centerY));
             }
 
-            Feature.Geometry = new Geometries.Polygon(exteriorRing);
+            Feature!.Geometry = new Geometries.Polygon(exteriorRing);
         }
     }
 }

--- a/Mapsui.UI.Forms/Objects/Drawable.cs
+++ b/Mapsui.UI.Forms/Objects/Drawable.cs
@@ -95,7 +95,7 @@ namespace Mapsui.UI.Objects
         /// <summary>
         /// Mapsui Feature belonging to this drawable
         /// </summary>
-        public IGeometryFeature Feature
+        public IGeometryFeature? Feature
         {
             get
             {
@@ -129,16 +129,20 @@ namespace Mapsui.UI.Objects
             switch (propertyName)
             {
                 case nameof(StrokeWidth):
-                    ((VectorStyle)Feature.Styles.First()).Line.Width = StrokeWidth;
+                    if (Feature != null)
+                        ((VectorStyle)Feature.Styles.First()).Line.Width = StrokeWidth;
                     break;
                 case nameof(StrokeColor):
-                    ((VectorStyle)Feature.Styles.First()).Line.Color = StrokeColor.ToMapsui();
+                    if (Feature != null)
+                        ((VectorStyle)Feature.Styles.First()).Line.Color = StrokeColor.ToMapsui();
                     break;
                 case nameof(MinVisible):
-                    ((VectorStyle)Feature.Styles.First()).MinVisible = MinVisible;
+                    if (Feature != null)
+                        ((VectorStyle)Feature.Styles.First()).MinVisible = MinVisible;
                     break;
                 case nameof(MaxVisible):
-                    ((VectorStyle)Feature.Styles.First()).MaxVisible = MaxVisible;
+                    if (Feature != null)
+                        ((VectorStyle)Feature.Styles.First()).MaxVisible = MaxVisible;
                     break;
             }
         }

--- a/Mapsui.UI.Forms/Objects/IFeatureProvider.cs
+++ b/Mapsui.UI.Forms/Objects/IFeatureProvider.cs
@@ -4,6 +4,6 @@ namespace Mapsui.UI.Objects
 {
     public interface IFeatureProvider
     {
-        IGeometryFeature Feature { get; }
+        IGeometryFeature? Feature { get; }
     }
 }

--- a/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
@@ -215,11 +215,11 @@ namespace Mapsui.UI.Objects
                     {
                         Extent = mapView.Viewport.Extent,
                         Resolution = mapView.Viewport.Resolution,
-                        CRS = mapView.Map.CRS,
+                        CRS = mapView.Map?.CRS,
                         ChangeType = ChangeType.Discrete
                     };
                     // At the end, update viewport
-                    animation.Commit(mapView, animationMyLocationName, 100, 3000, finished: (s, v) => mapView.Map.RefreshData(fetchInfo));
+                    animation.Commit(mapView, animationMyLocationName, 100, 3000, finished: (s, v) => mapView.Map?.RefreshData(fetchInfo));
                 }
                 else
                 {

--- a/Mapsui.UI.Forms/Objects/ObservableCollectionProvider.cs
+++ b/Mapsui.UI.Forms/Objects/ObservableCollectionProvider.cs
@@ -29,8 +29,8 @@ namespace Mapsui.UI.Objects
             {
                 foreach (T item in Collection)
                 {
-                    if (fetchInfo.Extent.Intersects(item.Feature.BoundingBox))
-                        list.Add((TU)item.Feature);
+                    if (fetchInfo.Extent.Intersects(item.Feature?.BoundingBox))
+                        list.Add((TU)item.Feature!);
                 }
             }
 

--- a/Mapsui.UI.Forms/Objects/ObservableCollectionProvider.cs
+++ b/Mapsui.UI.Forms/Objects/ObservableCollectionProvider.cs
@@ -29,7 +29,7 @@ namespace Mapsui.UI.Objects
             {
                 foreach (T item in Collection)
                 {
-                    if (fetchInfo.Extent.Intersects(item.Feature?.BoundingBox))
+                    if (fetchInfo.Extent?.Intersects(item.Feature?.BoundingBox) ?? false)
                         list.Add((TU)item.Feature!);
                 }
             }

--- a/Mapsui.UI.Forms/Objects/Pin.cs
+++ b/Mapsui.UI.Forms/Objects/Pin.cs
@@ -248,7 +248,7 @@ namespace Mapsui.UI.Forms
         /// Mapsui feature for this pin
         /// </summary>
         /// <value>Mapsui feature</value>
-        public IGeometryFeature Feature { get; private set; } = default!;
+        public IGeometryFeature? Feature { get; private set; }
 
         private Callout? _callout;
 
@@ -383,32 +383,40 @@ namespace Mapsui.UI.Forms
                     Callout.Subtitle = Address;
                     break;
                 case nameof(Transparency):
-                    ((SymbolStyle)Feature.Styles.First()).Opacity = 1 - Transparency;
+                    if (Feature != null)
+                        ((SymbolStyle)Feature.Styles.First()).Opacity = 1 - Transparency;
                     break;
                 case nameof(Anchor):
-                    ((SymbolStyle)Feature.Styles.First()).SymbolOffset = new Offset(Anchor.X, Anchor.Y);
+                    if (Feature != null)
+                        ((SymbolStyle)Feature.Styles.First()).SymbolOffset = new Offset(Anchor.X, Anchor.Y);
                     break;
                 case nameof(Rotation):
-                    ((SymbolStyle)Feature.Styles.First()).SymbolRotation = Rotation;
+                    if (Feature != null)
+                        ((SymbolStyle)Feature.Styles.First()).SymbolRotation = Rotation;
                     break;
                 case nameof(RotateWithMap):
-                    ((SymbolStyle)Feature.Styles.First()).RotateWithMap = RotateWithMap;
+                    if (Feature != null)
+                        ((SymbolStyle)Feature.Styles.First()).RotateWithMap = RotateWithMap;
                     break;
                 case nameof(IsVisible):
                     if (!IsVisible)
                         HideCallout();
-                    ((SymbolStyle)Feature.Styles.First()).Enabled = IsVisible;
+                    if (Feature != null)
+                        ((SymbolStyle)Feature.Styles.First()).Enabled = IsVisible;
                     break;
                 case nameof(MinVisible):
                     // TODO: Update callout MinVisble too
-                    ((SymbolStyle)Feature.Styles.First()).MinVisible = MinVisible;
+                    if (Feature != null)
+                        ((SymbolStyle)Feature.Styles.First()).MinVisible = MinVisible;
                     break;
                 case nameof(MaxVisible):
                     // TODO: Update callout MaxVisble too
-                    ((SymbolStyle)Feature.Styles.First()).MaxVisible = MaxVisible;
+                    if (Feature != null)
+                        ((SymbolStyle)Feature.Styles.First()).MaxVisible = MaxVisible;
                     break;
                 case nameof(Scale):
-                    ((SymbolStyle)Feature.Styles.First()).SymbolScale = Scale;
+                    if (Feature != null)
+                        ((SymbolStyle)Feature.Styles.First()).SymbolScale = Scale;
                     break;
                 case nameof(Type):
                 case nameof(Color):

--- a/Mapsui.UI.Forms/Utils/PolylineConverter.cs
+++ b/Mapsui.UI.Forms/Utils/PolylineConverter.cs
@@ -13,7 +13,7 @@ namespace Mapsui.UI.Forms.Utils
         /// </summary>
         /// <param name="encodedPolyline"></param>
         /// <returns></returns>
-        public static List<Position> DecodePolyline(string encodedPolyline)
+        public static List<Position>? DecodePolyline(string encodedPolyline)
         {
             if (string.IsNullOrWhiteSpace(encodedPolyline))
                 return null;

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -11,6 +11,8 @@ using Mapsui.Geometries.Utilities;
 using Mapsui.UI.iOS.Extensions;
 using SkiaSharp.Views.iOS;
 
+#nullable enable
+
 namespace Mapsui.UI.iOS
 {
     [Register("MapControl"), DesignTimeVisible(true)]
@@ -108,7 +110,7 @@ namespace Mapsui.UI.iOS
             CommonDrawControl(canvas);
         }
 
-        public override void TouchesBegan(NSSet touches, UIEvent evt)
+        public override void TouchesBegan(NSSet touches, UIEvent? evt)
         {
             base.TouchesBegan(touches, evt);
 
@@ -118,11 +120,11 @@ namespace Mapsui.UI.iOS
             Navigator.StopRunningAnimation();
         }
 
-        public override void TouchesMoved(NSSet touches, UIEvent evt)
+        public override void TouchesMoved(NSSet touches, UIEvent? evt)
         {
             base.TouchesMoved(touches, evt);
 
-            if (evt.AllTouches.Count == 1)
+            if (evt?.AllTouches.Count == 1)
             {
                 if (touches.AnyObject is UITouch touch)
                 {
@@ -135,7 +137,7 @@ namespace Mapsui.UI.iOS
                     _innerRotation = Viewport.Rotation;
                 }
             }
-            else if (evt.AllTouches.Count >= 2)
+            else if (evt?.AllTouches.Count >= 2)
             {
                 var previousLocation = evt.AllTouches.Select(t => ((UITouch)t).PreviousLocationInView(this))
                     .Select(p => new MPoint(p.X, p.Y)).ToList();
@@ -148,7 +150,7 @@ namespace Mapsui.UI.iOS
 
                 double rotationDelta = 0;
 
-                if (!Map.RotationLock)
+                if (!(Map?.RotationLock ?? false))
                 {
                     _innerRotation += angle - previousAngle;
                     _innerRotation %= 360;
@@ -174,7 +176,7 @@ namespace Mapsui.UI.iOS
             }
         }
 
-        public override void TouchesEnded(NSSet touches, UIEvent e)
+        public override void TouchesEnded(NSSet touches, UIEvent? e)
         {
             Refresh();
         }

--- a/Mapsui.sln
+++ b/Mapsui.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31624.102
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31825.309
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapsui", "Mapsui\Mapsui.csproj", "{D74C052A-C07E-4B37-A898-134218ACA5C9}"
 EndProject
@@ -44,6 +44,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		appveyor.yml = appveyor.yml
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
+		InitProperty.cs = InitProperty.cs
 		LICENSE.md = LICENSE.md
 		Mapsui.ncrunchsolution = Mapsui.ncrunchsolution
 		Mapsui.sln.DotSettings = Mapsui.sln.DotSettings

--- a/Mapsui.sln
+++ b/Mapsui.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31825.309
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31624.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapsui", "Mapsui\Mapsui.csproj", "{D74C052A-C07E-4B37-A898-134218ACA5C9}"
 EndProject

--- a/Mapsui/Extensions/BoundingBoxExtensions.cs
+++ b/Mapsui/Extensions/BoundingBoxExtensions.cs
@@ -20,7 +20,7 @@ namespace Mapsui.Extensions
             return true;
         }
 
-        public static Extent ToExtent(this BoundingBox boundingBox)
+        public static Extent ToExtent(this BoundingBox? boundingBox)
         {
             return new Extent(boundingBox.MinX, boundingBox.MinY, boundingBox.MaxX, boundingBox.MaxY);
         }

--- a/Mapsui/Extensions/BoundingBoxExtensions.cs
+++ b/Mapsui/Extensions/BoundingBoxExtensions.cs
@@ -25,7 +25,7 @@ namespace Mapsui.Extensions
             return new Extent(boundingBox.MinX, boundingBox.MinY, boundingBox.MaxX, boundingBox.MaxY);
         }
 
-        public static MRect ToMRect(this BoundingBox? boundingBox)
+        public static MRect? ToMRect(this BoundingBox? boundingBox)
         {
             if (boundingBox == null) return null;
             return new MRect(boundingBox.MinX, boundingBox.MinY, boundingBox.MaxX, boundingBox.MaxY);

--- a/Mapsui/Extensions/ExtentExtensions.cs
+++ b/Mapsui/Extensions/ExtentExtensions.cs
@@ -5,7 +5,7 @@ namespace Mapsui.Extensions
 {
     public static class ExtentExtensions
     {
-        public static BoundingBox ToBoundingBox(this Extent extent)
+        public static BoundingBox? ToBoundingBox(this Extent extent)
         {
             return new BoundingBox(
                 extent.MinX,

--- a/Mapsui/Extensions/FeatureExtensions.cs
+++ b/Mapsui/Extensions/FeatureExtensions.cs
@@ -11,7 +11,7 @@ namespace Mapsui.Extensions
     {
         public static IGeometryFeature Copy(this IGeometryFeature original)
         {
-            return new Feature(original) { Geometry = original.Geometry.Copy() };
+            return new Feature(original) { Geometry = original.Geometry?.Copy() };
         }
 
         public static IEnumerable<IGeometryFeature> Copy(this IEnumerable<IGeometryFeature> original)

--- a/Mapsui/Extensions/MRectExtensions.cs
+++ b/Mapsui/Extensions/MRectExtensions.cs
@@ -5,7 +5,7 @@ namespace Mapsui.Extensions
 {
     public static class MRectExtensions
     {
-        public static BoundingBox ToBoundingBox(this MRect boundingBox)
+        public static BoundingBox? ToBoundingBox(this MRect boundingBox)
         {
             return new BoundingBox(boundingBox.MinX, boundingBox.MinY, boundingBox.MaxX, boundingBox.MaxY);
         }

--- a/Mapsui/Fetcher/Delayer.cs
+++ b/Mapsui/Fetcher/Delayer.cs
@@ -9,7 +9,7 @@ namespace Mapsui.Fetcher
     public class Delayer
     {
         private readonly Timer _waitTimer;
-        private Action _action;
+        private Action? _action;
         private bool _waiting;
 
         /// <summary>

--- a/Mapsui/Fetcher/FeatureFetchDispatcher.cs
+++ b/Mapsui/Fetcher/FeatureFetchDispatcher.cs
@@ -44,7 +44,7 @@ namespace Mapsui.Fetcher
             }
         }
 
-        private void FetchCompleted(IEnumerable<T> features, Exception? exception)
+        private void FetchCompleted(IEnumerable<T>? features, Exception? exception)
         {
             if (exception == null)
             {

--- a/Mapsui/Fetcher/FetchWorker.cs
+++ b/Mapsui/Fetcher/FetchWorker.cs
@@ -7,7 +7,7 @@ namespace Mapsui.Fetcher
     internal class FetchWorker
     {
         private readonly IFetchDispatcher _fetchDispatcher;
-        private CancellationTokenSource _fetchLoopCancellationTokenSource;
+        private CancellationTokenSource? _fetchLoopCancellationTokenSource;
         public static long RestartCounter;
 
         public FetchWorker(IFetchDispatcher fetchDispatcher)

--- a/Mapsui/Fetcher/IFetchDispatcher.cs
+++ b/Mapsui/Fetcher/IFetchDispatcher.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Mapsui.Layers;
 
 namespace Mapsui.Fetcher
 {
     internal interface IFetchDispatcher
     {
-        bool TryTake(ref Action method);
+        bool TryTake([NotNullWhen(true)] ref Action? method);
         void SetViewport(FetchInfo fetchInfo);
         bool Busy { get; }
         event DataChangedEventHandler DataChanged;

--- a/Mapsui/Fetcher/TileFetchDispatcher.cs
+++ b/Mapsui/Fetcher/TileFetchDispatcher.cs
@@ -94,7 +94,7 @@ namespace Mapsui.Fetcher
             }
         }
 
-        private void FetchCompleted(TileInfo tileInfo, Feature feature, Exception? exception)
+        private void FetchCompleted(TileInfo tileInfo, Feature? feature, Exception? exception)
         {
             lock (_lockRoot)
             {

--- a/Mapsui/Layers/AnimatedFeatures.cs
+++ b/Mapsui/Layers/AnimatedFeatures.cs
@@ -114,7 +114,7 @@ namespace Mapsui.Layers
             return result;
         }
 
-        private static Point CopyAsPoint(IGeometry geometry)
+        private static Point? CopyAsPoint(IGeometry geometry)
         {
             var point = geometry as Point;
             return point == null ? null : new Point(point.X, point.Y);

--- a/Mapsui/Layers/TileLayer.cs
+++ b/Mapsui/Layers/TileLayer.cs
@@ -155,7 +155,7 @@ namespace Mapsui.Layers
             return new Feature { Geometry = ToGeometry(tileInfo, tileData) };
         }
 
-        private static Raster ToGeometry(TileInfo tileInfo, byte[]? tileData)
+        private static Raster? ToGeometry(TileInfo tileInfo, byte[]? tileData)
         {
             // A TileSource may return a byte array that is null. This is currently only implemented
             // for MbTilesTileSource. It is to indicate that the tile is not present in the source,

--- a/Mapsui/Layers/WritableLayer.cs
+++ b/Mapsui/Layers/WritableLayer.cs
@@ -24,7 +24,7 @@ namespace Mapsui.Layers
             return result;
         }
 
-        private MRect GetExtent()
+        private MRect? GetExtent()
         {
             // todo: Calculate extent only once. Use a _modified field to determine when this is needed.
 

--- a/Mapsui/Providers/ArcGIS/CapabilitiesHelper.cs
+++ b/Mapsui/Providers/ArcGIS/CapabilitiesHelper.cs
@@ -174,7 +174,7 @@ namespace Mapsui.Providers.ArcGIS
         /// Generate BruTile TileSchema based on ArcGIS Capabilities
         /// </summary>
         /// <returns>TileSchema, returns null if service is not tiled</returns>
-        public static ITileSchema GetTileSchema(ArcGISDynamicCapabilities arcGisDynamicCapabilities)
+        public static ITileSchema? GetTileSchema(ArcGISDynamicCapabilities arcGisDynamicCapabilities)
         {
             //TODO: Does this belong in Mapsui.Providers?
 

--- a/Mapsui/Providers/ArcGIS/CapabilitiesHelper.cs
+++ b/Mapsui/Providers/ArcGIS/CapabilitiesHelper.cs
@@ -24,7 +24,7 @@ namespace Mapsui.Providers.ArcGIS
         private int _timeOut;
         private string _url;
 
-        public delegate void StatusEventHandler(object sender, EventArgs e);
+        public delegate void StatusEventHandler(object? sender, EventArgs e);
 
         /// <summary>
         /// Triggered when finished parsing capabilities, returns Capabilities object

--- a/Mapsui/Providers/ArcGIS/Dynamic/ArcGISDynamicProvider.cs
+++ b/Mapsui/Providers/ArcGIS/Dynamic/ArcGISDynamicProvider.cs
@@ -176,7 +176,7 @@ namespace Mapsui.Providers.ArcGIS.Dynamic
         /// <param name="width"> </param>
         /// <param name="height"> </param>
         /// <returns>URL for ArcGIS Dynamic request</returns>
-        public string GetRequestUrl(BoundingBox box, int width, int height)
+        public string GetRequestUrl(BoundingBox? box, int width, int height)
         {
             //ArcGIS Export description see: http://resources.esri.com/help/9.3/arcgisserver/apis/rest/index.html?export.html
 

--- a/Mapsui/Providers/ArcGIS/Dynamic/ArcGISIdentify.cs
+++ b/Mapsui/Providers/ArcGIS/Dynamic/ArcGISIdentify.cs
@@ -13,7 +13,7 @@ namespace Mapsui.Providers.ArcGIS.Dynamic
 {
     //Documentation 9.3: http://resources.esri.com/help/9.3/arcgisserver/apis/rest/
     //Documentation 10.0: http://help.arcgis.com/EN/arcgisserver/10.0/apis/rest/index.html
-    public delegate void StatusEventHandler(object sender, ArcGISFeatureInfo featureInfo);
+    public delegate void StatusEventHandler(object sender, ArcGISFeatureInfo? featureInfo);
 
     public class ArcGISIdentify
     {

--- a/Mapsui/Providers/ArcGIS/Dynamic/ArcGISLegend.cs
+++ b/Mapsui/Providers/ArcGIS/Dynamic/ArcGISLegend.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Mapsui.Providers.ArcGIS.Dynamic
 {
-    public delegate void ArcGISLegendEventHandler(object sender, ArcGISLegendResponse legendInfo);
+    public delegate void ArcGISLegendEventHandler(object sender, ArcGISLegendResponse? legendInfo);
 
     /// <summary>
     /// ArcGislegend for getting the layer legends for ArcGIS layers only supports

--- a/Mapsui/Providers/ArcGIS/Dynamic/ArcGISLegend.cs
+++ b/Mapsui/Providers/ArcGIS/Dynamic/ArcGISLegend.cs
@@ -89,7 +89,7 @@ namespace Mapsui.Providers.ArcGIS.Dynamic
             }
         }
 
-        private static ArcGISLegendResponse GetLegendResponseFromWebresponse(WebResponse webResponse)
+        private static ArcGISLegendResponse? GetLegendResponseFromWebresponse(WebResponse webResponse)
         {
             var dataStream = webResponse.GetResponseStream();
 

--- a/Mapsui/Providers/ArcGIS/Image/ArcGISImageServiceProvider.cs
+++ b/Mapsui/Providers/ArcGIS/Image/ArcGISImageServiceProvider.cs
@@ -215,7 +215,7 @@ namespace Mapsui.Providers.ArcGIS.Image
             return url.ToString();
         }
 
-        public MRect GetExtent()
+        public MRect? GetExtent()
         {
             return null;
         }

--- a/Mapsui/Providers/ArcGIS/Image/ArcGISImageServiceProvider.cs
+++ b/Mapsui/Providers/ArcGIS/Image/ArcGISImageServiceProvider.cs
@@ -169,7 +169,7 @@ namespace Mapsui.Providers.ArcGIS.Image
             return false;
         }
 
-        private string GetRequestUrl(BoundingBox boundingBox, int width, int height)
+        private string GetRequestUrl(BoundingBox? boundingBox, int width, int height)
         {
             var url = new StringBuilder(Url);
 

--- a/Mapsui/Providers/Feature.cs
+++ b/Mapsui/Providers/Feature.cs
@@ -10,7 +10,7 @@ namespace Mapsui.Providers
 {
     public class Feature : IGeometryFeature, IDisposable
     {
-        private readonly Dictionary<string, object> _dictionary = new();
+        private readonly Dictionary<string, object?> _dictionary = new();
         private bool _disposed;
 
         public Feature()
@@ -31,13 +31,13 @@ namespace Mapsui.Providers
             }
         }
 
-        public IGeometry Geometry { get; set; }
+        public IGeometry? Geometry { get; set; }
 
         public IDictionary<IStyle, object> RenderedGeometry { get; }
 
         public ICollection<IStyle> Styles { get; set; }
 
-        public virtual object this[string key]
+        public virtual object? this[string key]
         {
             get => _dictionary.ContainsKey(key) ? _dictionary[key] : null;
             set => _dictionary[key] = value;
@@ -45,7 +45,7 @@ namespace Mapsui.Providers
 
         public IEnumerable<string> Fields => _dictionary.Keys;
 
-        public MRect BoundingBox => Geometry.BoundingBox.ToMRect();
+        public MRect? BoundingBox => Geometry?.BoundingBox.ToMRect();
 
         public void Dispose()
         {

--- a/Mapsui/Providers/IGeometryFeature.cs
+++ b/Mapsui/Providers/IGeometryFeature.cs
@@ -5,6 +5,6 @@ namespace Mapsui.Providers
 {
     public interface IGeometryFeature : IFeature
     {
-        public IGeometry Geometry { get; set; }
+        public IGeometry? Geometry { get; set; }
     }
 }

--- a/Mapsui/Providers/Shapefile/DbaseReader.cs
+++ b/Mapsui/Providers/Shapefile/DbaseReader.cs
@@ -46,8 +46,8 @@ namespace Mapsui.Providers.Shapefile
         private short _recordLength;
         private readonly string _filename;
         private DbaseField[] _dbaseColumns;
-        private FileStream _fs;
-        private BinaryReader _br;
+        private FileStream? _fs;
+        private BinaryReader? _br;
         private bool _headerIsParsed;
 
         public DbaseReader(string filename)

--- a/Mapsui/Providers/Shapefile/DbaseReader.cs
+++ b/Mapsui/Providers/Shapefile/DbaseReader.cs
@@ -443,7 +443,7 @@ namespace Mapsui.Providers.Shapefile
         /// <param name="oid"></param>
         /// <param name="table"></param>
         /// <returns></returns>
-        internal IGeometryFeature GetFeature(uint oid, IEnumerable<IGeometryFeature> table)
+        internal IGeometryFeature? GetFeature(uint oid, IEnumerable<IGeometryFeature> table)
         {
             if (oid >= _numberOfRecords)
                 throw (new ArgumentException("Invalid DataRow requested at index " + oid.ToString(CultureInfo.InvariantCulture)));

--- a/Mapsui/Providers/Shapefile/Indexing/BinaryTree.cs
+++ b/Mapsui/Providers/Shapefile/Indexing/BinaryTree.cs
@@ -25,8 +25,8 @@ namespace Mapsui.Providers.Shapefile.Indexing
     internal class Node<T, TU> where T : IComparable<T>
     {
         public BinaryTree<T, TU>.ItemValue Item;
-        public Node<T, TU> LeftNode;
-        public Node<T, TU> RightNode;
+        public Node<T, TU>? LeftNode;
+        public Node<T, TU>? RightNode;
 
         public Node() : this(default, default, null, null)
         {
@@ -40,7 +40,7 @@ namespace Mapsui.Providers.Shapefile.Indexing
         {
         }
 
-        public Node(T item, TU itemIndex, Node<T, TU> right, Node<T, TU> left)
+        public Node(T item, TU itemIndex, Node<T, TU>? right, Node<T, TU>? left)
         {
             RightNode = right;
             LeftNode = left;

--- a/Mapsui/Providers/Shapefile/Indexing/SpatialIndexing.cs
+++ b/Mapsui/Providers/Shapefile/Indexing/SpatialIndexing.cs
@@ -56,15 +56,15 @@ namespace Mapsui.Providers.Shapefile.Indexing
     public class QuadTree : IDisposable
     {
         private MRect _box;
-        private QuadTree _child0;
-        private QuadTree _child1;
+        private QuadTree? _child0;
+        private QuadTree? _child1;
 
         /// <summary>
         /// Nodes depth in a tree
         /// </summary>
         private uint _depth;
 
-        private List<BoxObjects> _objList;
+        private List<BoxObjects>? _objList;
 
         /// <summary>
         /// Creates a node and either splits the objects recursively into sub-nodes, or stores them at the node depending on the heuristics.

--- a/Mapsui/Providers/Shapefile/ShapeFile.cs
+++ b/Mapsui/Providers/Shapefile/ShapeFile.cs
@@ -718,7 +718,7 @@ namespace Mapsui.Providers.Shapefile
         /// <param name="oid">Object ID</param>
         /// <returns>geometry</returns>
         // ReSharper disable once CyclomaticComplexity // Fix when changes need to be made here
-        private Geometry ReadGeometry(uint oid)
+        private Geometry? ReadGeometry(uint oid)
         {
             _brShapeFile.BaseStream.Seek(GetShapeIndex(oid) + 8, 0); //Skip record number and content length
             var type = (ShapeType)_brShapeFile.ReadInt32(); //Shape type
@@ -847,7 +847,7 @@ namespace Mapsui.Providers.Shapefile
 
         }
 
-        private IGeometryFeature GetFeaturePrivate(uint rowId, IEnumerable<IGeometryFeature>? dt)
+        private IGeometryFeature? GetFeaturePrivate(uint rowId, IEnumerable<IGeometryFeature>? dt)
         {
             if (_dbaseFile != null)
             {

--- a/Mapsui/Providers/Shapefile/ShapeFile.cs
+++ b/Mapsui/Providers/Shapefile/ShapeFile.cs
@@ -148,7 +148,7 @@ namespace Mapsui.Providers.Shapefile
         /// <returns>true if this feature should be included, false if it should be filtered</returns>
         public delegate bool FilterMethod(IFeature dr);
 
-        private MRect _envelope;
+        private MRect? _envelope;
         private int _featureCount;
         private readonly bool _fileBasedIndex;
         private string _filename;
@@ -164,7 +164,7 @@ namespace Mapsui.Providers.Shapefile
         /// <summary>
         /// Tree used for fast query of data
         /// </summary>
-        private QuadTree _tree;
+        private QuadTree? _tree;
 
         /// <summary>
         /// Initializes a ShapeFile DataProvider.

--- a/Mapsui/Providers/StackedLabelProvider.cs
+++ b/Mapsui/Providers/StackedLabelProvider.cs
@@ -128,7 +128,7 @@ namespace Mapsui.Providers
             };
         }
 
-        private static Polygon ToPolygon(BoundingBox box)
+        private static Polygon ToPolygon(BoundingBox? box)
         {
             return new Polygon
             {
@@ -139,7 +139,7 @@ namespace Mapsui.Providers
             };
         }
 
-        private static BoundingBox GrowBox(BoundingBox box, double resolution)
+        private static BoundingBox? GrowBox(BoundingBox box, double resolution)
         {
             const int symbolSize = 32; // todo: determine margin by symbol size
             const int boxMargin = symbolSize / 2;

--- a/Mapsui/Providers/Wfs/Utilities/GeometryFactories.cs
+++ b/Mapsui/Providers/Wfs/Utilities/GeometryFactories.cs
@@ -105,7 +105,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// </summary>
         /// <param name="reader">An XmlReader instance at the position of the coordinates to read</param>
         /// <returns>A point collection (the collected coordinates)</returns>
-        protected Collection<Point> ParseCoordinates(XmlReader reader)
+        protected Collection<Point>? ParseCoordinates(XmlReader reader)
         {
             if (!reader.Read()) return null;
 
@@ -167,7 +167,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <param name="labels">A dictionary for recording label values. Pass 'null' to ignore searching for label values</param>
         /// <param name="pathNodes">A list of <see cref="IPathNode"/> instances defining the context of the retrieved reader</param>
         /// <returns>A sub-reader of the XmlReader given as argument</returns>
-        protected XmlReader GetSubReaderOf(XmlReader reader, Dictionary<string, string> labels, List<IPathNode> pathNodes)
+        protected XmlReader? GetSubReaderOf(XmlReader reader, Dictionary<string, string> labels, List<IPathNode> pathNodes)
         {
             while (reader.Read())
             {

--- a/Mapsui/Providers/Wfs/Utilities/GeometryFactories.cs
+++ b/Mapsui/Providers/Wfs/Utilities/GeometryFactories.cs
@@ -152,7 +152,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <param name="labels">A dictionary for recording label values. Pass 'null' to ignore searching for label values</param>
         /// <param name="pathNodes">A list of <see cref="IPathNode"/> instances defining the context of the retrieved reader</param>
         /// <returns>A sub-reader of the XmlReader given as argument</returns>
-        protected XmlReader GetSubReaderOf(XmlReader reader, Dictionary<string, string> labels, params IPathNode[] pathNodes)
+        protected XmlReader GetSubReaderOf(XmlReader reader, Dictionary<string, string>? labels, params IPathNode[] pathNodes)
         {
             _pathNodes.Clear();
             _pathNodes.AddRange(pathNodes);
@@ -167,7 +167,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <param name="labels">A dictionary for recording label values. Pass 'null' to ignore searching for label values</param>
         /// <param name="pathNodes">A list of <see cref="IPathNode"/> instances defining the context of the retrieved reader</param>
         /// <returns>A sub-reader of the XmlReader given as argument</returns>
-        protected XmlReader? GetSubReaderOf(XmlReader reader, Dictionary<string, string> labels, List<IPathNode> pathNodes)
+        protected XmlReader? GetSubReaderOf(XmlReader reader, Dictionary<string, string>? labels, List<IPathNode> pathNodes)
         {
             while (reader.Read())
             {

--- a/Mapsui/Providers/Wfs/Utilities/HttpClientUtil.cs
+++ b/Mapsui/Providers/Wfs/Utilities/HttpClientUtil.cs
@@ -17,11 +17,11 @@ namespace Mapsui.Providers.Wfs.Utilities
     {
 
         private readonly NameValueCollection _requestHeaders;
-        private byte[] _postData;
-        private string _proxyUrl;
-        private string _url;
+        private byte[]? _postData;
+        private string? _proxyUrl;
+        private string? _url;
         private HttpWebRequest _webRequest;
-        private HttpWebResponse _webResponse;
+        private HttpWebResponse? _webResponse;
         private ICredentials _credentials;
 
         /// <summary>

--- a/Mapsui/Providers/Wfs/Utilities/IWFS_TextResources.cs
+++ b/Mapsui/Providers/Wfs/Utilities/IWFS_TextResources.cs
@@ -44,8 +44,8 @@ namespace Mapsui.Providers.Wfs.Utilities
         string DescribeFeatureTypeRequest(string featureTypeName);
         string GetCapabilitiesRequest();
         string GetFeatureGETRequest(WfsFeatureTypeInfo featureTypeInfo, List<string> labelProperties,
-            BoundingBox boundingBox, IFilter filter);
+            BoundingBox? boundingBox, IFilter filter);
         byte[] GetFeaturePOSTRequest(WfsFeatureTypeInfo featureTypeInfo, List<string> labelProperties,
-            BoundingBox boundingBox, IFilter filter);
+            BoundingBox? boundingBox, IFilter filter);
     }
 }

--- a/Mapsui/Providers/Wfs/Utilities/WFS_1_0_0_TextResources.cs
+++ b/Mapsui/Providers/Wfs/Utilities/WFS_1_0_0_TextResources.cs
@@ -85,7 +85,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <param name="boundingBox">The bounding box of the query</param>
         /// <param name="filter">An instance implementing <see cref="IFilter"/></param>
         public byte[] GetFeaturePOSTRequest(WfsFeatureTypeInfo featureTypeInfo, List<string> labelProperties,
-                                            BoundingBox boundingBox, IFilter filter)
+                                            BoundingBox? boundingBox, IFilter filter)
         {
             var qualification = string.IsNullOrEmpty(featureTypeInfo.Prefix)
                                        ? string.Empty

--- a/Mapsui/Providers/Wfs/Utilities/WFS_1_1_0_TextResources.cs
+++ b/Mapsui/Providers/Wfs/Utilities/WFS_1_1_0_TextResources.cs
@@ -90,7 +90,7 @@ namespace Mapsui.Providers.Wfs.Utilities
         /// <param name="boundingBox">The bounding box of the query</param>
         /// <param name="filter">An instance implementing <see cref="IFilter"/></param>
         public byte[] GetFeaturePOSTRequest(WfsFeatureTypeInfo featureTypeInfo, List<string> labelProperties,
-                                            BoundingBox boundingBox, IFilter filter)
+                                            BoundingBox? boundingBox, IFilter filter)
         {
             var qualification = string.IsNullOrEmpty(featureTypeInfo.Prefix)
                                        ? string.Empty

--- a/Mapsui/Providers/Wfs/WFSProvider.cs
+++ b/Mapsui/Providers/Wfs/WFSProvider.cs
@@ -380,7 +380,7 @@ namespace Mapsui.Providers.Wfs
         /// </summary>
         /// <param name="bbox"></param>
         /// <returns>Features within the specified <see cref="Mapsui.Geometries.BoundingBox"/></returns>
-        public Features ExecuteIntersectionQuery(BoundingBox bbox)
+        public Features? ExecuteIntersectionQuery(BoundingBox bbox)
         {
             if (_featureTypeInfo == null) return null;
 

--- a/Mapsui/Providers/Wfs/WFSProvider.cs
+++ b/Mapsui/Providers/Wfs/WFSProvider.cs
@@ -61,7 +61,7 @@ namespace Mapsui.Providers.Wfs
         private bool _disposed;
         private string _featureType;
         private WfsFeatureTypeInfo _featureTypeInfo;
-        private IXPathQueryManager _featureTypeInfoQueryManager;
+        private IXPathQueryManager? _featureTypeInfoQueryManager;
         private string _nsPrefix;
         private bool _getFeatureGetRequest;
         private List<string> _labels = new List<string>();

--- a/Mapsui/Providers/Wfs/WFSProvider.cs
+++ b/Mapsui/Providers/Wfs/WFSProvider.cs
@@ -380,7 +380,7 @@ namespace Mapsui.Providers.Wfs
         /// </summary>
         /// <param name="bbox"></param>
         /// <returns>Features within the specified <see cref="Mapsui.Geometries.BoundingBox"/></returns>
-        public Features? ExecuteIntersectionQuery(BoundingBox bbox)
+        public Features? ExecuteIntersectionQuery(BoundingBox? bbox)
         {
             if (_featureTypeInfo == null) return null;
 
@@ -917,7 +917,7 @@ namespace Mapsui.Providers.Wfs
             /// The <see cref="HttpClientUtil"/> instance is returned for immediate usage. 
             /// </summary>
             internal void ConfigureForWfsGetFeatureRequest(HttpClientUtil httpClientUtil,
-                WfsFeatureTypeInfo featureTypeInfo, List<string> labelProperties, BoundingBox boundingBox,
+                WfsFeatureTypeInfo featureTypeInfo, List<string> labelProperties, BoundingBox? boundingBox,
                 IFilter filter, bool get)
             {
                 httpClientUtil.Reset();

--- a/Mapsui/Providers/Wfs/Xml/XPathQueryManager.cs
+++ b/Mapsui/Providers/Wfs/Xml/XPathQueryManager.cs
@@ -19,7 +19,7 @@ namespace Mapsui.Providers.Wfs.Xml
     public class XPathQueryManager : IXPathQueryManager
     {
 
-        private CustomQueryContext _paramContext;
+        private CustomQueryContext? _paramContext;
         private XPathNodeIterator _xIter;
         private XPathNavigator _xNav;
         private XPathDocument _xPathDoc;

--- a/Mapsui/Providers/Wfs/Xml/XPathQueryManager.cs
+++ b/Mapsui/Providers/Wfs/Xml/XPathQueryManager.cs
@@ -205,7 +205,7 @@ namespace Mapsui.Providers.Wfs.Xml
         /// </summary>
         /// <param name="xPath">The compiled XPath expression</param>
         /// <param name="queryParameters">Parameters for the compiled XPath expression</param>
-        public IXPathQueryManager GetXPathQueryManagerInContext(XPathExpression xPath, DictionaryEntry[]? queryParameters = null)
+        public IXPathQueryManager? GetXPathQueryManagerInContext(XPathExpression xPath, DictionaryEntry[]? queryParameters = null)
         {
             if (queryParameters != null) _paramContext.AddParam(queryParameters);
             FindXPath(xPath);
@@ -403,7 +403,7 @@ namespace Mapsui.Providers.Wfs.Xml
             /// <param name="prefix">The prefix of the function</param>
             /// <param name="name">The name of the function</param>
             /// <param name="argTypes">A list of argument types of the function</param>
-            public override IXsltContextFunction ResolveFunction(string prefix, string name, XPathResultType[] argTypes)
+            public override IXsltContextFunction? ResolveFunction(string prefix, string name, XPathResultType[] argTypes)
             {
                 if (name.Equals(ParamCompare.FunctionName)) return new ParamCompare(argTypes, 2, 2);
                 if (name.Equals(ParamCompareWithTargetNs.FunctionName))
@@ -416,7 +416,7 @@ namespace Mapsui.Providers.Wfs.Xml
             /// </summary>
             /// <param name="prefix">The prefix of the variable</param>
             /// <param name="name">The name of the variable</param>
-            public override IXsltContextVariable ResolveVariable(string prefix, string name)
+            public override IXsltContextVariable? ResolveVariable(string prefix, string name)
             {
                 var param = GetParam(name);
                 if (param != null)

--- a/Mapsui/Providers/Wfs/Xml/XPathQueryManager_CompiledExpressionsDecorator.cs
+++ b/Mapsui/Providers/Wfs/Xml/XPathQueryManager_CompiledExpressionsDecorator.cs
@@ -69,7 +69,7 @@ namespace Mapsui.Providers.Wfs.Xml
         /// </summary>
         /// <param name="xPath">The compiled XPath expression</param>
         /// <param name="queryParameters">Parameters for the compiled XPath expression</param>
-        public override IXPathQueryManager GetXPathQueryManagerInContext(XPathExpression xPath,
+        public override IXPathQueryManager? GetXPathQueryManagerInContext(XPathExpression xPath,
                                                                          DictionaryEntry[]? queryParameters = null)
         {
             var xPathQueryManager = (queryParameters == null)

--- a/Mapsui/Providers/Wms/GetFeatureInfo.cs
+++ b/Mapsui/Providers/Wms/GetFeatureInfo.cs
@@ -9,15 +9,15 @@ using System.Threading.Tasks;
 
 namespace Mapsui.Providers.Wms
 {
-    public delegate void StatusEventHandler(object sender, FeatureInfo featureInfo);
+    public delegate void StatusEventHandler(object sender, FeatureInfo? featureInfo);
 
     public class GetFeatureInfo
     {
-        private string _infoFormat;
-        private string _layerName;
+        private string? _infoFormat;
+        private string? _layerName;
         public event StatusEventHandler? IdentifyFinished;
         public event StatusEventHandler? IdentifyFailed;
-        private readonly Func<string, Task<Stream>> _getStreamAsync;
+        private readonly Func<string, Task<Stream>>? _getStreamAsync;
 
         public GetFeatureInfo(Func<string, Task<Stream>>? getStreamAsync = null)
         {
@@ -30,12 +30,12 @@ namespace Mapsui.Providers.Wms
         /// </summary>
         public int TimeOut { get; set; }
 
-        public Dictionary<string, string> ExtraParams { get; set; }
+        public Dictionary<string, string>? ExtraParams { get; set; }
 
         /// <summary>
         /// Provides the base authentication interface for retrieving credentials for Web client authentication.
         /// </summary>
-        public ICredentials Credentials { get; set; }
+        public ICredentials? Credentials { get; set; }
 
         /// <summary>
         /// Request FeatureInfo for a WMS Server

--- a/Mapsui/Providers/Wms/GetFeatureInfo.cs
+++ b/Mapsui/Providers/Wms/GetFeatureInfo.cs
@@ -17,7 +17,7 @@ namespace Mapsui.Providers.Wms
         private string? _layerName;
         public event StatusEventHandler? IdentifyFinished;
         public event StatusEventHandler? IdentifyFailed;
-        private readonly Func<string, Task<Stream>>? _getStreamAsync;
+        private readonly Func<string, Task<Stream>> _getStreamAsync;
 
         public GetFeatureInfo(Func<string, Task<Stream>>? getStreamAsync = null)
         {

--- a/Mapsui/Providers/Wms/GetFeatureInfo.cs
+++ b/Mapsui/Providers/Wms/GetFeatureInfo.cs
@@ -157,7 +157,7 @@ namespace Mapsui.Providers.Wms
         /// Get a parser that is able to parse the output returned from the service
         /// </summary>
         /// <param name="format">Output format of the service</param>
-        private static IGetFeatureInfoParser GetParserFromFormat(string format)
+        private static IGetFeatureInfoParser? GetParserFromFormat(string format)
         {
             if (format.Equals("application/vnd.ogc.gml"))
                 return new GmlGetFeatureInfoParser();

--- a/Mapsui/Providers/Wms/GmlGetFeatureInfoParser.cs
+++ b/Mapsui/Providers/Wms/GmlGetFeatureInfoParser.cs
@@ -11,7 +11,7 @@ namespace Mapsui.Providers.Wms
     {
         private FeatureInfo? _featureInfo;
 
-        public FeatureInfo ParseWMSResult(string layerName, Stream result)
+        public FeatureInfo ParseWMSResult(string? layerName, Stream result)
         {
             _featureInfo = new FeatureInfo { LayerName = layerName, FeatureInfos = new List<Dictionary<string, string>>() };
             XDocument xdoc;
@@ -34,7 +34,7 @@ namespace Mapsui.Providers.Wms
         {
             LookExtractMultipleElements(root);
 
-            if (_featureInfo.FeatureInfos.Count == 0)
+            if (_featureInfo?.FeatureInfos?.Count == 0)
                 ExtractFeatures(root);
         }
 

--- a/Mapsui/Providers/Wms/IGetFeatureInfoParser.cs
+++ b/Mapsui/Providers/Wms/IGetFeatureInfoParser.cs
@@ -4,6 +4,6 @@ namespace Mapsui.Providers.Wms
 {
     public interface IGetFeatureInfoParser
     {
-        FeatureInfo ParseWMSResult(string layerName, Stream result);
+        FeatureInfo ParseWMSResult(string? layerName, Stream result);
     }
 }

--- a/Mapsui/Providers/Wms/WmsProvider.cs
+++ b/Mapsui/Providers/Wms/WmsProvider.cs
@@ -443,7 +443,7 @@ namespace Mapsui.Providers.Wms
 
         public Dictionary<string, string> ExtraParams { get; set; }
 
-        public MRect GetExtent()
+        public MRect? GetExtent()
         {
             return _wmsClient.Layer.BoundingBoxes.ContainsKey(CRS) ? _wmsClient.Layer.BoundingBoxes[CRS] : null;
         }

--- a/Mapsui/Providers/Wms/WmsProvider.cs
+++ b/Mapsui/Providers/Wms/WmsProvider.cs
@@ -338,7 +338,7 @@ namespace Mapsui.Providers.Wms
         /// Gets the URL for a map request base on current settings, the image size and BoundingBox
         /// </summary>
         /// <returns>URL for WMS request</returns>
-        public string GetRequestUrl(BoundingBox box, int width, int height)
+        public string GetRequestUrl(BoundingBox? box, int width, int height)
         {
             var resource = GetPreferredMethod();
             var strReq = new StringBuilder(resource.OnlineResource);

--- a/Mapsui/Rendering/IRenderFetchStrategy.cs
+++ b/Mapsui/Rendering/IRenderFetchStrategy.cs
@@ -18,7 +18,7 @@ namespace Mapsui.Rendering
         /// <param name="schema">The tile schema of the tile source</param>
         /// <param name="memoryCache">The cached features from which to select</param>
         /// <returns></returns>
-        IList<IFeature> Get(BoundingBox extent, double resolution, ITileSchema schema,
+        IList<IFeature> Get(BoundingBox? extent, double resolution, ITileSchema schema,
             ITileCache<Feature> memoryCache);
     }
 }

--- a/Mapsui/Rendering/MinimalRenderFetchStrategy.cs
+++ b/Mapsui/Rendering/MinimalRenderFetchStrategy.cs
@@ -10,7 +10,7 @@ namespace Mapsui.Rendering
 {
     public class MinimalRenderFetchStrategy : IRenderFetchStrategy
     {
-        public IList<IFeature> Get(BoundingBox extent, double resolution, ITileSchema schema, ITileCache<Feature> memoryCache)
+        public IList<IFeature> Get(BoundingBox? extent, double resolution, ITileSchema schema, ITileCache<Feature> memoryCache)
         {
             var tiles = schema.GetTileInfos(extent.ToExtent(), resolution);
             var result = new List<IFeature>();

--- a/Mapsui/Rendering/RenderFetchStrategy.cs
+++ b/Mapsui/Rendering/RenderFetchStrategy.cs
@@ -11,7 +11,7 @@ namespace Mapsui.Rendering
 {
     public class RenderFetchStrategy : IRenderFetchStrategy
     {
-        public IList<IFeature> Get(BoundingBox extent, double resolution, ITileSchema schema, ITileCache<Feature> memoryCache)
+        public IList<IFeature> Get(BoundingBox? extent, double resolution, ITileSchema schema, ITileCache<Feature> memoryCache)
         {
             var dictionary = new Dictionary<TileIndex, IFeature>();
             var level = BruTile.Utilities.GetNearestLevel(schema.Resolutions, resolution);

--- a/Mapsui/Utilities/ProjectionHelper.cs
+++ b/Mapsui/Utilities/ProjectionHelper.cs
@@ -21,7 +21,7 @@ namespace Mapsui.Utilities
         public const string EsriStringPrefix = "ESRISTRING:";
         public const string Proj4StringPrefix = "PROJ4STRING:";
 
-        public static string ToStandardizedCRS(string? crs)
+        public static string? ToStandardizedCRS(string? crs)
         {
             if (crs == null) return null;
             if (string.IsNullOrWhiteSpace(crs)) return crs.Trim();
@@ -63,7 +63,7 @@ namespace Mapsui.Utilities
             return geometryTransformation.IsProjectionSupported(fromCRS, toCRS) == true;
         }
 
-        public static BoundingBox Transform(BoundingBox? extent,
+        public static BoundingBox? Transform(BoundingBox? extent,
             IGeometryTransformation geometryTransformation, string fromCRS, string toCRS)
         {
             if (extent == null) return null;
@@ -81,7 +81,7 @@ namespace Mapsui.Utilities
             return copiedExtent;
         }
 
-        public static IEnumerable<IGeometryFeature> Transform(IEnumerable<IGeometryFeature>? features,
+        public static IEnumerable<IGeometryFeature>? Transform(IEnumerable<IGeometryFeature>? features,
             IGeometryTransformation geometryTransformation, string fromCRS, string toCRS)
         {
             if (features == null) return null;

--- a/Samples/Mapsui.Samples.Common/AllSamples.cs
+++ b/Samples/Mapsui.Samples.Common/AllSamples.cs
@@ -10,7 +10,7 @@ namespace Mapsui.Samples.Common
 {
     public static class AllSamples
     {
-        public static IEnumerable<ISample> GetSamples()
+        public static IEnumerable<ISample>? GetSamples()
         {
             var type = typeof(ISample);
             var assemblies = AppDomain.CurrentDomain.GetAssemblies()

--- a/Tests/Mapsui.Tests/Fetcher/Providers/NullTileProvider.cs
+++ b/Tests/Mapsui.Tests/Fetcher/Providers/NullTileProvider.cs
@@ -4,7 +4,7 @@ namespace Mapsui.Tests.Fetcher.Providers
 {
     class NullTileProvider : CountingTileProvider
     {
-        public override byte[] GetTile(TileInfo tileInfo)
+        public override byte[]? GetTile(TileInfo tileInfo)
         {
             base.GetTile(tileInfo); // Just for counting
 

--- a/Tests/Mapsui.Tests/Fetcher/Providers/SometimesFailingTileProvider.cs
+++ b/Tests/Mapsui.Tests/Fetcher/Providers/SometimesFailingTileProvider.cs
@@ -7,7 +7,7 @@ namespace Mapsui.Tests.Fetcher.Providers
     {
         private readonly Random _random = new Random(DateTime.Now.Millisecond);
 
-        public override byte[] GetTile(TileInfo tileInfo)
+        public override byte[]? GetTile(TileInfo tileInfo)
         {
             base.GetTile(tileInfo); // Just for counting
 


### PR DESCRIPTION
Made some more nullable fixes.

What I'm not sure is the new MRect type.

```
   public MRect(IEnumerable<MRect> rects)
        {
            Max = null;
            Min = null;

            foreach (var rect in rects)
            {
                Min ??= rect.Min.Clone();
                Max ??= rect.Max.Clone();

                Min.X = Math.Min(rect.Min.X, Min.X);
                Min.Y = Math.Min(rect.Min.Y, Min.Y);
                Max.X = Math.Max(rect.Max.X, Max.X);
                Max.Y = Math.Max(rect.Max.Y, Max.Y);
            }
        }
```

Max and Min are currently defined  not nullable.  changing that would require to change although

things like that

`public double MinX => Min.X;`

giviing a default when Min is not set.

`public double MinX => Min?.X ?? 0;`
