### PR TITLE
fix rotation of callout anchor

### DIFF
--- a/Mapsui/MPoint.cs
+++ b/Mapsui/MPoint.cs
@@ -82,6 +82,17 @@ public class MPoint
         return Rotate(degrees, center.X, center.Y);
     }
 
+    /// <summary>
+    ///     Calculates a new point by rotating this point clockwise about the origin (0,0)
+    /// </summary>
+    /// <param name="degrees">Angle to rotate clockwise (degrees)</param>
+    /// <returns>Returns the rotated point</returns>
+    public MPoint Rotate(double degrees)
+    {
+        // rotate the values
+        return Algorithms.RotateClockwiseDegrees(X, Y, degrees);
+    }
+
     public static MPoint operator +(MPoint point1, MPoint point2)
     {
         return new MPoint(point1.X + point2.X, point1 .Y + point2.Y);

--- a/Mapsui/Styles/Offset.cs
+++ b/Mapsui/Styles/Offset.cs
@@ -27,6 +27,11 @@ namespace Mapsui.Styles
         public double Y { get; set; }
         public bool IsRelative { get; set; }
 
+        public MPoint ToPoint()
+        {
+            return new MPoint(X, Y);
+        }
+
         public override bool Equals(object obj)
         {
             if (!(obj is Offset offset))


### PR DESCRIPTION
* fixes #1503
* and at the same time cleans up the code a bit
  - use an MPoint for the symbol offset, so that we can use its rotate method
  - add an conversion method Offset.ToPoint
  - add a variant of MPoint.Rotate that otates around the origin