### PR TITLE
bump version number to 4.0.0 in AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ assembly_info:
   assembly_file_version: '{version}'
   assembly_informational_version: '{version}'
 environment:
-  version-short: 3.0.0  
+  version-short: 4.0.0  
 nuget:
   disable_publish_on_pr: true
 install:


### PR DESCRIPTION
Since a lot of changes have occurred on master since 3.0 and we're quickly moving towards 4.0, the version in the AppVeyor CI builds should be bumped to reflect that (and to distinguish the master builds from build on the develop/3.0 branch).

To clarify: This of course does not mean that we have a final version 4.0 yet (which might still take quite a while), but simply that the builds occur on the will-be-4.0 branch (master).