### PR TITLE
MyLocationLayer: add an optional label next to the symbol

### DIFF
--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -645,6 +645,22 @@ namespace Mapsui.UI.Forms
 
                 return;
             }
+            // Check for clicked mylocation
+            else if (e.MapInfo?.Layer == MyLocationLayer)
+            {
+                if (e.MapInfo!.ScreenPosition == null)
+                    return;
+
+                var args = new DrawableClickedEventArgs(
+                    Viewport.ScreenToWorld(e.MapInfo!.ScreenPosition).ToNative(),
+                    new Point(e.MapInfo.ScreenPosition.X, e.MapInfo.ScreenPosition.Y), e.NumTaps);
+
+                MyLocationLayer?.HandleClicked(args);
+
+                e.Handled = args.Handled;
+
+                return;
+            }
         }
 
         private void HandlerLongTap(object? sender, TappedEventArgs e)

--- a/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
@@ -36,7 +36,7 @@ namespace Mapsui.UI.Objects
         private readonly GeometryFeature _feature;
         private SymbolStyle _locStyle;  // style for the location indicator
         private SymbolStyle _dirStyle;  // style for the view-direction indicator
-        private LabelStyle _labStyle;   // style for the label
+        private CalloutStyle _coStyle;  // style for the callout
 
         private static int _bitmapMovingId = -1;
         private static int _bitmapStillId = -1;
@@ -91,38 +91,35 @@ namespace Mapsui.UI.Objects
         /// <value>Scale of symbol</value>
         public double Scale { get; set; } = 1.0;
 
-        private string _labelText;
-
         /// <summary>
-        /// The text that is displayed in the MyLocation label
+        /// The text that is displayed in the MyLocation callout.
         /// (can contains line breaks).
         /// </summary>
-        public string LabelText
+        public string CalloutText
         {
             get
             {
-                return _labelText;
+                return _coStyle.Title;
             }
             set
             {
-                _labelText = value;
-                _labStyle.Text = value;
+                _coStyle.Title = value;
                 _mapView.Refresh();
             }
         }
 
         /// <summary>
-        /// Show or hide the a label with further infos next to the MyLocation symbol.
+        /// Show or hide a callout with further infos next to the MyLocation symbol.
         /// </summary>
-        public bool ShowLabel
+        public bool ShowCallout
         {
             get
             {
-                return _labStyle.Enabled;
+                return _coStyle.Enabled;
             }
             set
             {
-                _labStyle.Enabled = value;
+                _coStyle.Enabled = value;
                 _mapView.Refresh();
             }
         }
@@ -199,20 +196,21 @@ namespace Mapsui.UI.Objects
                 SymbolOffset = new Offset(0, 0),
                 Opacity = 1,
             };
-            _labelText = "";
-            _labStyle = new LabelStyle
+            _coStyle = new CalloutStyle
             {
                 Enabled = false,
-                Text = _labelText,
-                BackColor = new Mapsui.Styles.Brush(Mapsui.Styles.Color.White),
-                Opacity = 0.75F,
-                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
-                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
-                Offset = new Offset(8, 8)
+                Type = CalloutType.Single,
+                Title = "",
+                TitleFontColor = Styles.Color.Black,
+                ArrowAlignment = ArrowAlignment.Top,
+                ArrowPosition = 0,
+                SymbolOffset = new Offset(0, -SymbolStyle.DefaultHeight * 0.4f),
+                MaxWidth = 300,
+                RotateWithMap = true
             };
 
             _feature.Styles.Clear();
-            _feature.Styles.Add(_labStyle);
+            _feature.Styles.Add(_coStyle);
             _feature.Styles.Add(_dirStyle);
             _feature.Styles.Add(_locStyle);
 

--- a/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
@@ -99,7 +99,7 @@ namespace Mapsui.UI.Objects
         {
             get
             {
-                return _coStyle.Title;
+                return _coStyle.Title ?? "";
             }
             set
             {

--- a/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
@@ -92,15 +92,12 @@ namespace Mapsui.UI.Objects
         public double Scale { get; set; } = 1.0;
 
         /// <summary>
-        /// The text that is displayed in the MyLocation callout.
-        /// (can contains line breaks).
+        /// The text that is displayed in the MyLocation callout
+        /// (can contain line breaks).
         /// </summary>
         public string CalloutText
         {
-            get
-            {
-                return _coStyle.Title ?? "";
-            }
+            get => _coStyle.Title ?? "";
             set
             {
                 _coStyle.Title = value;
@@ -113,10 +110,7 @@ namespace Mapsui.UI.Objects
         /// </summary>
         public bool ShowCallout
         {
-            get
-            {
-                return _coStyle.Enabled;
-            }
+            get => _coStyle.Enabled;
             set
             {
                 _coStyle.Enabled = value;
@@ -206,13 +200,16 @@ namespace Mapsui.UI.Objects
                 ArrowPosition = 0,
                 SymbolOffset = new Offset(0, -SymbolStyle.DefaultHeight * 0.4f),
                 MaxWidth = 300,
-                RotateWithMap = true
+                RotateWithMap = true,
+                Color = Styles.Color.White,
+                StrokeWidth = 0,
+                ShadowWidth = 0
             };
 
             _feature.Styles.Clear();
-            _feature.Styles.Add(_coStyle);
             _feature.Styles.Add(_dirStyle);
             _feature.Styles.Add(_locStyle);
+            _feature.Styles.Add(_coStyle);
 
             DataSource = new MemoryProvider<IFeature>(new List<IFeature> { _feature });
             Style = null;

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
@@ -40,7 +40,7 @@ namespace Mapsui.Samples.Forms
             mapView.MapClicked += OnMapClicked;
 
             mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position());
-            mapView.MyLocationLayer.LabelText = "My location!\n";
+            mapView.MyLocationLayer.CalloutText = "My location!\n";
             mapView.MyLocationLayer.Clicked += MyLocationClicked;
 
             mapView.Info += MapView_Info;
@@ -207,7 +207,7 @@ namespace Mapsui.Samples.Forms
                 mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position(e.Position.Latitude, e.Position.Longitude));
                 mapView.MyLocationLayer.UpdateMyDirection(e.Position.Heading, mapView.Viewport.Rotation);
                 mapView.MyLocationLayer.UpdateMySpeed(e.Position.Speed);
-                mapView.MyLocationLayer.LabelText = $"My location:\nlat={e.Position.Latitude:F6}, lon={e.Position.Longitude:F6}";
+                mapView.MyLocationLayer.CalloutText = $"My location:\nlat={e.Position.Latitude:F6}°\nlon={e.Position.Longitude:F6}°";
             });
         }
 
@@ -219,7 +219,7 @@ namespace Mapsui.Samples.Forms
             if (myLocLayer == null)
                 return;
             // toggle label
-            myLocLayer.ShowLabel = !myLocLayer.ShowLabel;
+            myLocLayer.ShowCallout = !myLocLayer.ShowCallout;
         }
     }
 }

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
@@ -1,16 +1,17 @@
-﻿using Mapsui.Samples.Common;
-using Mapsui.Samples.CustomWidget;
-using Mapsui.UI.Forms;
-using Plugin.Geolocator;
+﻿using Plugin.Geolocator;
 using Plugin.Geolocator.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Mapsui.Extensions;
-using Mapsui.Logging;
-using Mapsui.Styles;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
+using Mapsui.Extensions;
+using Mapsui.Logging;
+using Mapsui.Samples.Common;
+using Mapsui.Samples.CustomWidget;
+using Mapsui.Styles;
+using Mapsui.UI.Forms;
+using Mapsui.UI.Objects;
 
 namespace Mapsui.Samples.Forms
 {
@@ -39,6 +40,8 @@ namespace Mapsui.Samples.Forms
             mapView.MapClicked += OnMapClicked;
 
             mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position());
+            mapView.MyLocationLayer.LabelText = "My location!\n";
+            mapView.MyLocationLayer.Clicked += MyLocationClicked;
 
             mapView.Info += MapView_Info;
             mapView.Renderer.WidgetRenders[typeof(CustomWidget.CustomWidget)] = new CustomWidgetSkiaRenderer();
@@ -204,8 +207,19 @@ namespace Mapsui.Samples.Forms
                 mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position(e.Position.Latitude, e.Position.Longitude));
                 mapView.MyLocationLayer.UpdateMyDirection(e.Position.Heading, mapView.Viewport.Rotation);
                 mapView.MyLocationLayer.UpdateMySpeed(e.Position.Speed);
+                mapView.MyLocationLayer.LabelText = $"My location:\nlat={e.Position.Latitude:F6}, lon={e.Position.Longitude:F6}";
             });
         }
 
+
+        public void MyLocationClicked(object sender, DrawableClickedEventArgs args)
+        {
+            var myLocLayer = sender as MyLocationLayer;
+            args.Handled = true;
+            if (myLocLayer == null)
+                return;
+            // toggle label
+            myLocLayer.ShowLabel = !myLocLayer.ShowLabel;
+        }
     }
 }

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml.cs
@@ -41,7 +41,7 @@ namespace Mapsui.Samples.Forms
             Compass.ReadingChanged += Compass_ReadingChanged;
 
             mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position());
-            mapView.MyLocationLayer.LabelText = "My location!\n";
+            mapView.MyLocationLayer.CalloutText = "My location!\n";
             mapView.MyLocationLayer.Clicked += MyLocationClicked;
 
             mapView.Info += MapView_Info;
@@ -185,7 +185,7 @@ namespace Mapsui.Samples.Forms
                 mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position(e.Position.Latitude, e.Position.Longitude));
                 mapView.MyLocationLayer.UpdateMyDirection(e.Position.Heading, mapView.Viewport.Rotation);
                 mapView.MyLocationLayer.UpdateMySpeed(e.Position.Speed);
-                mapView.MyLocationLayer.LabelText = $"My location:\nlat={e.Position.Latitude:F6}, lon={e.Position.Longitude:F6}";
+                mapView.MyLocationLayer.CalloutText = $"My location:\nlat={e.Position.Latitude:F6}°\nlon={e.Position.Longitude:F6}°";
             });
         }
 
@@ -201,7 +201,7 @@ namespace Mapsui.Samples.Forms
             if (myLocLayer == null)
                 return;
             // toggle label
-            myLocLayer.ShowLabel = !myLocLayer.ShowLabel;
+            myLocLayer.ShowCallout = !myLocLayer.ShowCallout;
         }
     }
 }

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml.cs
@@ -1,16 +1,15 @@
 ﻿using System;
+using Xamarin.Essentials;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
-using Mapsui.UI.Forms;
 using Plugin.Geolocator;
 using Plugin.Geolocator.Abstractions;
-using Mapsui.UI;
 using System.Threading.Tasks;
+using Mapsui.Samples.Common;
 using Mapsui.Samples.CustomWidget;
 using Mapsui.Styles;
-using Xamarin.Essentials;
-using Mapsui.Samples.Common;
-using System.Diagnostics;
+using Mapsui.UI.Forms;
+using Mapsui.UI.Objects;
 
 namespace Mapsui.Samples.Forms
 {
@@ -42,6 +41,8 @@ namespace Mapsui.Samples.Forms
             Compass.ReadingChanged += Compass_ReadingChanged;
 
             mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position());
+            mapView.MyLocationLayer.LabelText = "My location!\n";
+            mapView.MyLocationLayer.Clicked += MyLocationClicked;
 
             mapView.Info += MapView_Info;
             mapView.Renderer.WidgetRenders[typeof(CustomWidget.CustomWidget)] = new CustomWidgetSkiaRenderer();
@@ -184,12 +185,23 @@ namespace Mapsui.Samples.Forms
                 mapView.MyLocationLayer.UpdateMyLocation(new UI.Forms.Position(e.Position.Latitude, e.Position.Longitude));
                 mapView.MyLocationLayer.UpdateMyDirection(e.Position.Heading, mapView.Viewport.Rotation);
                 mapView.MyLocationLayer.UpdateMySpeed(e.Position.Speed);
+                mapView.MyLocationLayer.LabelText = $"My location:\nlat={e.Position.Latitude:F6}, lon={e.Position.Longitude:F6}";
             });
         }
 
         private void Compass_ReadingChanged(object sender, CompassChangedEventArgs e)
         {
             mapView.MyLocationLayer.UpdateMyViewDirection(e.Reading.HeadingMagneticNorth, mapView.Viewport.Rotation, false);
+        }
+
+        public void MyLocationClicked(object sender, DrawableClickedEventArgs args)
+        {
+            var myLocLayer = sender as MyLocationLayer;
+            args.Handled = true;
+            if (myLocLayer == null)
+                return;
+            // toggle label
+            myLocLayer.ShowLabel = !myLocLayer.ShowLabel;
         }
     }
 }


### PR DESCRIPTION
This PR implements the feature suggested in #1143: It adds an optional label to the MyLocationLayer, next to the actual location symbol. The label text can be chosen freely, so it can for example be used to display the coordinates of the user's location (or any other information). The label is hidden by default and can be shown or hidden as desired. Also clicks on the MyLocation symbol can be caught now, e.g. in order to toggle the label when clicked.

I extended Mapsui.Samples.Forms to display a label with coordinates when the MyLocation symbol is clicked, so anyone can test the feature in the sample apps.

Any kind of feedback welcome ...