### PR TITLE
[3.0.x] Fix WFS sample

### DIFF
--- a/Samples/Mapsui.Samples.Common/Maps/Data/WfsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Data/WfsSample.cs
@@ -22,10 +22,12 @@ namespace Mapsui.Samples.Common.Maps.Data
         public void Setup(IMapControl mapControl)
         {
             mapControl.Map = CreateMap();
+            var bb = new BoundingBox(1100000.0, 5800000.0, 1400000.0, 6000000.0);
+            mapControl.Navigator.NavigateTo(bb);
         }
 
         private const string wfsUri = "https://geoservices.buergernetz.bz.it/geoserver/ows";
-        private const string crs = "EPSG:25832";
+        private const string crs = "EPSG:3857";  // originally: "EPSG:25832"
         private const string layerName = "MAPS_DISTRICTS_VW";
         private const string nsPrefix = "gvcc_maps";
         private const string labelField = "CAMM_NOME_DE";
@@ -39,13 +41,7 @@ namespace Mapsui.Samples.Common.Maps.Data
                 map.Layers.Add(CreateTileLayer(CreateTileSource()));
                 map.Layers.Add(CreateWfsLayer(provider));
                 map.Layers.Add(CreateLabelLayer(provider));
-                
-                var bb = new BoundingBox(550000, 5050000, 800000, 5400000);
-                map.Limiter = new ViewportLimiterKeepWithin
-                {
-                    PanLimits = bb
-                };
-                
+
                 return map;
                 
             }
@@ -105,20 +101,25 @@ namespace Mapsui.Samples.Common.Maps.Data
         
         
         
+        //public static HttpTileSource CreateTileSource()
+        //{
+        //    using (var httpClient = new HttpClient())
+        //    using (var response = httpClient.GetStreamAsync("https://geoservices.buergernetz.bz.it/mapproxy/service/ows?SERVICE=WMTS&REQUEST=GetCapabilities").Result)
+        //    {
+        //        var tileSources = WmtsParser.Parse(response);
+        //        return tileSources.First(t =>
+        //            ((WmtsTileSchema) t.Schema).Layer == "P_BZ_OF_2014_2015_2017" && t.Schema.Srs == "EPSG:25832");
+        //    }
+        //}
+
         public static HttpTileSource CreateTileSource()
         {
-            using (var httpClient = new HttpClient())
-            using (var response = httpClient.GetStreamAsync("https://geoservices.buergernetz.bz.it/mapproxy/service/ows?SERVICE=WMTS&REQUEST=GetCapabilities").Result)
-            {
-                var tileSources = WmtsParser.Parse(response);
-                return tileSources.First(t =>
-                    ((WmtsTileSchema) t.Schema).Layer == "P_BZ_OF_2014_2015_2017" && t.Schema.Srs == "EPSG:25832");
-            }
+            return BruTile.Predefined.KnownTileSources.Create(BruTile.Predefined.KnownTileSource.OpenStreetMap);
         }
 
         public static ILayer CreateTileLayer(ITileSource tileSource, string name = null)
         {
-            return new TileLayer(tileSource) {Name = name ?? tileSource.Name};
+            return new TileLayer(tileSource) { Name = name ?? tileSource.Name, CRS = crs };
         }
 
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Data/WfsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Data/WfsSample.cs
@@ -24,14 +24,18 @@ namespace Mapsui.Samples.Common.Maps.Data
             mapControl.Map = CreateMap();
         }
 
+        private const string wfsUri = "https://geoservices.buergernetz.bz.it/geoserver/ows";
+        private const string crs = "EPSG:25832";
+        private const string layerName = "MAPS_DISTRICTS_VW";
+        private const string nsPrefix = "gvcc_maps";
+        private const string labelField = "CAMM_NOME_DE";
+
         public static Map CreateMap()
         {
             try
             {
-                const string serviceUri = "https://geoservices.buergernetz.bz.it/geoserver/ows";
-
-                var map = new Map() {CRS = "EPSG:25832"};
-                var provider = CreateWfsProvider(serviceUri);
+                var map = new Map() {CRS = crs};
+                var provider = CreateWfsProvider(wfsUri);
                 map.Layers.Add(CreateTileLayer(CreateTileSource()));
                 map.Layers.Add(CreateWfsLayer(provider));
                 map.Layers.Add(CreateLabelLayer(provider));
@@ -54,7 +58,7 @@ namespace Mapsui.Samples.Common.Maps.Data
 
         private static ILayer CreateWfsLayer(WFSProvider provider)
         {
-            return new Layer("COMUNI_AMMINISTRATIVI")
+            return new Layer(layerName)
             {
                 Style = new VectorStyle {Fill = new Brush {Color = Color.Red}},
                 DataSource = provider,
@@ -64,13 +68,13 @@ namespace Mapsui.Samples.Common.Maps.Data
 
         private static WFSProvider CreateWfsProvider(string getCapabilitiesUri)
         {
-            var provider = new WFSProvider(getCapabilitiesUri, "p_bz-cadastre", "COMUNI_AMMINISTRATIVI",
+            var provider = new WFSProvider(getCapabilitiesUri, nsPrefix, layerName,
                 WFSProvider.WFSVersionEnum.WFS_1_1_0)
             {
                 QuickGeometries = false,
                 GetFeatureGetRequest = true,
-                CRS = "EPSG:25832",
-                Labels = new List<string> {"CAMM_NOME_DE"}
+                CRS = crs,
+                Labels = new List<string> { labelField }
             };
             return provider;
         }
@@ -81,7 +85,6 @@ namespace Mapsui.Samples.Common.Maps.Data
             // Labels are collected when parsing the geometry. So there's just one 'GetFeature' call necessary.
             // Otherwise (when calling twice for retrieving labels) there may be an inconsistent read...
             // If a label property is set, the quick geometry option is automatically set to 'false'.
-            const string labelField = "CAMM_NOME_DE";
             provider.Labels.Add(labelField);
 
             return new Layer("labels")


### PR DESCRIPTION
This fixes the errors from #1464 on the branch `develop/3.0` and makes some minor improvements in the WFS sample. I can forward-port it also to master (will be done as follow-up).

The sample now shows opaque red WFS features covering South Tyrol (similar as it did before) on an OSM background map.

Notes:
* The sample code also includes a label layer, but this one is not visible (not sure if this was working before). Possibly the WFS service does not provide these labels any more, or we're using the wrong field.
* I still see the following error when running the sample via `Mapsui.Samples.Forms.Mac` (not sure where this comes from; and yes, I have a working Internet connection of course):
```
Mapsui.Samples.Forms.Mac.exe Error: 0 : An exception occured while parsing a polygon geometry: The request was aborted: The request was canceled.
Warning: A WebException occurred. Do you have internet?, System.Net.WebException: The request was aborted: The request was canceled.
  at System.Net.HttpWebRequest.RunWithTimeoutWorker[T] (System.Threading.Tasks.Task`1[TResult] workerTask, System.Int32 timeout, System.Action abort, System.Func`1[TResult] aborted, System.Threading.CancellationTokenSource cts) [0x000e8] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/System/System.Net/HttpWebRequest.cs:956 
  at System.Net.WebConnectionStream.Read (System.Byte[] buffer, System.Int32 offset, System.Int32 count) [0x0007e] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/System/System.Net/WebConnectionStream.cs:138 
  at System.Xml.XmlTextReaderImpl.ReadData () [0x00366] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlTextReaderImpl.cs:3165 
  at System.Xml.XmlTextReaderImpl.ParseText (System.Int32& startPos, System.Int32& endPos, System.Int32& outOrChars) [0x00377] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlTextReaderImpl.cs:5224 
  at System.Xml.XmlTextReaderImpl.FinishPartialValue () [0x00036] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlTextReaderImpl.cs:5279 
  at System.Xml.XmlTextReaderImpl.get_Value () [0x00014] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlTextReaderImpl.cs:910 
  at System.Xml.XmlSubtreeReader.get_Value () [0x00000] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlSubtreeReader.cs:142 
  at System.Xml.XmlSubtreeReader.get_Value () [0x00000] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlSubtreeReader.cs:142 
  at System.Xml.XmlSubtreeReader.get_Value () [0x00000] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlSubtreeReader.cs:142 
  at System.Xml.XmlSubtreeReader.get_Value () [0x00000] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlSubtreeReader.cs:142 
  at System.Xml.XmlSubtreeReader.get_Value () [0x00000] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlSubtreeReader.cs:142 
  at System.Xml.XmlReader.ReadString () [0x0005d] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlReader.cs:702 
  at System.Xml.XmlReader.ReadElementString () [0x00043] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlReader.cs:778 
  at Mapsui.Providers.Wfs.Utilities.GeometryFactory.ParseCoordinates (System.Xml.XmlReader reader) [0x0001f] in /Users/janus/github/Mapsui/Mapsui/Providers/Wfs/Utilities/GeometryFactories.cs:112 
  at Mapsui.Providers.Wfs.Utilities.PolygonFactory.CreateGeometries (Mapsui.Providers.Features features) [0x00265] in /Users/janus/github/Mapsui/Mapsui/Providers/Wfs/Utilities/GeometryFactories.cs:518 
  at Mapsui.Providers.Wfs.Utilities.UnspecifiedGeometryFactoryWfs100Gml2.CreateGeometries (Mapsui.Providers.Features features) [0x00331] in /Users/janus/github/Mapsui/Mapsui/Providers/Wfs/Utilities/GeometryFactories.cs:880 
  at Mapsui.Providers.Wfs.WFSProvider.ExecuteIntersectionQuery (Mapsui.Geometries.BoundingBox bbox) [0x003e1] in /Users/janus/github/Mapsui/Mapsui/Providers/Wfs/WFSProvider.cs:489 
  at Mapsui.Providers.Wfs.WFSProvider.GetFeaturesInView (Mapsui.Geometries.BoundingBox box, System.Double resolution) [0x00001] in /Users/janus/github/Mapsui/Mapsui/Providers/Wfs/WFSProvider.cs:956 
  at Mapsui.Fetcher.FeatureFetchDispatcher.FetchOnThread (Mapsui.Geometries.BoundingBox extent, System.Double resolution) [0x00002] in /Users/janus/github/Mapsui/Mapsui/Fetcher/FeatureFetchDispatcher.cs:44 
```
* The performance of the sample is pretty bad. Scrolling the map is a pain on my MacBook (no idea why, the drawn features don't seem extremely complex).