### PR TITLE
Remove Info handler in Mapview to fix #1496

### DIFF
--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MainPageLarge.xaml.cs
@@ -43,7 +43,6 @@ namespace Mapsui.Samples.Forms
             mapView.MyLocationLayer.CalloutText = "My location!\n";
             mapView.MyLocationLayer.Clicked += MyLocationClicked;
 
-            mapView.Info += MapView_Info;
             mapView.Renderer.WidgetRenders[typeof(CustomWidget.CustomWidget)] = new CustomWidgetSkiaRenderer();
 
             StartGPS();
@@ -52,30 +51,6 @@ namespace Mapsui.Samples.Forms
         protected override void OnAppearing()
         {
             mapView.Refresh();
-        }
-
-        private void MapView_Info(object sender, UI.MapInfoEventArgs e)
-        {
-            if (e.MapInfo?.Feature is IFeature feature)
-            {
-                featureInfo.Text = $"Click Info:";
-
-                if (e?.MapInfo?.Feature != null)
-                {
-                    featureInfo.Text = $"Click Info:{Environment.NewLine}{feature.ToDisplayText()}";
-
-                    foreach (var style in e.MapInfo.Feature.Styles)
-                    {
-                        if (style is CalloutStyle)
-                        {
-                            style.Enabled = !style.Enabled;
-                            e.Handled = true;
-                        }
-                    }
-
-                    mapView.Refresh();
-                }
-            }
         }
 
         private void FillListWithSamples()

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/MapPage.xaml.cs
@@ -44,7 +44,6 @@ namespace Mapsui.Samples.Forms
             mapView.MyLocationLayer.CalloutText = "My location!\n";
             mapView.MyLocationLayer.Clicked += MyLocationClicked;
 
-            mapView.Info += MapView_Info;
             mapView.Renderer.WidgetRenders[typeof(CustomWidget.CustomWidget)] = new CustomWidgetSkiaRenderer();
 
             Task.Run(() => StartGPS());
@@ -73,7 +72,6 @@ namespace Mapsui.Samples.Forms
 
             mapView.PinClicked -= OnPinClicked;
             mapView.MapClicked -= OnMapClicked;
-            mapView.Info -= MapView_Info;
 
             Compass.ReadingChanged -= Compass_ReadingChanged;
             CrossGeolocator.Current.PositionChanged -= MyLocationPositionChanged;
@@ -82,23 +80,6 @@ namespace Mapsui.Samples.Forms
             if (LeaksPage.DisposeMapView)
             {
                 mapView.Dispose();
-            }
-        }
-
-        private void MapView_Info(object sender, UI.MapInfoEventArgs? e)
-        {
-            if (e?.MapInfo?.Feature != null)
-            {
-                foreach (var style in e.MapInfo.Feature.Styles)
-                {
-                    if (style is CalloutStyle)
-                    {
-                        style.Enabled = !style.Enabled;
-                        e.Handled = true;
-                    }
-                }
-
-                mapView.Refresh();
             }
         }
 


### PR DESCRIPTION
### Doubts
Not sure if this fully solves the problem. Perhaps some more discussion is needed to fix this properly. I decided to go ahead with this step acting on my current understanding, I am ready to change my mind if this causes problems. Perhaps @charlenni can provide feedback.

### The problem
In #1496 the callout is not shown in forms because Enabled is toggled twice. This is because the sample itself adds an Info handler but here is already an Info handler for Info in the Mapview which does the same thing. So the callout is enabled and disabled on every click.

### The solution
I went into this suspecting the callout.Enabled was used toggling the callout in Mapview itself, but this is not the case, there is a different handler, where OnPinClicked is called from HandlerInfo, which is called from HandlerTab, which is called from OnSingleTabbeld, which is called from OnTouch. So if I remove the handler entirely and click a pin in the 'Many Pins' sample it still works. There may be another reason why the Info handler is there, but if so perhaps we should look for another way to solve this. The idea of the Info handler is that the user attaches an event handler and does its own handling, if there is also some handling within the Mapview of the same event I think this is confusing. So, the PR just removes the handlers. Please let me know if this causes other things to fail.

