### PR TITLE
Set image used to build the docs to VS 2022 in relation to #1405

### DIFF
--- a/appveyor-docs.yml
+++ b/appveyor-docs.yml
@@ -1,5 +1,5 @@
-version: 1.0.{build}
-image: Visual Studio 2019
+version: '{build}'
+image: Visual Studio 2022
 
 only_commits:
   files:


### PR DESCRIPTION
### What
Set image used to build the docs to VS 2022 

### Why
The same image is used to the code build. This could
prevent possible problem although at this point there is no
concrete indication this will matter.