### PR TITLE
Add correct ToString() for basic types

### DIFF
--- a/Mapsui/MPoint.cs
+++ b/Mapsui/MPoint.cs
@@ -87,6 +87,8 @@ public class MPoint
         return new MPoint(point1.X + point2.X, point1 .Y + point2.Y);
     }
 
+    public override string ToString() => $"(X={X},Y={Y})";
+
     public static MPoint operator -(MPoint point1, MPoint point2)
     {
         return new MPoint(point1.X - point2.X, point1.Y - point2.Y);

--- a/Mapsui/MQuad.cs
+++ b/Mapsui/MQuad.cs
@@ -144,16 +144,8 @@ namespace Mapsui
         /// <returns>Returns the string</returns>
         public override string ToString()
         {
-            return $"BL: {ToString(BottomLeft)}  TL: {ToString(TopLeft)}  " +
-                   $"TR: {ToString(TopRight)}  BR: {ToString(BottomRight)}";
-        }
-
-        private static string ToString(MPoint? p)
-        {
-            if (p == null)
-                return "";
-
-            return $"({p.X}, {p.Y})";
+            return $"BL: {BottomLeft}  TL: {TopLeft}  " +
+                   $"TR: {TopRight}  BR: {BottomRight}";
         }
     }
 }

--- a/Mapsui/MReadOnlyPoint.cs
+++ b/Mapsui/MReadOnlyPoint.cs
@@ -22,6 +22,8 @@
 
         public double Y { get; }
 
+        public override string ToString() => $"(X={X},Y={Y})";
+
         /// <summary>
         /// Implicit conversion from MPoint to ReadOnlyPoint
         /// </summary>

--- a/Mapsui/MRect.cs
+++ b/Mapsui/MRect.cs
@@ -189,4 +189,13 @@ public class MRect
             (Min.Y, Max.Y) = (Max.Y, Min.Y);
         }
     }
+
+    /// <summary>
+    ///     Returns a string representation of the vertices from bottom-left and top-right
+    /// </summary>
+    /// <returns>Returns the string</returns>
+    public override string ToString()
+    {
+        return $"BL: {BottomLeft}  TR: {TopRight}";
+    }
 }


### PR DESCRIPTION
 Add correct ToString() for basic types, so it is possible to hover over while debugging to see the values without expanding the content.