### PR TITLE
Fixed WFS PropertyName using POST requests

### DIFF
--- a/Mapsui/Providers/Wfs/Utilities/WFS_1_0_0_TextResources.cs
+++ b/Mapsui/Providers/Wfs/Utilities/WFS_1_0_0_TextResources.cs
@@ -103,9 +103,11 @@ namespace Mapsui.Providers.Wfs.Utilities
                     xWriter.WriteAttributeString("typeName", qualification + featureTypeInfo.Name);
                     xWriter.WriteAttributeString("srsName", ProjectionHelper.EpsgPrefix + featureTypeInfo.SRID);
                     xWriter.WriteElementString("PropertyName", qualification + featureTypeInfo.Geometry.GeometryName);
-                    if (!labelProperties.All(string.IsNullOrWhiteSpace))
-                        xWriter.WriteElementString("PropertyName", string.Join(",", 
-                            labelProperties.Where(x => !string.IsNullOrWhiteSpace(x)).Select(lbl => qualification + lbl)));
+                    foreach (var labelProperty in labelProperties.Where(labelProperty =>
+                                 !string.IsNullOrWhiteSpace(labelProperty)))
+                    {
+                        xWriter.WriteElementString("PropertyName", qualification + labelProperty);
+                    }
 
                     AppendGml2Filter(xWriter, featureTypeInfo, boundingBox, filter, qualification);
                     

--- a/Mapsui/Providers/Wfs/Utilities/WFS_1_1_0_TextResources.cs
+++ b/Mapsui/Providers/Wfs/Utilities/WFS_1_1_0_TextResources.cs
@@ -112,9 +112,11 @@ namespace Mapsui.Providers.Wfs.Utilities
                     xWriter.WriteAttributeString("typeName", qualification + featureTypeInfo.Name);
                     xWriter.WriteAttributeString("srsName", ProjectionHelper.EpsgPrefix + featureTypeInfo.SRID);
                     xWriter.WriteElementString("PropertyName", qualification + featureTypeInfo.Geometry.GeometryName);
-                    if (!labelProperties.All(string.IsNullOrWhiteSpace))
-                        xWriter.WriteElementString("PropertyName", string.Join(",", 
-                            labelProperties.Where(x => !string.IsNullOrWhiteSpace(x)).Select(lbl => qualification + lbl)));
+                    foreach (var labelProperty in labelProperties.Where(labelProperty =>
+                                 !string.IsNullOrWhiteSpace(labelProperty)))
+                    {
+                        xWriter.WriteElementString("PropertyName", qualification + labelProperty);
+                    }
 
                     AppendGml3Filter(xWriter, featureTypeInfo, boundingBox, filter, qualification);
                     


### PR DESCRIPTION
This fixes the following error:

`System.Exception: A service exception occured: Requested property: PPOL_ID,p_bz-Cadastre:PPOL_CCAT_ID,p_bz-Cadastre:PPOL_ISTAT is not available for p_bz-Cadastre:ParcelsPolygons.  The possible propertyName values are: [PPOL_ID, PPOL_CCAT_ID, PPOL_ISTAT]`

When using GET requests you need to join the [PropertyNames with commas](https://docs.geoserver.org/latest/en/user/services/wfs/reference.html#getfeature), but when using POST request, you need to pass every property by his own xml element.
It may even work when **not using namespaces** and joining them with commas, because as you can see above in the error response, the first property has the namespace removed, only the second and third still have it. But I think better than removing the namespaces in the request is passing every propertyName as single xml element.

Without this fix WFS with POST requests is not working when using multiple LABELS, and I need POST requests in my current project, because the query parameter is too long when using GET requests (using a filter with many entries) and I get an error from the server:
`System.Net.WebException: Der Remoteserver hat einen Fehler zurückgegeben: (414) Request-URI Too Long.`

I will make a follow up PR to master branch afterwards.