### PR TITLE
Remove lat lon constructor from Position

### DIFF
--- a/Mapsui.UI.Forms/Extensions/PositionExtensions.cs
+++ b/Mapsui.UI.Forms/Extensions/PositionExtensions.cs
@@ -11,7 +11,7 @@
         {
             var result = Projection.SphericalMercator.ToLonLat(point.X, point.Y);
 
-            return new Position(result.lat, result.lon);
+            return new Position { Longitude = result.lon, Latitude = result.lat };
         }
     }
 }

--- a/Mapsui.UI.Forms/Objects/MapSpan.cs
+++ b/Mapsui.UI.Forms/Objects/MapSpan.cs
@@ -80,7 +80,7 @@ namespace Mapsui.UI.Forms
             south = Math.Max(Math.Min(south, 0), -90);
             var lat = Math.Max(Math.Min(Center.Latitude, north), south);
             var maxDLat = Math.Min(north - lat, -south + lat) * 2;
-            return new MapSpan(new Position(lat, Center.Longitude), Math.Min(LatitudeDegrees, maxDLat), LongitudeDegrees);
+            return new MapSpan(new Position { Longitude = Center.Longitude, Latitude = lat }, Math.Min(LatitudeDegrees, maxDLat), LongitudeDegrees);
         }
 
         /// <summary>
@@ -128,7 +128,13 @@ namespace Mapsui.UI.Forms
                 maxLat = Math.Max(maxLat, p.Latitude);
                 maxLon = Math.Max(maxLon, p.Longitude);
             }
-            return new MapSpan(new Position((minLat + maxLat) / 2d, (minLon + maxLon) / 2d), maxLat - minLat, maxLon - minLon);
+            return new MapSpan(
+                new Position
+                {
+                    Longitude = (minLon + maxLon) / 2d,
+                    Latitude = (minLat + maxLat) / 2d
+                },
+                maxLat - minLat, maxLon - minLon);
         }
 
         public override int GetHashCode()

--- a/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
@@ -51,7 +51,7 @@ namespace Mapsui.UI.Objects
             }
         }
 
-        private Position myLocation = new(0, 0);
+        private Position myLocation = new Position { Longitude = 0, Latitude = 0 };
 
         /// <summary>
         /// Position of location, that is displayed
@@ -193,7 +193,11 @@ namespace Mapsui.UI.Objects
                     var animation = new Animation((v) => {
                         var deltaLat = (animationMyLocationEnd.Latitude - animationMyLocationStart.Latitude) * v;
                         var deltaLon = (animationMyLocationEnd.Longitude - animationMyLocationStart.Longitude) * v;
-                        var modified = InternalUpdateMyLocation(new Position(animationMyLocationStart.Latitude + deltaLat, animationMyLocationStart.Longitude + deltaLon));
+                        var modified = InternalUpdateMyLocation(new Position
+                        {
+                            Longitude = animationMyLocationStart.Longitude + deltaLon,
+                            Latitude = animationMyLocationStart.Latitude + deltaLat
+                        });
                         // Update viewport
                         if (modified && mapView.MyLocationFollow && mapView.MyLocationEnabled)
                             mapView.Navigator.CenterOn(MyLocation.ToMapsui());

--- a/Mapsui.UI.Forms/Objects/Position.cs
+++ b/Mapsui.UI.Forms/Objects/Position.cs
@@ -6,38 +6,37 @@ namespace Mapsui.UI.Forms
     /// <summary>
     /// Structure holding latitude and longitude of a position in spherical coordinate system
     /// </summary>
-    public struct Position
+    public readonly struct Position
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:Mapsui.UI.Forms.Position"/> from latitude and longitude
-        /// </summary>
-        /// <param name="latitude">Latitude of position</param>
-        /// <param name="longitude">Longitude of position</param>
-        public Position(double latitude, double longitude)
+        private static double DelimitLongitudeRange(double longitude)
         {
-            Latitude = Math.Min(Math.Max(latitude, -90.0), 90.0);
-            Longitude = Math.Min(Math.Max(longitude, -180.0), 180.0);
+            return Math.Min(Math.Max(longitude, -180.0), 180.0);
+        }
+
+        private static double DelimitLatitudeRange(double latitude)
+        {
+            return Math.Min(Math.Max(latitude, -90.0), 90.0);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Mapsui.UI.Forms.Position"/> from position
         /// </summary>
-        /// <param name="point">Position to use</param>
-        public Position(Position point)
+        /// <param name="position">Position to use</param>
+        public Position(Position position)
         {
-            Latitude = point.Latitude;
-            Longitude = point.Longitude;
+            _longitude = position.Longitude;
+            _latitude = position.Latitude;
         }
 
         /// <summary>
         /// Latitude of position
         /// </summary>
-        public double Latitude { get; }
+        public double Latitude { get => _latitude; init => _latitude = DelimitLatitudeRange(value); }
 
         /// <summary>
         /// Longitude of position
         /// </summary>
-        public double Longitude { get; }
+        public double Longitude { get => _longitude; init => _longitude = DelimitLongitudeRange(value); }
 
         /// <summary>
         /// Convert Xamarin.Forms.Maps.Position to Mapsui.Geometries.Point
@@ -115,7 +114,7 @@ namespace Mapsui.UI.Forms
         /// <param name="format">Format string</param>
         public string ToString(string format)
         {
-            var formats = format.Split(new char[] { '|' }, StringSplitOptions.None);
+            var formats = format.Split(new[] { '|' }, StringSplitOptions.None);
 
             var formatLatitude = formats.Length > 0 && !string.IsNullOrEmpty(formats[0]) ? formats[0] : "P DD° MM.MMM'";
             var formatLongitude = formats.Length > 1 && !string.IsNullOrEmpty(formats[1]) ? formats[1] : "P DDD° MM.MMM'";
@@ -143,6 +142,8 @@ namespace Mapsui.UI.Forms
         /// Format for coordinates with decimal seconds
         /// </summary>
         public const string DecimalSeconds = "P DD° MM' SS.sss\"|P DDD° MM' SS.sss\"|N|S|E|W";
+        private readonly double _latitude;
+        private readonly double _longitude;
 
         private string FormatNumber(double value, string format, string positiveDirection, string negativDirection)
         {

--- a/Mapsui.UI.Forms/Utils/PolylineConverter.cs
+++ b/Mapsui.UI.Forms/Utils/PolylineConverter.cs
@@ -59,7 +59,11 @@ namespace Mapsui.UI.Forms.Utils
                 }
 
                 currentLng += (sum & 1) == 1 ? ~(sum >> 1) : (sum >> 1);
-                var mLatLng = new Position(Convert.ToDouble(currentLat) / 100000.0, Convert.ToDouble(currentLng) / 100000.0);
+                var mLatLng = new Position
+                {
+                    Longitude = Convert.ToDouble(currentLng) / 100000.0,
+                    Latitude = Convert.ToDouble(currentLat) / 100000.0
+                };
                 poly.Add(mLatLng);
             }
 

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
@@ -186,7 +186,7 @@ namespace Mapsui.Samples.Forms
         private void MyLocationPositionChanged(object sender, PositionEventArgs e)
         {
             Device.BeginInvokeOnMainThread(() => {
-                mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position(e.Position.Latitude, e.Position.Longitude));
+                mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position { Longitude = e.Position.Longitude, Latitude = e.Position.Latitude, });
                 mapView.MyLocationLayer.UpdateMyDirection(e.Position.Heading, mapView.Viewport.Rotation);
                 mapView.MyLocationLayer.UpdateMySpeed(e.Position.Speed);
             });

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/ManyPinsSample.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/ManyPinsSample.cs
@@ -146,7 +146,7 @@ namespace Mapsui.Samples.Forms
 
         private Pin CreatePin(int num)
         {
-            var position = new Position(0 + rnd.Next(-85000, +85000) / 1000.0, 0 + rnd.Next(-180000, +180000) / 1000.0);
+            var position = new Position { Longitude = 0 + rnd.Next(-180000, +180000) / 1000.0, Latitude = 0 + rnd.Next(-85000, +85000) / 1000.0 };
 
             var pin = new Pin()
             {
@@ -154,7 +154,7 @@ namespace Mapsui.Samples.Forms
                 Address = position.ToString(),
                 Position = position,
                 Type = PinType.Pin,
-                Color = new Xamarin.Forms.Color(rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0),
+                Color = new Color(rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0, rnd.Next(0, 256) / 256.0),
                 Transparency = 0.5f,
                 Scale = rnd.Next(50, 130) / 100f,
             };

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml.cs
@@ -154,10 +154,10 @@ namespace Mapsui.Samples.Forms
         private void MyLocationPositionChanged(object sender, PositionEventArgs e)
         {
             Device.BeginInvokeOnMainThread(() => {
-                var coords = new UI.Forms.Position(e.Position.Latitude, e.Position.Longitude);
-                info.Text = $"{coords.ToString()} - D:{(int)e.Position.Heading} S:{Math.Round(e.Position.Speed, 2)}";
+                var coords = new UI.Forms.Position { Longitude = e.Position.Longitude, Latitude = e.Position.Latitude };
+                info.Text = $"{coords} - D:{(int)e.Position.Heading} S:{Math.Round(e.Position.Speed, 2)}";
 
-                mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position(e.Position.Latitude, e.Position.Longitude));
+                mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position { Longitude = e.Position.Longitude, Latitude = e.Position.Latitude });
                 mapView.MyLocationLayer.UpdateMyDirection(e.Position.Heading, mapView.Viewport.Rotation);
                 mapView.MyLocationLayer.UpdateMySpeed(e.Position.Speed);
             });

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PinSample.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PinSample.cs
@@ -78,7 +78,7 @@ namespace Mapsui.Samples.Forms.Shared
                         {
                             // Double click on callout moves pin
                             var p = e.Callout.Pin;
-                            p.Position = new Position(p.Position.Latitude + 0.01, p.Position.Longitude);
+                            p.Position = new Position { Longitude = p.Position.Longitude, Latitude = p.Position.Latitude + 0.01 };
                             e.Handled = true;
                             return;
                         }

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PolygonSample.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/PolygonSample.cs
@@ -30,17 +30,17 @@ namespace Mapsui.Samples.Forms
                 FillColor = new Color(random.Next(0, 255) / 255.0, random.Next(0, 255) / 255.0, random.Next(0, 255) / 255.0)
             };
 
-            polygon.Positions.Add(new Position(center.Latitude - diffY, center.Longitude - diffX));
-            polygon.Positions.Add(new Position(center.Latitude + diffY, center.Longitude - diffX));
-            polygon.Positions.Add(new Position(center.Latitude + diffY, center.Longitude + diffX));
-            polygon.Positions.Add(new Position(center.Latitude - diffY, center.Longitude + diffX));
+            polygon.Positions.Add(new Position { Longitude = center.Longitude - diffX, Latitude = center.Latitude - diffY });
+            polygon.Positions.Add(new Position { Longitude = center.Longitude - diffX, Latitude = center.Latitude + diffY });
+            polygon.Positions.Add(new Position { Longitude = center.Longitude + diffX, Latitude = center.Latitude + diffY });
+            polygon.Positions.Add(new Position { Longitude = center.Longitude + diffX, Latitude = center.Latitude - diffY });
 
             // Be carefull: holes should have other direction of Positions.
             // If Positions is clockwise, than Holes should all be counter clockwise and the other way round.
             polygon.Holes.Add(new Position[] {
-                new Position(center.Latitude - diffY * 0.3, center.Longitude - diffX * 0.3),
-                new Position(center.Latitude + diffY * 0.3, center.Longitude + diffX * 0.3),
-                new Position(center.Latitude + diffY * 0.3, center.Longitude - diffX * 0.3),
+                new Position { Longitude = center.Longitude - diffX * 0.3, Latitude = center.Latitude - diffY * 0.3 },
+                new Position { Longitude = center.Longitude + diffX * 0.3, Latitude = center.Latitude + diffY * 0.3 },
+                new Position { Longitude = center.Longitude - diffX * 0.3, Latitude = center.Latitude + diffY * 0.3 },
             });
 
             polygon.IsClickable = true;


### PR DESCRIPTION
@charlenni I noticed the Position had a lat, lon constructor. I had intended Mapsui to always used lon/lat (consistent with x/y) order of coordinates. This PR removes the constructor and replaces it with init properties. The Position is still readonly and there is no order of parameters at all this way.