### PR TITLE
Fixed ShapeFile with Label

### DIFF
--- a/Mapsui/Layers/RasterizingLayer.cs
+++ b/Mapsui/Layers/RasterizingLayer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Mapsui.Fetcher;
 using Mapsui.Logging;
 using Mapsui.Rendering;
+using Mapsui.Styles;
 
 namespace Mapsui.Layers
 {
@@ -63,6 +64,7 @@ namespace Mapsui.Layers
             _layer.DataChanged += LayerOnDataChanged;
             Delayer.StartWithDelay = true;
             Delayer.MillisecondsToWait = delayBeforeRasterize;
+            Style = new RasterStyle(); // default raster style
         }
 
         public override MRect? Extent => _layer.Extent;


### PR DESCRIPTION
Set Default Style For Rasterizing Style Layer or else it won't display because Mapsui has default VectorStyleLayer and this does not know how to display RasterFeatures

This is fixed
https://github.com/Mapsui/Mapsui/pull/1530#issuecomment-1065838694