### PR TITLE
Feature/work on features

### DIFF
--- a/Mapsui.Core/Layers/FetchInfo.cs
+++ b/Mapsui.Core/Layers/FetchInfo.cs
@@ -2,19 +2,25 @@
 {
     public class FetchInfo
     {
-        public FetchInfo() { }
+        public FetchInfo(MRect extent, double resolution, string? crs = null, ChangeType changeType = ChangeType.Discrete)
+        {
+            Extent = extent;
+            Resolution = resolution;
+            CRS = crs;
+            ChangeType = changeType;
+        }
 
         public FetchInfo(FetchInfo fetchInfo)
         {
-            Extent = fetchInfo.Extent != null ? new MRect(fetchInfo.Extent) : null;
+            Extent = new MRect(fetchInfo.Extent);
             Resolution = fetchInfo.Resolution;
             CRS = fetchInfo.CRS;
             ChangeType = fetchInfo.ChangeType;
         }
 
-        public MRect? Extent { get; set; }
-        public double Resolution { get; set; }
-        public string? CRS { get; set; }
-        public ChangeType ChangeType { get; set; }
+        public MRect Extent { get; }
+        public double Resolution { get; }
+        public string? CRS { get; }
+        public ChangeType ChangeType { get; }
     }
 }

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -551,13 +551,7 @@ namespace Mapsui.UI.Forms
             if (touchPoints.Count == 0)
             {
                 _mode = TouchMode.None;
-                var fetchInfo = new FetchInfo
-                {
-                    Extent = _viewport.Extent,
-                    Resolution = _viewport.Resolution,
-                    CRS = Map?.CRS,
-                    ChangeType = ChangeType.Discrete
-                };
+                var fetchInfo = new FetchInfo(_viewport.Extent, _viewport.Resolution, Map?.CRS, ChangeType.Discrete);
                 _map?.RefreshData(fetchInfo);
             }
 
@@ -602,13 +596,7 @@ namespace Mapsui.UI.Forms
             if (touchPoints.Count == 0)
             {
                 _mode = TouchMode.None;
-                var fetchInfo = new FetchInfo
-                {
-                    Extent = _viewport.Extent,
-                    Resolution = _viewport.Resolution,
-                    CRS = Map?.CRS,
-                    ChangeType = ChangeType.Discrete
-                };
+                var fetchInfo = new FetchInfo(_viewport.Extent, _viewport.Resolution, Map?.CRS, ChangeType.Discrete);
                 _map?.RefreshData(fetchInfo);
             }
 

--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -694,13 +694,7 @@ namespace Mapsui.UI.Forms
 
         private void HandlerPinPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            var fetchInfo = new FetchInfo
-            {
-                Extent = Viewport.Extent,
-                Resolution = Viewport.Resolution,
-                CRS = Map?.CRS,
-                ChangeType = ChangeType.Continuous
-            };
+            var fetchInfo = new FetchInfo(Viewport.Extent, Viewport.Resolution, Map?.CRS, ChangeType.Continuous);
 
             Map?.RefreshData(fetchInfo);
 
@@ -710,13 +704,7 @@ namespace Mapsui.UI.Forms
 
         private void HandlerDrawablePropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            var fetchInfo = new FetchInfo
-            {
-                Extent = Viewport.Extent,
-                Resolution = Viewport.Resolution,
-                CRS = Map?.CRS,
-                ChangeType = ChangeType.Continuous
-            };
+            var fetchInfo = new FetchInfo(Viewport.Extent, Viewport.Resolution, Map?.CRS, ChangeType.Continuous);
 
             Map?.RefreshData(fetchInfo);
 

--- a/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
@@ -201,13 +201,7 @@ namespace Mapsui.UI.Objects
                             mapView.Refresh();
                     }, 0.0, 1.0);
 
-                    var fetchInfo = new FetchInfo
-                    {
-                        Extent = mapView.Viewport.Extent,
-                        Resolution = mapView.Viewport.Resolution,
-                        CRS = mapView.Map?.CRS,
-                        ChangeType = ChangeType.Discrete
-                    };
+                    var fetchInfo = new FetchInfo(mapView.Viewport.Extent, mapView.Viewport.Resolution, mapView.Map?.CRS, ChangeType.Discrete);
                     // At the end, update viewport
                     animation.Commit(mapView, animationMyLocationName, 100, 3000, finished: (s, v) => mapView.Map?.RefreshData(fetchInfo));
                 }

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -482,13 +482,7 @@ namespace Mapsui.UI.Wpf
         /// </summary>
         public void RefreshData(ChangeType changeType = ChangeType.Discrete)
         {
-            var fetchInfo = new FetchInfo
-            {
-                Extent = Viewport.Extent,
-                Resolution = Viewport.Resolution,
-                CRS = Map?.CRS,
-                ChangeType = changeType
-            };
+            var fetchInfo = new FetchInfo(Viewport.Extent, Viewport.Resolution, Map?.CRS, changeType);
             _map?.RefreshData(fetchInfo);
         }
 

--- a/Mapsui/Fetcher/FeatureFetchDispatcher.cs
+++ b/Mapsui/Fetcher/FeatureFetchDispatcher.cs
@@ -65,12 +65,11 @@ namespace Mapsui.Fetcher
             // Fetch a bigger extent to include partially visible symbols. 
             // todo: Take into account the maximum symbol size of the layer
 
-            _fetchInfo = new FetchInfo(fetchInfo)
-            {
-                Extent = fetchInfo.Extent.Grow(
-                    SymbolStyle.DefaultWidth * 2 * fetchInfo.Resolution,
-                    SymbolStyle.DefaultHeight * 2 * fetchInfo.Resolution)
-            };
+            var biggerBox = fetchInfo.Extent.Grow(
+                SymbolStyle.DefaultWidth * 2 * fetchInfo.Resolution,
+                SymbolStyle.DefaultHeight * 2 * fetchInfo.Resolution);
+            _fetchInfo = new FetchInfo(biggerBox, fetchInfo.Resolution, fetchInfo.CRS, fetchInfo.ChangeType);
+
 
             _modified = true;
             Busy = true;

--- a/Mapsui/Fetcher/FeatureFetcher.cs
+++ b/Mapsui/Fetcher/FeatureFetcher.cs
@@ -18,9 +18,10 @@ namespace Mapsui.Fetcher
         public FeatureFetcher(FetchInfo fetchInfo, IProvider<IFeature> provider, DataArrivedDelegate dataArrived, long timeOfRequest = default)
         {
             _dataArrived = dataArrived;
-            _fetchInfo = fetchInfo;
-            var biggerBox = _fetchInfo.Extent.Grow(SymbolStyle.DefaultWidth * 2 * fetchInfo.Resolution, SymbolStyle.DefaultHeight * 2 * fetchInfo.Resolution);
-            _fetchInfo.Extent = biggerBox;
+            var biggerBox = fetchInfo.Extent.Grow(
+                SymbolStyle.DefaultWidth * 2 * fetchInfo.Resolution,
+                SymbolStyle.DefaultHeight * 2 * fetchInfo.Resolution);
+            _fetchInfo = new FetchInfo(biggerBox, fetchInfo.Resolution, fetchInfo.CRS, fetchInfo.ChangeType);
             _provider = provider;
             _timeOfRequest = timeOfRequest;
         }

--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -34,14 +34,11 @@ namespace Mapsui.Layers
             // Safeguard in case BoundingBox is null, most likely due to no features in layer
             if (box == null) { return new List<IFeature>(); }
 
-            var fetchInfo = new FetchInfo
-            {
-                Extent = box.Grow(
+            var biggerBox = box.Grow(
                     SymbolStyle.DefaultWidth * 2 * resolution,
-                    SymbolStyle.DefaultHeight * 2 * resolution),
-                Resolution = resolution,
-                CRS = CRS
-            };
+                    SymbolStyle.DefaultHeight * 2 * resolution);
+            var fetchInfo = new FetchInfo(biggerBox, resolution, CRS);
+
             return DataSource.GetFeatures(fetchInfo);
         }
 

--- a/Mapsui/Layers/RasterizingLayer.cs
+++ b/Mapsui/Layers/RasterizingLayer.cs
@@ -164,9 +164,9 @@ namespace Mapsui.Layers
             var features = _cache.ToArray();
 
             // Use a larger extent so that symbols partially outside of the extent are included
-            var grownBox = box.Grow(resolution * SymbolSize * 0.5);
+            var biggerBox = box.Grow(resolution * SymbolSize * 0.5);
 
-            return features.Where(f => f.Geometry != null && f.Geometry.BoundingBox.Intersects(grownBox.ToBoundingBox())).ToList();
+            return features.Where(f => f.Geometry != null && f.Geometry.BoundingBox.Intersects(biggerBox.ToBoundingBox())).ToList();
         }
 
         public void AbortFetch()
@@ -188,10 +188,8 @@ namespace Mapsui.Layers
                 (_currentViewport.Resolution != newViewport.Resolution) ||
                 !_currentViewport.Extent.Contains(newViewport.Extent))
             {
-                _fetchInfo = new FetchInfo(fetchInfo)
-                {
-                    ChangeType = ChangeType.Discrete
-                };
+                // Explicitly set the change type to discrete for rasterization
+                _fetchInfo = new FetchInfo(fetchInfo.Extent, fetchInfo.Resolution, fetchInfo.CRS, ChangeType.Discrete);
                 if (_layer is IAsyncDataFetcher)
                     Delayer.ExecuteDelayed(() => _layer.RefreshData(_fetchInfo));
                 else

--- a/Mapsui/Providers/GeometryMemoryProvider.cs
+++ b/Mapsui/Providers/GeometryMemoryProvider.cs
@@ -142,8 +142,8 @@ namespace Mapsui.Providers
 
             fetchInfo = new FetchInfo(fetchInfo);
             // Use a larger extent so that symbols partially outside of the extent are included
-            var grownBox = fetchInfo.Extent.Grow(fetchInfo.Resolution * SymbolSize * 0.5);
-            var grownFeatures = features.Where(f => f != null && f.BoundingBox.Intersects(grownBox));
+            var biggerBox = fetchInfo.Extent.Grow(fetchInfo.Resolution * SymbolSize * 0.5);
+            var grownFeatures = features.Where(f => f != null && f.BoundingBox.Intersects(biggerBox));
             return (IEnumerable<T>)grownFeatures.ToList(); // Why do I need to cast if T is constrained to IFeature?
         }
 

--- a/Mapsui/Providers/GeometryMemoryProvider.cs
+++ b/Mapsui/Providers/GeometryMemoryProvider.cs
@@ -162,15 +162,15 @@ namespace Mapsui.Providers
             return _boundingBox;
         }
 
-        private static MRect GetExtent(IReadOnlyList<IGeometryFeature> features)
+        private static MRect GetExtent(IReadOnlyList<IFeature> features)
         {
             MRect? box = null;
             foreach (var feature in features)
             {
-                if (feature.Geometry.IsEmpty()) continue;
+                if (feature.BoundingBox == null) continue;
                 box = box == null
-                    ? feature.Geometry.BoundingBox.ToMRect()
-                    : box.Join(feature.Geometry.BoundingBox.ToMRect());
+                    ? feature.BoundingBox
+                    : box.Join(feature.BoundingBox);
             }
             return box;
         }

--- a/Mapsui/Providers/TransformingProvider.cs
+++ b/Mapsui/Providers/TransformingProvider.cs
@@ -22,8 +22,10 @@ namespace Mapsui.Providers
 
         public IEnumerable<IGeometryFeature> GetFeatures(FetchInfo fetchInfo)
         {
-            fetchInfo = new FetchInfo(fetchInfo); // Copy so we do not modify the original
-            fetchInfo.Extent = ProjectionHelper.Transform(fetchInfo.Extent.ToBoundingBox(), _geometryTransformation, CRS, _provider.CRS).ToMRect();
+            var transformedExtent = ProjectionHelper.Transform(fetchInfo.Extent.ToBoundingBox(), _geometryTransformation, CRS, _provider.CRS).ToMRect();
+            if (transformedExtent == null) return new List<IGeometryFeature>(); // Perhaps Transform should not return null
+            fetchInfo = new FetchInfo(transformedExtent, fetchInfo.Resolution, fetchInfo.CRS, fetchInfo.ChangeType);
+
             var features = _provider.GetFeatures(fetchInfo);
             return ProjectionHelper.Transform(features, _geometryTransformation, _provider.CRS, CRS);
         }

--- a/Tests/Mapsui.Tests/Fetcher/FeatureFetcherTests.cs
+++ b/Tests/Mapsui.Tests/Fetcher/FeatureFetcherTests.cs
@@ -29,12 +29,7 @@ namespace Mapsui.Tests.Fetcher
                     notifications.Add(layer.Busy);
                 }
             };
-            var fetchInfo = new FetchInfo
-            {
-                Extent = extent,
-                Resolution = 1,
-                ChangeType = ChangeType.Discrete
-            };
+            var fetchInfo = new FetchInfo(extent, 1, null, ChangeType.Discrete);
 
             // act
             layer.RefreshData(fetchInfo);

--- a/Tests/Mapsui.Tests/Fetcher/FetchMachineTests.cs
+++ b/Tests/Mapsui.Tests/Fetcher/FetchMachineTests.cs
@@ -33,11 +33,7 @@ namespace Mapsui.Tests.Fetcher
             var level = 3;
             var expectedTiles = 64;
 
-            var fetchInfo = new FetchInfo
-            {
-                Extent = tileSchema.Extent.ToMRect(),
-                Resolution = tileSchema.Resolutions[level].UnitsPerPixel
-            };
+            var fetchInfo = new FetchInfo(tileSchema.Extent.ToMRect(), tileSchema.Resolutions[level].UnitsPerPixel);
 
             // Act
             // Get all tiles of level 3
@@ -63,11 +59,8 @@ namespace Mapsui.Tests.Fetcher
             var tileMachine = new FetchMachine(fetchDispatcher);
             var level = 3;
             var expectedTiles = 64;
-            var fetchInfo = new FetchInfo
-            {
-                Extent = tileSchema.Extent.ToMRect(),
-                Resolution = tileSchema.Resolutions[level].UnitsPerPixel
-            };
+            var fetchInfo = new FetchInfo(tileSchema.Extent.ToMRect(), tileSchema.Resolutions[level].UnitsPerPixel);
+
             // Act
             fetchDispatcher.SetViewport(fetchInfo);
             tileMachine.Start();
@@ -98,11 +91,7 @@ namespace Mapsui.Tests.Fetcher
             var tileMachine = new FetchMachine(fetchDispatcher);
             var level = 3;
             var tilesInLevel = 64;
-            var fetchInfo = new FetchInfo
-            {
-                Extent = tileSchema.Extent.ToMRect(),
-                Resolution = tileSchema.Resolutions[level].UnitsPerPixel
-            };
+            var fetchInfo = new FetchInfo(tileSchema.Extent.ToMRect(), tileSchema.Resolutions[level].UnitsPerPixel);
             // Act
             fetchDispatcher.SetViewport(fetchInfo);
             tileMachine.Start();
@@ -128,11 +117,7 @@ namespace Mapsui.Tests.Fetcher
             var tileMachine = new FetchMachine(fetchDispatcher);
             var level = 3;
             var tilesInLevel = 64;
-            var fetchInfo = new FetchInfo
-            {
-                Extent = tileSchema.Extent.ToMRect(),
-                Resolution = tileSchema.Resolutions[level].UnitsPerPixel
-            };
+            var fetchInfo = new FetchInfo(tileSchema.Extent.ToMRect(), tileSchema.Resolutions[level].UnitsPerPixel);
 
             // Act
             fetchDispatcher.SetViewport(fetchInfo);
@@ -160,11 +145,8 @@ namespace Mapsui.Tests.Fetcher
             var tileMachine = new FetchMachine(fetchDispatcher);
             var level = 3;
             var tilesInLevel = 64;
-            var fetchInfo = new FetchInfo
-            {
-                Extent = tileSchema.Extent.ToMRect(),
-                Resolution = tileSchema.Resolutions[level].UnitsPerPixel
-            };
+            var fetchInfo = new FetchInfo(tileSchema.Extent.ToMRect(), tileSchema.Resolutions[level].UnitsPerPixel);
+
             // Act
             fetchDispatcher.SetViewport(fetchInfo);
             tileMachine.Start();
@@ -195,11 +177,7 @@ namespace Mapsui.Tests.Fetcher
             var tileMachine = new FetchMachine(fetchDispatcher);
             var numberOfWorkers = 8;
             var numberOfRestarts = 3;
-            var fetchInfo = new FetchInfo
-            {
-                Extent = tileSchema.Extent.ToMRect(),
-                Resolution = tileSchema.Resolutions[3].UnitsPerPixel
-            };
+            var fetchInfo = new FetchInfo(tileSchema.Extent.ToMRect(), tileSchema.Resolutions[3].UnitsPerPixel);
 
             // Act
             for (var i = 0; i < numberOfRestarts; i++)

--- a/Tests/Mapsui.Tests/Layers/ImageLayerTests.cs
+++ b/Tests/Mapsui.Tests/Layers/ImageLayerTests.cs
@@ -43,12 +43,7 @@ namespace Mapsui.Tests.Layers
                 waitHandle.Go();
             };
 
-            var fetchInfo = new FetchInfo
-            {
-                Extent = new MRect(-1, -1, 0, 0),
-                Resolution = 1,
-                ChangeType = ChangeType.Discrete
-            };
+            var fetchInfo = new FetchInfo(new MRect(-1, -1, 0, 0), 1, null, ChangeType.Discrete);
 
             // act
             map.RefreshData(fetchInfo);

--- a/Tests/Mapsui.Tests/Layers/RasterizingLayerTests.cs
+++ b/Tests/Mapsui.Tests/Layers/RasterizingLayerTests.cs
@@ -32,12 +32,7 @@ namespace Mapsui.Tests.Layers
                 waitHandle.Set();
             };
 
-            var fetchInfo = new FetchInfo
-            {
-                Extent = box,
-                Resolution = resolution,
-                ChangeType = ChangeType.Discrete
-            };
+            var fetchInfo = new FetchInfo(box, resolution, null, ChangeType.Discrete);
 
             // act
             layer.RefreshData(fetchInfo);


### PR DESCRIPTION
@inforithmics This PR stems from the nullable changes. FetchInfo.Extent was nullable but this made no sense, no fetch is needed when the extent is null. Since it also makes no sense to initialize the Extent with 0,0 0,0 in the constructor FetchInfo is now fully immutable. All values have to be set through the constructor. This is the right way to go. More non-nullable, more immutable. I am also interested in C# 9 records.