### PR TITLE
MyLocationLayer: make sure that callout rotates properly with map

### DIFF
--- a/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.Forms/Objects/MyLocationLayer.cs
@@ -201,6 +201,7 @@ namespace Mapsui.UI.Objects
                 SymbolOffset = new Offset(0, -SymbolStyle.DefaultHeight * 0.4f),
                 MaxWidth = 300,
                 RotateWithMap = true,
+                SymbolOffsetRotatesWithMap = true,
                 Color = Styles.Color.White,
                 StrokeWidth = 0,
                 ShadowWidth = 0


### PR DESCRIPTION
* so that not only the callout itself rotates with the map,
  but also the symbol offset does
* this is sort of a follow-up to #1486 and #1508