### PR TITLE
Making clone return IGeometry object, and avoid breaking inheritance calls

### DIFF
--- a/Mapsui.Geometries/BoundingBox.cs
+++ b/Mapsui.Geometries/BoundingBox.cs
@@ -84,8 +84,8 @@ namespace Mapsui.Geometries
                     continue;
                 }
 
-                min ??= boundingBox.Min.Clone();
-                max ??= boundingBox.Max.Clone();
+                min ??= (Point)boundingBox.Min.Clone();
+                max ??= (Point)boundingBox.Max.Clone();
 
                 min.X = Math.Min(boundingBox.Min.X, min.X);
                 min.Y = Math.Min(boundingBox.Min.Y, min.Y);

--- a/Mapsui.Geometries/Geometry.cs
+++ b/Mapsui.Geometries/Geometry.cs
@@ -111,10 +111,7 @@ namespace Mapsui.Geometries
         ///     This method must be overridden using 'public new [derived_data_type] Clone()'
         /// </summary>
         /// <returns>Copy of Geometry</returns>
-        public Geometry Clone()
-        {
-            throw new Exception("Clone() has not been implemented on derived datatype");
-        }
+        public abstract IGeometry Clone();
 
         /// <summary>
         ///     Creates a <see cref="Geometry" /> based on a WellKnownText string

--- a/Mapsui.Geometries/GeometryCollection.cs
+++ b/Mapsui.Geometries/GeometryCollection.cs
@@ -181,13 +181,13 @@ namespace Mapsui.Geometries
             return hash;
         }
 
-        public new GeometryCollection Clone()
+        public override IGeometry Clone()
         {
             var geometryCollection = new GeometryCollection();
 
             foreach (var geometry in this)
             {
-                geometryCollection.Collection.Add(geometry.Clone());
+                geometryCollection.Collection.Add((Geometry)geometry.Clone());
             }
 
             return geometryCollection;

--- a/Mapsui.Geometries/IGeometry.cs
+++ b/Mapsui.Geometries/IGeometry.cs
@@ -15,8 +15,6 @@
 // along with SharpMap; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
 
-using System;
-
 namespace Mapsui.Geometries
 {
     /// <summary>
@@ -63,7 +61,7 @@ namespace Mapsui.Geometries
         ///     This method must be overridden using 'public new [derived_data_type] Clone()'
         /// </summary>
         /// <returns>Copy of Geometry</returns>
-        Geometry Clone();
+        IGeometry Clone();
 
         /// <summary>
         ///     Returns 'true' if this <see cref="Geometry" /> is 'spatially equal' to another <see cref="Geometry" />

--- a/Mapsui.Geometries/LineString.cs
+++ b/Mapsui.Geometries/LineString.cs
@@ -158,12 +158,12 @@ namespace Mapsui.Geometries
         ///     Return a copy of this geometry
         /// </summary>
         /// <returns>Copy of Geometry</returns>
-        public new LineString Clone()
+        public override IGeometry Clone()
         {
             var l = new LineString();
             foreach (var vertex in Vertices)
             {
-                l.Vertices.Add(vertex.Clone());
+                l.Vertices.Add((Point)vertex.Clone());
             }
             return l;
         }

--- a/Mapsui.Geometries/LinearRing.cs
+++ b/Mapsui.Geometries/LinearRing.cs
@@ -75,12 +75,12 @@ namespace Mapsui.Geometries
         ///     Return a copy of this geometry
         /// </summary>
         /// <returns>Copy of Geometry</returns>
-        public new LinearRing Clone()
+        public override IGeometry Clone()
         {
             var linearRing = new LinearRing();
             for (var i = 0; i < Vertices.Count; i++)
             {
-                linearRing.Vertices.Add(Vertices[i].Clone());
+                linearRing.Vertices.Add((Point)Vertices[i].Clone());
             }
             return linearRing;
         }
@@ -169,7 +169,7 @@ namespace Mapsui.Geometries
         public LineString GetLineString()
         {
             // Make deep copy
-            var tmpLineString = Clone();
+            var tmpLineString = (LinearRing)Clone();
 
             // Check if first vertex is approximately equal to last vertex
             if (Math.Abs(tmpLineString.StartPoint.X - tmpLineString.EndPoint.X) > double.Epsilon ||
@@ -185,7 +185,7 @@ namespace Mapsui.Geometries
 
         public LinearRing Rotate(double degrees, Point center)
         {
-            var rotatedLinearRing = Clone();
+            var rotatedLinearRing = (LinearRing)Clone();
             for (var i = 0; i < Vertices.Count; i++)
             {
                 rotatedLinearRing.Vertices[i] = Vertices[i].Rotate(degrees, center);

--- a/Mapsui.Geometries/MultiLineString.cs
+++ b/Mapsui.Geometries/MultiLineString.cs
@@ -159,12 +159,12 @@ namespace Mapsui.Geometries
         ///     Return a copy of this geometry
         /// </summary>
         /// <returns>Copy of Geometry</returns>
-        public new MultiLineString Clone()
+        public override IGeometry Clone()
         {
             var geoms = new MultiLineString();
             foreach (var lineString in LineStrings)
             {
-                geoms.LineStrings.Add(lineString.Clone());
+                geoms.LineStrings.Add((LineString)lineString.Clone());
             }
             return geoms;
         }

--- a/Mapsui.Geometries/MultiPoint.cs
+++ b/Mapsui.Geometries/MultiPoint.cs
@@ -125,12 +125,12 @@ namespace Mapsui.Geometries
         ///     Return a copy of this geometry
         /// </summary>
         /// <returns>Copy of Geometry</returns>
-        public new MultiPoint Clone()
+        public override IGeometry Clone()
         {
             var geoms = new MultiPoint();
             foreach (var point in Points)
             {
-                geoms.Points.Add(point.Clone());
+                geoms.Points.Add((Point)point.Clone());
             }
             return geoms;
         }

--- a/Mapsui.Geometries/MultiPolygon.cs
+++ b/Mapsui.Geometries/MultiPolygon.cs
@@ -133,12 +133,12 @@ namespace Mapsui.Geometries
         ///     Return a copy of this geometry
         /// </summary>
         /// <returns>Copy of Geometry</returns>
-        public new MultiPolygon Clone()
+        public override IGeometry Clone()
         {
             var geoms = new MultiPolygon();
             foreach (var polygon in Polygons)
             {
-                geoms.Polygons.Add(polygon.Clone());
+                geoms.Polygons.Add((Polygon)polygon.Clone());
             }
             return geoms;
         }

--- a/Mapsui.Geometries/Point.cs
+++ b/Mapsui.Geometries/Point.cs
@@ -16,7 +16,6 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Mapsui.Geometries.Utilities;
 
 // ReSharper disable NonReadonlyMemberInGetHashCode // todo: Fix this real issue
@@ -204,7 +203,7 @@ namespace Mapsui.Geometries
         ///     This method must be overridden using 'public new [derived_data_type] Clone()'
         /// </summary>
         /// <returns>Clone</returns>
-        public new Point Clone()
+        public override IGeometry Clone()
         {
             return new Point(X, Y);
         }

--- a/Mapsui.Geometries/Polygon.cs
+++ b/Mapsui.Geometries/Polygon.cs
@@ -131,12 +131,12 @@ namespace Mapsui.Geometries
         ///     Return a copy of this geometry
         /// </summary>
         /// <returns>Copy of Geometry</returns>
-        public new Polygon Clone()
+        public override IGeometry Clone()
         {
-            var polygon = new Polygon { ExteriorRing = ExteriorRing?.Clone() };
+            var polygon = new Polygon { ExteriorRing = ExteriorRing?.Clone() as LinearRing };
             foreach (var interiorRing in InteriorRings)
             {
-                polygon.InteriorRings.Add(interiorRing.Clone());
+                polygon.InteriorRings.Add((LinearRing)interiorRing.Clone());
             }
             return polygon;
         }
@@ -213,7 +213,7 @@ namespace Mapsui.Geometries
 
         public Polygon Rotate(double degrees, Point center)
         {
-            var rotatedPolygon = Clone();
+            var rotatedPolygon = (Polygon)Clone();
             rotatedPolygon.ExteriorRing = ExteriorRing?.Rotate(degrees, center);
             for (var i = 0; i < InteriorRings.Count; i++)
             {

--- a/Samples/Mapsui.Samples.Wpf.Editing/Editing/EditManager.cs
+++ b/Samples/Mapsui.Samples.Wpf.Editing/Editing/EditManager.cs
@@ -5,7 +5,6 @@ using Mapsui.Extensions;
 using Mapsui.Geometries;
 using Mapsui.GeometryLayer;
 using Mapsui.Layers;
-using Mapsui.Providers;
 using Mapsui.UI;
 using Point = Mapsui.Geometries.Point;
 
@@ -84,9 +83,9 @@ namespace Mapsui.Samples.Wpf.Editing.Editing
             }
             else if (EditMode == EditMode.AddLine)
             {
-                var firstPoint = worldPosition.Clone();
+                var firstPoint = (Point)worldPosition.Clone();
                 // Add a second point right away. The second one will be the 'hover' vertex
-                var secondPoint = worldPosition.Clone();
+                var secondPoint = (Point)worldPosition.Clone();
                 _addInfo.Vertex = secondPoint;
                 _addInfo.Feature = new GeometryFeature { Geometry = new LineString(new[] { firstPoint, secondPoint }) };
                 _addInfo.Vertices = _addInfo.Feature.Geometry.MainVertices();
@@ -98,17 +97,17 @@ namespace Mapsui.Samples.Wpf.Editing.Editing
             {
                 var lineString = _addInfo.Feature?.Geometry as LineString;
                 // Set the final position of the 'hover' vertex (that was already part of the geometry)
-                SetPointXY(_addInfo.Vertex, worldPosition.Clone());
-                _addInfo.Vertex = worldPosition.Clone(); // and create a new hover vertex
+                SetPointXY(_addInfo.Vertex, (Point)worldPosition.Clone());
+                _addInfo.Vertex = (Point)worldPosition.Clone(); // and create a new hover vertex
                 lineString?.Vertices.Add(_addInfo.Vertex); // and add it to the geometry
                 _addInfo.Feature?.RenderedGeometry?.Clear();
                 Layer?.DataHasChanged();
             }
             else if (EditMode == EditMode.AddPolygon)
             {
-                var firstPoint = worldPosition.Clone();
+                var firstPoint = (Point)worldPosition.Clone();
                 // Add a second point right away. The second one will be the 'hover' vertex
-                var secondPoint = worldPosition.Clone();
+                var secondPoint = (Point)worldPosition.Clone();
                 _addInfo.Vertex = secondPoint;
                 _addInfo.Feature = new GeometryFeature
                 {
@@ -126,8 +125,8 @@ namespace Mapsui.Samples.Wpf.Editing.Editing
             {
                 var polygon = _addInfo.Feature?.Geometry as Polygon;
                 // Set the final position of the 'hover' vertex (that was already part of the geometry)
-                SetPointXY(_addInfo.Vertex, worldPosition.Clone());
-                _addInfo.Vertex = worldPosition.Clone(); // and create a new hover vertex
+                SetPointXY(_addInfo.Vertex, (Point)worldPosition.Clone());
+                _addInfo.Vertex = (Point)worldPosition.Clone(); // and create a new hover vertex
                 polygon?.ExteriorRing?.Vertices.Add(_addInfo.Vertex); // and add it to the geometry
                 _addInfo.Feature?.RenderedGeometry?.Clear();
                 Layer?.DataHasChanged();


### PR DESCRIPTION
As discussed in Issue #1445 the current Clone implementation breaks inheritance due to the redefinition of Clone in each derived class.
This prevents the GeometryCollection from being able to be cloned and prevents users from creating custom geometry.

These changes worked for me in getting it to work with a custom derived geometry.
Unfortunately I wasn't able to test it against the full project, since it fails to build on my Visual Studio setup (different versions or other dependencies that are causing issues, that I didn't bother to figure out).