### PR TITLE
MyLocationLayer: change default value of 'animated' parameter in update methods

### DIFF
--- a/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
@@ -173,7 +173,7 @@ namespace Mapsui.UI.Objects
         /// Updates my location
         /// </summary>
         /// <param name="newLocation">New location</param>
-        public void UpdateMyLocation(Position newLocation, bool animated = true)
+        public void UpdateMyLocation(Position newLocation, bool animated = false)
         {
             if (!MyLocation.Equals(newLocation))
             {
@@ -224,7 +224,7 @@ namespace Mapsui.UI.Objects
         /// </summary>
         /// <param name="newDirection">New direction</param>
         /// <param name="newViewportRotation">New viewport rotation</param>
-        public void UpdateMyDirection(double newDirection, double newViewportRotation, bool animated = true)
+        public void UpdateMyDirection(double newDirection, double newViewportRotation, bool animated = false)
         {
             var newRotation = (int)(newDirection - newViewportRotation);
             var oldRotation = (int)((SymbolStyle)feature.Styles.First()).SymbolRotation;
@@ -295,7 +295,7 @@ namespace Mapsui.UI.Objects
         /// </summary>
         /// <param name="newDirection">New direction</param>
         /// <param name="newViewportRotation">New viewport rotation</param>
-        public void UpdateMyViewDirection(double newDirection, double newViewportRotation, bool animated = true)
+        public void UpdateMyViewDirection(double newDirection, double newViewportRotation, bool animated = false)
         {
             var newRotation = (int)(newDirection - newViewportRotation);
             var oldRotation = (int)((SymbolStyle)featureDir.Styles.First()).SymbolRotation;


### PR DESCRIPTION
It is changed to unanimated updates by default, since the animation can be problematic or misleading in some situations (see e.g. #1338). Cf the rationale in https://github.com/Mapsui/Mapsui/issues/1338#issuecomment-961239334.