### PR TITLE
Remove SkiaSharp.Views.Avalonia from Avalonia nuspec

### DIFF
--- a/NuSpec/Mapsui.Avalonia.nuspec
+++ b/NuSpec/Mapsui.Avalonia.nuspec
@@ -19,7 +19,7 @@
 			<group targetFramework="netcoreapp3.1">
 				<dependency id="Mapsui" version="$version$"/>
 				<dependency id="BruTile" version="[4.0.0,5.0.0)"/>
-				<dependency id="SkiaSharp.Views.Avalonia" version="[2.88.0-preview.232,3.0.0)"/>
+				<dependency id="SkiaSharp" version="[2.88.0-preview.232,3.0.0)"/>
 				<dependency id="Avalonia" version="[0.10.11,0.11.0)" />
 				<dependency id="Avalonia.Desktop" version="[0.10.11,0.11.0)" />
 				<dependency id="Avalonia.ReactiveUI" version="[0.10.11,0.11.0)" />


### PR DESCRIPTION
SkiaSharp.Views.Avalonia does not seem to exist anywhere.


Also, Leave SkiaSharp because Avalonia.Desktop refers to different version
and Mapsui was tested with this specific version.