### PR TITLE
Use More PointFeature and add RectFeture to replace IGeometryFeature

### DIFF
--- a/Mapsui.Core/Layers/BaseFeature.cs
+++ b/Mapsui.Core/Layers/BaseFeature.cs
@@ -4,13 +4,12 @@ using Mapsui.Styles;
 
 namespace Mapsui.Layers
 {
-    public abstract class BaseFeature : IFeature
+    public abstract class BaseFeature
     {
         private readonly Dictionary<string, object?> _dictionary = new();
 
         public ICollection<IStyle> Styles { get; set; } = new Collection<IStyle>();
         public IEnumerable<string> Fields => _dictionary.Keys;
-        public MRect? BoundingBox { get; }
 
         public virtual object? this[string key]
         {

--- a/Mapsui.Core/Layers/IPointFeature.cs
+++ b/Mapsui.Core/Layers/IPointFeature.cs
@@ -2,6 +2,6 @@ namespace Mapsui.Layers
 {
     public interface IPointFeature : IFeature
     {
-        public MPoint? Point { get; set; }
+        public MPoint? Point { get; }
     }
 }

--- a/Mapsui.Core/Layers/PointFeature.cs
+++ b/Mapsui.Core/Layers/PointFeature.cs
@@ -1,8 +1,8 @@
 ﻿namespace Mapsui.Layers
 {
-    public class PointFeature : BaseFeature, IPointFeature
+    public class PointFeature : BaseFeature, IPointFeature, IFeature
     {
         public MPoint? Point { get; set; }
-
+        public MRect? BoundingBox => Point?.MRect;
     }
 }

--- a/Mapsui.Core/Layers/RectFeature.cs
+++ b/Mapsui.Core/Layers/RectFeature.cs
@@ -1,0 +1,8 @@
+﻿namespace Mapsui.Layers
+{
+    public class RectFeature : BaseFeature, IFeature
+    {
+        public MRect? Rect { get; set; }
+        public MRect? BoundingBox => Rect;
+    }
+}

--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -170,6 +170,10 @@ namespace Mapsui.Rendering.Skia
                 PointRenderer.Draw(canvas, viewport, style, pointFeature, pointFeature.Point.X, pointFeature.Point.Y, _symbolCache,
                    layerOpacity * style.Opacity);
             }
+            else if (feature is RectFeature rectFeature)
+            {
+                RectRenderer.Draw(canvas, viewport, style, rectFeature, layerOpacity * style.Opacity);
+            }
         }
 
         private void RenderGeometry(SKCanvas canvas, IReadOnlyViewport viewport, IStyle style, float layerOpacity,

--- a/Mapsui.Rendering.Skia/RectRenderer.cs
+++ b/Mapsui.Rendering.Skia/RectRenderer.cs
@@ -1,0 +1,25 @@
+using System;
+using Mapsui.Extensions;
+using Mapsui.Layers;
+using Mapsui.Logging;
+using Mapsui.Styles;
+using SkiaSharp;
+
+namespace Mapsui.Rendering.Skia
+{
+    public static class RectRenderer
+    {
+        public static void Draw(SKCanvas canvas, IReadOnlyViewport viewport, IStyle style, RectFeature rectFeature,
+            float opacity)
+        {
+            try
+            {
+                PolygonRenderer.Draw(canvas, viewport, style, rectFeature, rectFeature.Rect.ToPolygon(), opacity);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(LogLevel.Error, ex.Message, ex);
+            }
+        }
+    }
+}

--- a/Mapsui/Extensions/MRectExtensions.cs
+++ b/Mapsui/Extensions/MRectExtensions.cs
@@ -14,5 +14,15 @@ namespace Mapsui.Extensions
         {
             return new Extent(rect.MinX, rect.MinY, rect.MaxX, rect.MaxY);
         }
+
+        public static Polygon ToPolygon(this MRect rect)
+        {
+            return new Polygon(new LinearRing(new[] {
+                rect.TopLeft.ToPoint(),
+                rect.TopRight.ToPoint(),
+                rect.BottomRight.ToPoint(),
+                rect.BottomLeft.ToPoint(),
+                rect.TopLeft.ToPoint() }));
+        }
     }
 }

--- a/Mapsui/Providers/MemoryProvider.cs
+++ b/Mapsui/Providers/MemoryProvider.cs
@@ -10,7 +10,7 @@ namespace Mapsui.Providers
         /// <summary>
         /// Gets or sets the geometries this data source contains
         /// </summary>
-        public IReadOnlyList<IFeature> Features { get; private set; }
+        public IReadOnlyList<T> Features { get; private set; }
 
         public double SymbolSize { get; set; } = 64;
 
@@ -23,7 +23,7 @@ namespace Mapsui.Providers
 
         public MemoryProvider()
         {
-            Features = new List<IGeometryFeature>();
+            Features = new List<T>();
             _boundingBox = GetExtent(Features);
         }
 
@@ -31,9 +31,9 @@ namespace Mapsui.Providers
         /// Initializes a new instance of the MemoryProvider
         /// </summary>
         /// <param name="feature">Feature to be in this dataSource</param>
-        public MemoryProvider(IFeature feature)
+        public MemoryProvider(T feature)
         {
-            Features = new List<IFeature> { feature };
+            Features = new List<T> { feature };
             _boundingBox = GetExtent(Features);
         }
 
@@ -42,7 +42,7 @@ namespace Mapsui.Providers
         /// Initializes a new instance of the MemoryProvider
         /// </summary>
         /// <param name="features">Features to be included in this dataSource</param>
-        public MemoryProvider(IEnumerable<IGeometryFeature> features)
+        public MemoryProvider(IEnumerable<T> features)
         {
             Features = features.ToList();
             _boundingBox = GetExtent(Features);
@@ -59,16 +59,17 @@ namespace Mapsui.Providers
             // Use a larger extent so that symbols partially outside of the extent are included
             var biggerBox = fetchInfo.Extent.Grow(fetchInfo.Resolution * SymbolSize * 0.5);
             var grownFeatures = features.Where(f => f != null && f.BoundingBox.Intersects(biggerBox));
-            return (IEnumerable<T>)grownFeatures.ToList(); // Why do I need to cast if T is constrained to IFeature?
+
+            return grownFeatures.ToList(); 
         }
 
         /// <summary>
         /// Search for a feature
         /// </summary>
         /// <param name="value">Value to search for</param>
-        /// <param name="fieldName">Name of the field to search in. This is the key of the IFeature dictionary</param>
+        /// <param name="fieldName">Name of the field to search in. This is the key of the T dictionary</param>
         /// <returns></returns>
-        public IFeature Find(object? value, string fieldName)
+        public T Find(object? value, string fieldName)
         {
             return Features.FirstOrDefault(f => value != null && f[fieldName] == value);
         }
@@ -82,7 +83,7 @@ namespace Mapsui.Providers
             return _boundingBox;
         }
 
-        private static MRect GetExtent(IReadOnlyList<IFeature> features)
+        private static MRect GetExtent(IReadOnlyList<T> features)
         {
             MRect? box = null;
             foreach (var feature in features)
@@ -97,7 +98,7 @@ namespace Mapsui.Providers
 
         public void Clear()
         {
-            Features = new List<IGeometryFeature>();
+            Features = new List<T>();
         }
     }
 }

--- a/Samples/Mapsui.Samples.Common/GeoData/RandomPointGenerator.cs
+++ b/Samples/Mapsui.Samples.Common/GeoData/RandomPointGenerator.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Mapsui.Extensions;
+using Mapsui.Layers;
 using Mapsui.Providers;
 
 namespace Mapsui.Samples.Common.Helpers
@@ -10,15 +10,15 @@ namespace Mapsui.Samples.Common.Helpers
     {
         private static Random _random = new Random(0);
 
-        public static GeometryMemoryProvider<IGeometryFeature> CreateProviderWithRandomPoints(MRect envelope, int count = 25, int seed = 123)
+        public static MemoryProvider<IPointFeature> CreateProviderWithRandomPoints(MRect envelope, int count = 25, int seed = 123)
         {
-            return new GeometryMemoryProvider<IGeometryFeature>(CreateFeatures(GenerateRandomPoints(envelope, count, seed)));
+            return new MemoryProvider<IPointFeature>(CreateFeatures(GenerateRandomPoints(envelope, count, seed)));
         }
 
-        private static IEnumerable<IGeometryFeature> CreateFeatures(IEnumerable<MPoint> randomPoints)
+        private static IEnumerable<IPointFeature> CreateFeatures(IEnumerable<MPoint> randomPoints)
         {
             var counter = 0;
-            return randomPoints.Select(p => new GeometryFeature { Geometry = p.ToPoint(), ["Label"] = counter++.ToString() });
+            return randomPoints.Select(p => new PointFeature { Point = p, ["Label"] = counter++.ToString() });
         }
 
         public static IEnumerable<MPoint> GenerateRandomPoints(MRect envelope, int count = 25, int seed = 192)

--- a/Samples/Mapsui.Samples.Common/Maps/Special/AnimatedPointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/AnimatedPointsSample.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/Samples/Mapsui.Samples.Common/Maps/Special/StackedLabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/StackedLabelsSample.cs
@@ -29,7 +29,7 @@ namespace Mapsui.Samples.Common.Maps
             return map;
         }
 
-        private static ILayer CreateStackedLabelLayer(IProvider<IGeometryFeature> provider, string labelColumn)
+        private static ILayer CreateStackedLabelLayer(IProvider<IPointFeature> provider, string labelColumn)
         {
             return new MemoryLayer
             {
@@ -45,7 +45,7 @@ namespace Mapsui.Samples.Common.Maps
             };
         }
 
-        private static ILayer CreateLayer(IProvider<IGeometryFeature> dataSource)
+        private static ILayer CreateLayer(IProvider<IPointFeature> dataSource)
         {
             return new Layer("Point Layer")
             {

--- a/Tests/Mapsui.Rendering.Skia.Tests/MapRendererTests.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/MapRendererTests.cs
@@ -281,7 +281,7 @@ namespace Mapsui.Rendering.Skia.Tests
             File.WriteToGeneratedFolder(fileName, bitmap);
 
             // assert
-            Assert.IsTrue(CompareBitmaps(File.ReadFromOriginalFolder(fileName), bitmap, 1, 0.99));
+            Assert.IsTrue(CompareBitmaps(File.ReadFromOriginalFolder(fileName), bitmap, 1, 0.995));
         }
 
         private static bool CompareColors(SKColor color1, SKColor color2, int allowedColorDistance)


### PR DESCRIPTION
To prepare for the move to NTS I first limit the use of IGeometryFeature (which depends on Mapsui.Geometries) by using PointFeature and RectFeature where possible.

Side notes. 
- I think it should be named MRectangle instead of MRect.
- I think the IFeature.BoundingBox should be called Extent.