### PR TITLE
Fix compile error assigning ISampleBase to ISample

### DIFF
--- a/Samples/Mapsui.Samples.Maui/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui/MainPageLarge.xaml.cs
@@ -19,7 +19,7 @@ namespace Mapsui.Samples.Maui
 {
     public sealed partial class MainPageLarge : ContentPage, IDisposable
     {
-        IEnumerable<ISample> allSamples;
+        IEnumerable<ISampleBase> allSamples;
         Func<object?, EventArgs, bool>? clicker;
         private CancellationTokenSource? gpsCancelation;
 
@@ -31,7 +31,7 @@ namespace Mapsui.Samples.Maui
             var test = this.listView ?? throw new InvalidOperationException();
             var test2 = this.featureInfo ?? throw new InvalidOperationException();
 
-            allSamples = AllSamples.GetSamples() ?? new List<ISample>();
+            allSamples = AllSamples.GetSamples() ?? new List<ISampleBase>();
 
             var categories = allSamples.Select(s => s.Category).Distinct().OrderBy(c => c);
             picker!.ItemsSource = categories.ToList<string>();

--- a/Samples/Mapsui.Samples.Maui/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui/MapPage.xaml.cs
@@ -31,7 +31,7 @@ namespace Mapsui.Samples.Maui
             var test1 = this.info ?? throw new InvalidOperationException();
         }
 
-        public MapPage(ISample sample, Func<MapView?, MapClickedEventArgs, bool>? c = null)
+        public MapPage(ISampleBase sample, Func<MapView?, MapClickedEventArgs, bool>? c = null)
         {
             InitializeComponent();
 


### PR DESCRIPTION
This a fix of a basic compile error in the Xamarin.Forms samples. ISampleBase can not be assigned to ISample, which is obvious. I would expect the build server to fail. I did not investigate why they did not fail.