### PR TITLE
Use Xamarin Essentials, Maui and Forms have now the same code to open ..

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -21,6 +21,7 @@ using Color = Microsoft.Maui.Graphics.Color;
 using KnownColor = Mapsui.UI.Maui.KnownColor;
 #else
 using SkiaSharp.Views.Forms;
+using Xamarin.Essentials;
 using Xamarin.Forms;
 using KnownColor = Xamarin.Forms.Color;
 #endif
@@ -820,11 +821,7 @@ namespace Mapsui.UI.Forms
 
         public void OpenBrowser(string url)
         {
-#if __MAUI__
             Launcher.OpenAsync(new Uri(url));
-#else
-            Device.OpenUri(new Uri(url));
-#endif
         }
 
         protected void RunOnUIThread(Action action)

--- a/Mapsui.UI.Forms/Mapsui.UI.Forms.csproj
+++ b/Mapsui.UI.Forms/Mapsui.UI.Forms.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="2.80.2" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="2.80.2" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
   </ItemGroup>
 

--- a/NuSpec/Mapsui.Forms.nuspec
+++ b/NuSpec/Mapsui.Forms.nuspec
@@ -22,11 +22,13 @@
       <group targetFramework="netstandard2.0">
         <dependency id="Mapsui" version="$version$"/>
         <dependency id="Xamarin.Forms" version="[5.0.0.2083,6.0)" />
+        <dependency id="Xamarin.Essentials" version="[1.7.0,2.0)" />
         <dependency id="SkiaSharp.Views.Forms" version="[2.80.2,3.0.0)" />		
       </group>
 	  <group targetFramework="xamarinios1.0">
         <dependency id="Mapsui" version="$version$"/>
         <dependency id="Xamarin.Forms" version="[5.0.0.2083,6.0)" />
+        <dependency id="Xamarin.Essentials" version="[1.7.0,2.0)" />
         <dependency id="SkiaSharp.Views.Forms" version="[2.80.2,3.0.0)" />		
       </group>
     </dependencies>


### PR DESCRIPTION
Fix Obsolete warnings in Mapsui.Forms around opening an url. (Is now the same code as Mapsui.Maui) Using Xamarin Essentials.

in Mauis case its Maui.Essentials but they are the "same".