### PR TITLE
…Changed TileLayer to handle IFeature instead of RasterFeature

### DIFF
--- a/Mapsui.Layers.Tiling/Fetcher/TileFetchDispatcher.cs
+++ b/Mapsui.Layers.Tiling/Fetcher/TileFetchDispatcher.cs
@@ -17,18 +17,18 @@ namespace Mapsui.Fetcher
         private readonly object _lockRoot = new();
         private bool _busy;
         private bool _viewportIsModified;
-        private readonly ITileCache<RasterFeature?> _tileCache;
+        private readonly ITileCache<IFeature?> _tileCache;
         private readonly IDataFetchStrategy _dataFetchStrategy;
         private readonly ConcurrentQueue<TileInfo> _tilesToFetch = new();
         private readonly ConcurrentHashSet<TileIndex> _tilesInProgress = new();
         private readonly ITileSchema? _tileSchema;
         private readonly FetchMachine _fetchMachine;
-        private readonly Func<TileInfo, RasterFeature?> _fetchTileAsFeature;
+        private readonly Func<TileInfo, IFeature?> _fetchTileAsFeature;
 
         public TileFetchDispatcher(
-            ITileCache<RasterFeature?> tileCache,
+            ITileCache<IFeature?> tileCache,
             ITileSchema? tileSchema,
-            Func<TileInfo, RasterFeature?> fetchTileAsFeature,
+            Func<TileInfo, IFeature?> fetchTileAsFeature,
             IDataFetchStrategy? dataFetchStrategy = null)
         {
             _tileCache = tileCache;
@@ -95,7 +95,7 @@ namespace Mapsui.Fetcher
             }
         }
 
-        private void FetchCompleted(TileInfo tileInfo, RasterFeature? feature, Exception? exception)
+        private void FetchCompleted(TileInfo tileInfo, IFeature? feature, Exception? exception)
         {
             lock (_lockRoot)
             {

--- a/Mapsui.Layers.Tiling/Layers/TileLayer.cs
+++ b/Mapsui.Layers.Tiling/Layers/TileLayer.cs
@@ -58,10 +58,10 @@ namespace Mapsui.Layers
         // ReSharper disable once UnusedParameter.Local // Is public and won't break this now
         public TileLayer(ITileSource tileSource, int minTiles = 200, int maxTiles = 300,
             IDataFetchStrategy? dataFetchStrategy = null, IRenderFetchStrategy? renderFetchStrategy = null,
-            int minExtraTiles = -1, int maxExtraTiles = -1, Func<TileInfo, RasterFeature?>? fetchTileAsFeature = null)
+            int minExtraTiles = -1, int maxExtraTiles = -1, Func<TileInfo, IFeature?>? fetchTileAsFeature = null)
         {
             _tileSource = tileSource ?? throw new ArgumentException($"{tileSource} can not null");
-            MemoryCache = new MemoryCache<RasterFeature?>(minTiles, maxTiles);
+            MemoryCache = new MemoryCache<IFeature?>(minTiles, maxTiles);
             Style = new VectorStyle { Outline = { Color = Color.FromArgb(0, 0, 0, 0) } }; // initialize with transparent outline
             Attribution.Text = _tileSource.Attribution?.Text;
             Attribution.Url = _tileSource.Attribution?.Url;
@@ -82,7 +82,7 @@ namespace Mapsui.Layers
         /// <summary>
         /// Memory cache for this layer
         /// </summary>
-        private MemoryCache<RasterFeature?> MemoryCache { get; }
+        private MemoryCache<IFeature?> MemoryCache { get; }
 
         /// <inheritdoc />
         public override IReadOnlyList<double> Resolutions => _tileSource.Schema.Resolutions.Select(r => r.Value.UnitsPerPixel).ToList();

--- a/Mapsui.Layers.Tiling/Rendering/IRenderFetchStrategy.cs
+++ b/Mapsui.Layers.Tiling/Rendering/IRenderFetchStrategy.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using BruTile;
 using BruTile.Cache;
-using Mapsui.Layers;
 
 namespace Mapsui.Rendering
 {
@@ -17,6 +16,6 @@ namespace Mapsui.Rendering
         /// <param name="memoryCache">The cached features from which to select</param>
         /// <returns></returns>
         IList<IFeature> Get(MRect extent, double resolution, ITileSchema schema,
-            ITileCache<RasterFeature?> memoryCache);
+            ITileCache<IFeature?> memoryCache);
     }
 }

--- a/Mapsui.Layers.Tiling/Rendering/MinimalRenderFetchStrategy.cs
+++ b/Mapsui.Layers.Tiling/Rendering/MinimalRenderFetchStrategy.cs
@@ -2,13 +2,12 @@ using System.Collections.Generic;
 using BruTile;
 using BruTile.Cache;
 using Mapsui.Extensions;
-using Mapsui.Layers;
 
 namespace Mapsui.Rendering
 {
     public class MinimalRenderFetchStrategy : IRenderFetchStrategy
     {
-        public IList<IFeature> Get(MRect? extent, double resolution, ITileSchema schema, ITileCache<RasterFeature?> memoryCache)
+        public IList<IFeature> Get(MRect? extent, double resolution, ITileSchema schema, ITileCache<IFeature?> memoryCache)
         {
             var result = new List<IFeature>();
             if (extent == null)

--- a/Mapsui.Layers.Tiling/Rendering/RenderFetchStrategy.cs
+++ b/Mapsui.Layers.Tiling/Rendering/RenderFetchStrategy.cs
@@ -3,13 +3,12 @@ using System.Linq;
 using BruTile;
 using BruTile.Cache;
 using Mapsui.Extensions;
-using Mapsui.Layers;
 
 namespace Mapsui.Rendering
 {
     public class RenderFetchStrategy : IRenderFetchStrategy
     {
-        public IList<IFeature> Get(MRect extent, double resolution, ITileSchema schema, ITileCache<RasterFeature?> memoryCache)
+        public IList<IFeature> Get(MRect extent, double resolution, ITileSchema schema, ITileCache<IFeature?> memoryCache)
         {
             var dictionary = new Dictionary<TileIndex, IFeature>();
             var level = BruTile.Utilities.GetNearestLevel(schema.Resolutions, resolution);
@@ -19,7 +18,7 @@ namespace Mapsui.Rendering
         }
 
         public static void GetRecursive(IDictionary<TileIndex, IFeature> resultTiles, ITileSchema schema,
-            ITileCache<RasterFeature?> cache, Extent extent, int level)
+            ITileCache<IFeature?> cache, Extent extent, int level)
         {
             // to improve performance, convert the resolutions to a list so they can be walked up by
             // simply decrementing an index when the level index needs to change
@@ -35,7 +34,7 @@ namespace Mapsui.Rendering
         }
 
         private static void GetRecursive(IDictionary<TileIndex, IFeature> resultTiles, ITileSchema schema,
-            ITileCache<RasterFeature?> cache, Extent extent, IList<KeyValuePair<int, Resolution>> resolutions, int resolutionIndex)
+            ITileCache<IFeature?> cache, Extent extent, IList<KeyValuePair<int, Resolution>> resolutions, int resolutionIndex)
         {
             if (resolutionIndex < 0 || resolutionIndex >= resolutions.Count)
                 return;
@@ -49,7 +48,7 @@ namespace Mapsui.Rendering
                 // Geometry can be null for some tile sources to indicate the tile is not present.
                 // It is stored in the tile cache to prevent retries. It should not be returned to the 
                 // renderer.
-                if (feature?.Raster == null)
+                if (feature == null)
                 {
                     // only continue the recursive search if this tile is within the extent
                     if (tileInfo.Extent.Intersects(extent))

--- a/Tests/Mapsui.Tests/Fetcher/FetchMachineTests.cs
+++ b/Tests/Mapsui.Tests/Fetcher/FetchMachineTests.cs
@@ -25,7 +25,7 @@ namespace Mapsui.Tests.Fetcher
             var tileProvider = new CountingTileProvider();
             var tileSchema = new GlobalSphericalMercator();
             var tileSource = new TileSource(tileProvider, tileSchema);
-            using var cache = new MemoryCache<RasterFeature?>();
+            using var cache = new MemoryCache<IFeature?>();
             var fetchDispatcher = new TileFetchDispatcher(cache, tileSource.Schema, tileInfo => TileToFeature(tileSource, tileInfo));
             var tileMachine = new FetchMachine(fetchDispatcher);
             var level = 3;
@@ -52,7 +52,7 @@ namespace Mapsui.Tests.Fetcher
             var tileProvider = new CountingTileProvider();
             var tileSchema = new GlobalSphericalMercator();
             var tileSource = new TileSource(tileProvider, tileSchema);
-            using var cache = new MemoryCache<RasterFeature?>();
+            using var cache = new MemoryCache<IFeature?>();
             var fetchDispatcher = new TileFetchDispatcher(cache, tileSource.Schema, tileInfo => TileToFeature(tileSource, tileInfo));
             var tileMachine = new FetchMachine(fetchDispatcher);
             var level = 3;
@@ -84,7 +84,7 @@ namespace Mapsui.Tests.Fetcher
             var tileProvider = new NullTileProvider();
             var tileSchema = new GlobalSphericalMercator();
             var tileSource = new TileSource(tileProvider, tileSchema);
-            using var cache = new MemoryCache<RasterFeature?>();
+            using var cache = new MemoryCache<IFeature?>();
             var fetchDispatcher = new TileFetchDispatcher(cache, tileSource.Schema, tileInfo => TileToFeature(tileSource, tileInfo));
             var tileMachine = new FetchMachine(fetchDispatcher);
             var level = 3;
@@ -110,7 +110,7 @@ namespace Mapsui.Tests.Fetcher
             var tileProvider = new FailingTileProvider();
             var tileSchema = new GlobalSphericalMercator();
             var tileSource = new TileSource(tileProvider, tileSchema);
-            using var cache = new MemoryCache<RasterFeature?>();
+            using var cache = new MemoryCache<IFeature?>();
             var fetchDispatcher = new TileFetchDispatcher(cache, tileSource.Schema, tileInfo => TileToFeature(tileSource, tileInfo));
             var tileMachine = new FetchMachine(fetchDispatcher);
             var level = 3;
@@ -138,7 +138,7 @@ namespace Mapsui.Tests.Fetcher
             var tileProvider = new SometimesFailingTileProvider();
             var tileSchema = new GlobalSphericalMercator();
             var tileSource = new TileSource(tileProvider, tileSchema);
-            using var cache = new MemoryCache<RasterFeature?>();
+            using var cache = new MemoryCache<IFeature?>();
             var fetchDispatcher = new TileFetchDispatcher(cache, tileSource.Schema, tileInfo => TileToFeature(tileSource, tileInfo));
             var tileMachine = new FetchMachine(fetchDispatcher);
             var level = 3;
@@ -170,7 +170,7 @@ namespace Mapsui.Tests.Fetcher
             var tileProvider = new CountingTileProvider();
             var tileSchema = new GlobalSphericalMercator();
             var tileSource = new TileSource(tileProvider, tileSchema);
-            using var cache = new MemoryCache<RasterFeature?>();
+            using var cache = new MemoryCache<IFeature?>();
             var fetchDispatcher = new TileFetchDispatcher(cache, tileSource.Schema, tileInfo => TileToFeature(tileSource, tileInfo));
             var tileMachine = new FetchMachine(fetchDispatcher);
             var numberOfWorkers = 8;

--- a/Tests/Mapsui.Tests/Rendering/RenderFetchStrategyTests.cs
+++ b/Tests/Mapsui.Tests/Rendering/RenderFetchStrategyTests.cs
@@ -20,7 +20,7 @@ namespace Mapsui.Tests.Rendering
             var box = schema.Extent.ToMRect();
             const int level = 3;
             var resolution = schema.Resolutions[level];
-            var memoryCache = PopulateMemoryCache(schema, new MemoryCache<RasterFeature?>(), level);
+            var memoryCache = PopulateMemoryCache(schema, new MemoryCache<IFeature?>(), level);
             var renderFetchStrategy = new RenderFetchStrategy();
 
             // act
@@ -30,7 +30,7 @@ namespace Mapsui.Tests.Rendering
             Assert.True(tiles.Count == 43);
         }
 
-        private static ITileCache<RasterFeature?> PopulateMemoryCache(GlobalSphericalMercator schema, MemoryCache<RasterFeature?> cache, int levelId)
+        private static ITileCache<IFeature?> PopulateMemoryCache(GlobalSphericalMercator schema, MemoryCache<IFeature?> cache, int levelId)
         {
             for (var i = levelId; i >= 0; i--)
             {


### PR DESCRIPTION
Changed TileLayer to handle IFeature instead of RasterFeature, so that it could be used for all other types of tiled data, not only raster data.

Only problem could occur in RenderFetchStrategy.cs, line 51, where is checked, if the returned Feature has a Raster that isn't null. Perhaps IFeature could have a HasData flag for this.