### PR TITLE
Alter some null checks

### DIFF
--- a/Samples/Mapsui.Samples.Common/Maps/Navigation/KeepCenterInMapSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Navigation/KeepCenterInMapSample.cs
@@ -1,7 +1,6 @@
 ﻿using Mapsui.Layers.Tiling;
 using Mapsui.Projections;
 using Mapsui.UI;
-using Mapsui.Utilities;
 
 namespace Mapsui.Samples.Common.Maps.Navigation
 {
@@ -26,10 +25,10 @@ namespace Mapsui.Samples.Common.Maps.Navigation
             // Madagaskar is used. In such a scenario it makes sense to also limit
             // the top ZoomLimit.
 
-            map.Limiter.PanLimits = GetLimitsOfMadagaskar();
+            var extent = GetLimitsOfMadagaskar();
+            map.Limiter.PanLimits = extent;
             map.Limiter.ZoomLimits = new MinMax(0.15, 2500);
-            if (map.Limiter.PanLimits != null)
-                map.Home = n => n.NavigateTo(map.Limiter.PanLimits);
+            map.Home = n => n.NavigateTo(extent);
             return map;
         }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Projection/MultiPolygonProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Projection/MultiPolygonProjectionSample.cs
@@ -33,7 +33,7 @@ namespace Mapsui.Samples.Common.Maps.Projection
             // the Map CRS.
 
             var geometryLayer = CreateWgs84Layer();
-            var extent = geometryLayer.Extent?.Grow(10000);
+            var extent = geometryLayer.Extent!.Grow(10000);
             var map = new Map
             {
                 CRS = "EPSG:3857", // The Map CRS needs to be set
@@ -41,8 +41,7 @@ namespace Mapsui.Samples.Common.Maps.Projection
             };
             map.Layers.Add(OpenStreetMap.CreateTileLayer());
             map.Layers.Add(geometryLayer);
-            if (extent != null)
-                map.Home = n => n.NavigateTo(extent);
+            map.Home = n => n.NavigateTo(extent);
             return map;
         }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
@@ -28,7 +28,7 @@ namespace Mapsui.Samples.Common.Maps.Projection
             // the Map CRS.
 
             var geometryLayer = CreateWorldCitiesLayer();
-            var extent = geometryLayer.Extent?.Grow(10000);
+            var extent = geometryLayer.Extent!.Grow(10000);
             var map = new Map
             {
                 CRS = "EPSG:3857", // The Map CRS needs to be set
@@ -36,8 +36,7 @@ namespace Mapsui.Samples.Common.Maps.Projection
             };
             map.Layers.Add(OpenStreetMap.CreateTileLayer());
             map.Layers.Add(geometryLayer);
-            if (extent != null)
-                map.Home = n => n.NavigateTo(extent);
+            map.Home = n => n.NavigateTo(extent);
             return map;
         }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Special/ManyVerticesSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/ManyVerticesSample.cs
@@ -29,9 +29,8 @@ namespace Mapsui.Samples.Common.Maps
 
             map.Layers.Add(OpenStreetMap.CreateTileLayer());
             map.Layers.Add(new RasterizingLayer(CreatePointLayer(), pixelDensity: pixelDensity));
-            var extent = map.Layers[1].Extent?.Grow(map.Layers[1].Extent!.Width * 0.25);
-            if (extent != null)
-                map.Home = n => n.NavigateTo(extent);
+            var extent = map.Layers[1].Extent!.Grow(map.Layers[1].Extent!.Width * 0.25);
+            map.Home = n => n.NavigateTo(extent);
             return map;
         }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Special/RasterizingLayerSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/RasterizingLayerSample.cs
@@ -23,9 +23,8 @@ namespace Mapsui.Samples.Common.Maps
             var map = new Map();
             map.Layers.Add(OpenStreetMap.CreateTileLayer());
             map.Layers.Add(new RasterizingLayer(CreateRandomPointLayer(), pixelDensity: pixelDensity));
-            var extent = map.Layers[1].Extent?.Grow(map.Layers[1].Extent!.Width * 0.1);
-            if (extent != null)
-                map.Home = n => n.NavigateTo(extent);
+            var extent = map.Layers[1].Extent!.Grow(map.Layers[1].Extent!.Width * 0.1);
+            map.Home = n => n.NavigateTo(extent);
             return map;
         }
 

--- a/Samples/Mapsui.Samples.Wpf.Editing/MainWindow.xaml.cs
+++ b/Samples/Mapsui.Samples.Wpf.Editing/MainWindow.xaml.cs
@@ -166,9 +166,8 @@ namespace Mapsui.Samples.Wpf.Editing
 
             _editManager.EditMode = EditMode.Modify;
             Loaded += (sender, args) => {
-                var extent = _editManager.Layer.Extent?.Grow(_editManager.Layer.Extent.Width * 0.2);
-                if (extent != null)
-                    MapControl.Navigator.NavigateTo(extent);
+                var extent = _editManager.Layer.Extent!.Grow(_editManager.Layer.Extent.Width * 0.2);
+                MapControl.Navigator.NavigateTo(extent);
             };
         }
 


### PR DESCRIPTION
This MR is not very important. It is mainly a kind of thinking aloud about how to go about nullability. 

I checked all the calls to void NavigateTo(MRect) in the samples. What I do now is add the ! when doing the Grow. This will result in an crash at that point. And I think that is a good thing. The Home method is called later on, and that would make it harder to find the bug.

There should be some form of try catch around creating the sample map so we can show the error to the user.