### PR TITLE
Fix/timers memory leak

### DIFF
--- a/Mapsui.Core/INavigator.cs
+++ b/Mapsui.Core/INavigator.cs
@@ -3,7 +3,7 @@ using Mapsui.Utilities;
 
 namespace Mapsui
 {
-    public interface INavigator
+    public interface INavigator : IDisposable
     {
         /// <summary>
         /// Called each time one of the navigation methods is called

--- a/Mapsui.Core/Navigator.cs
+++ b/Mapsui.Core/Navigator.cs
@@ -31,7 +31,6 @@ namespace Mapsui
             _map = map;
             _viewport = viewport;
             _animation.Ticked += AnimationTimerTicked;
-
         }
 
         private void AnimationTimerTicked(object sender, AnimationEventArgs e)
@@ -610,6 +609,26 @@ namespace Mapsui
         public void UpdateAnimations()
         {
             _animation.UpdateAnimations();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _animation.Ticked -= AnimationTimerTicked;
+                _animation.Dispose();
+            }
+        }
+
+        ~Navigator()
+        {
+            Dispose(false);
         }
     }
 }

--- a/Mapsui.Core/Utilities/Animation.cs
+++ b/Mapsui.Core/Utilities/Animation.cs
@@ -6,7 +6,7 @@ using System.Timers;
 
 namespace Mapsui.Utilities
 {
-    public class Animation
+    public class Animation : IDisposable
     {
         // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
         private readonly Timer _timer;
@@ -135,6 +135,22 @@ namespace Mapsui.Utilities
                 _entries.AddRange(entries);
                 Start();
             }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            _timer.Dispose();
+        }
+
+        ~Animation()
+        {
+            Dispose(false);
         }
     }
 }

--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -368,16 +368,10 @@ namespace Mapsui.UI.Android
             Context?.StartActivity(chooser);
         }
 
-        public new void Dispose()
-        {
-            Unsubscribe();
-            base.Dispose();
-        }
-
         protected override void Dispose(bool disposing)
         {
-            Unsubscribe();
             base.Dispose(disposing);
+            CommonDispose(disposing);
         }
 
         private static (MPoint centre, double radius, double angle) GetPinchValues(List<MPoint> locations)

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -157,8 +157,6 @@ namespace Mapsui.UI.Forms
 
             Content = view;
 
-            Map = new Map();
-
             BackgroundColor = KnownColor.White;
         }
 

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -832,12 +832,18 @@ namespace Mapsui.UI.Forms
 
         public void Dispose()
         {
-            Unsubscribe();
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
-        protected void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
-            Unsubscribe();
+            CommonDispose(disposing);
+        }
+
+        ~MapControl()
+        {
+            Dispose(false);
         }
 
         private float GetPixelDensity()

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -257,6 +257,7 @@ namespace Mapsui.UI.Wpf
                 if (_navigator != null)
                 {
                     _navigator.Navigated -= Navigated;
+                    _navigator.Dispose();
                 }
                 _navigator = value ?? throw new ArgumentException($"{nameof(Navigator)} can not be null");
                 _navigator.Navigated += Navigated;
@@ -617,6 +618,18 @@ namespace Mapsui.UI.Wpf
             // not sure if we need this method
             _map?.ClearCache();
             RefreshGraphics();
+        }
+
+        private void CommonDispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Unsubscribe();
+                Navigator?.Dispose();
+                StopUpdates();
+                _invalidateTimer?.Dispose();
+            }
+            _invalidateTimer = null;
         }
     }
 }


### PR DESCRIPTION
These days i have been trying to hunt down memory leaks in my xamarin forms application. I was using this code:

```csharp
using System;
using System.Collections.Concurrent;
using System.Collections.Generic;

namespace MyApp
{
    public static class Refs
    {
        private static ConcurrentQueue<WeakReference> _refs = new();

        public static void AddRef(object p)
        {
            _refs.Enqueue(new WeakReference(p));
        }

        private static void Collect()
        {
            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
            GC.WaitForPendingFinalizers();
            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
        }

        public static void Inspect()
        {
            Collect();
            ConcurrentQueue<WeakReference> remainingRefs = new();

            Dictionary<string, int> count = new();
            foreach (var myref in _refs)
            {
                object obj = myref.Target;
                if (obj != null)
                {
                    string k = obj.GetType().FullName;
                    if (count.TryGetValue(k, out int v))
                    {
                        count[k] = v + 1;
                    }
                    else
                    {
                        count[k] = 1;
                    }
                    remainingRefs.Enqueue(myref);
                }
            }
            System.Diagnostics.Debug.WriteLine("\n\n\n----------\nInspect refs\n\n");
            foreach (var kv in count)
            {
                System.Diagnostics.Debug.WriteLine($"{kv.Key} = {kv.Value}");
            }
            System.Diagnostics.Debug.WriteLine("\n---------\n\n\n");
            _refs = remainingRefs;
        }

        public static void Clear()
        {
            _refs.Clear();
        }
    }
}
```

In every view / viewmodel of my application I was calling `Refs.AddRef(this)` to track if the object was being leaked or not.
This code allow to see what object is still not collected when calling Inspect() and to count them by type.
To detect leaks , by calling the `Inspect()` on the xamarin.android part of my xamarin.forms , just after the mainactivity is destroyed (but the app is not killed), i start the app again and again (without killing the process by swiping the app) and each time I look if the number of object that are still alive is increasing or not.

After investigation, by means of commenting large part of codes (halves by halves) to eliminate parts, I found out that the mapcontrol was basically making my whole UI view hierarchy leak.
A little more investigation, i found out that you use timers (there is two , one for the render loop and one for the animations)

these two timers , despite not begin of the same class, they both are disposables, but they are never disposed.

I dont know exactly about the implementations of timers, but i guess that the runtime has to keep a global references on currently active timers somewhere to keep track of them and actually trigger them on time, so if they are not disposed they are never going to be collected , alongside everything these timer references... Disposing the timer seems to remove that global reference.

for example the timer inside the animation class that is inside the navigator:

- the Timer is referenced globally by the runtime (somehow...)
- Timer has a reference on the Animation instance because of  the HandleTimerElapse member method being registered as an event handler on the timer.
- the Animation instance has a reference on the Navigator instance because of AnimationTimerTick member method being an event handler 
- the Navigator has a reference on the MapControl because of member method Navigated being event handler
- in xamarin forms the mapcontrol is a regular view and has basically reference to the whole UI Hierachy because the way the xamarin forms hierarchy is implemented (Element type has a Parent property referencing their parent)

To sum up: (Runtime or some kind of global static) -> Timer -> Animation -> Navigator -> MapControl (-> optionally rest of application being referenced from there).
Thanks to the mark and sweep garbage collector if we cut off the first arrow by disposing the timer, everything else can be garbage collected, even if there are circular references.

So in the case where the mapcontrol is in the mainview of a xamarin forms application, if the application is closed with the back button on android, the activity is destroyed (but the process is not killed). 
If you restart the application a whole new UI hierarchy may be instantiated (i think there may be ways to avoid that, but this is the way the visual studio template does it. I think it is probably best to stick with it, because when the app is terminated in background, I would like that my app uses as little memory as possible). At this point the whole UI hierarchy has been leaked by the timers.

I think that my pull request is far from perfect but this is an first step to show what needs to be done (this is affecting not only xamarin forms but all platform since the timers are in shared code ...). Currently in my application I have taken directly the mapsui code with modifications instead of using the nugets (i added some extra logic to  always unsubscribe all event handlers in dispose including the OnGLPaintSurface and OnPaintSurface out of prevention, i did not actually test if these event handlers created any leaks ...)