### PR TITLE
Remove xcopy extensionmethods becasuse it did not exist

### DIFF
--- a/Samples/Mapsui.Samples.Uwp/Mapsui.Samples.Uwp.csproj
+++ b/Samples/Mapsui.Samples.Uwp/Mapsui.Samples.Uwp.csproj
@@ -194,8 +194,7 @@
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>xcopy ..\..\..\MainPage.* ..\..\..\..\Mapsui.Samples.Uno\Mapsui.Samples.Uno.Shared /Y
-xcopy ..\..\..\ExtensionMethods\*.* ..\..\..\..\Mapsui.Samples.Uno\Mapsui.Samples.Uno.Shared /Y</PreBuildEvent>
+    <PreBuildEvent>xcopy ..\..\..\MainPage.* ..\..\..\..\Mapsui.Samples.Uno\Mapsui.Samples.Uno.Shared /Y</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
This xcopy broke the build, so I removed it. 

In general I think we should try to avoid solutions like this because they are hard to maintain. If more folders are added they should all be xcopied? Could this not have been solved with a shared project?

Also I think it is time to deprecate UWP. It can be replaced with WinUI. How is that in Uno? It has not fully moved to WinUI? Maybe my question does not make sense be I don't follow the Uno news at all, so I really know nothing about it. Could we wait for a WinUI Uno version before we release it?

Also also, I want to get rid of the old csproj format.

