### PR TITLE
Replace T in IProvider with IFeature

### DIFF
--- a/Mapsui.ArcGIS/DynamicProvider/ArcGISDynamicProvider.cs
+++ b/Mapsui.ArcGIS/DynamicProvider/ArcGISDynamicProvider.cs
@@ -15,7 +15,7 @@ using Mapsui.Providers;
 
 namespace Mapsui.ArcGIS.DynamicProvider
 {
-    public class ArcGISDynamicProvider : IProvider<IFeature>, IProjectingProvider
+    public class ArcGISDynamicProvider : IProvider, IProjectingProvider
     {
         private int _timeOut;
         private string _url = default!;

--- a/Mapsui.ArcGIS/ImageServiceProvider/ArcGISImageServiceProvider.cs
+++ b/Mapsui.ArcGIS/ImageServiceProvider/ArcGISImageServiceProvider.cs
@@ -16,7 +16,7 @@ using Mapsui.Rendering;
 
 namespace Mapsui.ArcGIS.ImageServiceProvider
 {
-    public class ArcGISImageServiceProvider : IProvider<IFeature>, IProjectingProvider
+    public class ArcGISImageServiceProvider : IProvider, IProjectingProvider
     {
         private int _timeOut;
         private string _url = default!;

--- a/Mapsui.Extensions/Provider/GeoTiffProvider.cs
+++ b/Mapsui.Extensions/Provider/GeoTiffProvider.cs
@@ -12,7 +12,7 @@ using Color = Mapsui.Styles.Color;
 
 namespace Mapsui.Extensions.Provider
 {
-    public class GeoTiffProvider : IProvider<IFeature>, IDisposable
+    public class GeoTiffProvider : IProvider, IDisposable
     {
         private struct TiffProperties
         {

--- a/Mapsui.Nts/Providers/GeometrySimplifyProvider.cs
+++ b/Mapsui.Nts/Providers/GeometrySimplifyProvider.cs
@@ -10,13 +10,13 @@ using NetTopologySuite.Simplify;
 
 namespace Mapsui.Nts.Providers;
 
-public class GeometrySimplifyProvider : IProvider<IFeature>
+public class GeometrySimplifyProvider : IProvider
 {
-    private readonly IProvider<IFeature> _provider;
+    private readonly IProvider _provider;
     private readonly Func<Geometry, double, Geometry> _simplify;
     private readonly double? _distanceTolerance;
 
-    public GeometrySimplifyProvider(IProvider<IFeature> provider, Func<Geometry, double, Geometry>? simplify = null, double? distanceTolerance = null)
+    public GeometrySimplifyProvider(IProvider provider, Func<Geometry, double, Geometry>? simplify = null, double? distanceTolerance = null)
     {
         _provider = provider;
         _simplify = simplify ?? TopologyPreservingSimplifier.Simplify;

--- a/Mapsui.Nts/Providers/Shapefile/ShapeFile.cs
+++ b/Mapsui.Nts/Providers/Shapefile/ShapeFile.cs
@@ -129,7 +129,7 @@ namespace Mapsui.Nts.Providers.Shapefile
     /// M and Z values in a shapefile is ignored by Mapsui.
     /// </para>
     /// </remarks>
-    public class ShapeFile : IProvider<IFeature>, IDisposable
+    public class ShapeFile : IProvider, IDisposable
     {
 
         static ShapeFile()

--- a/Mapsui.Nts/Providers/Wfs/WFSProvider.cs
+++ b/Mapsui.Nts/Providers/Wfs/WFSProvider.cs
@@ -36,7 +36,7 @@ namespace Mapsui.Providers.Wfs
     /// - MultiCurvePropertyType
     /// - MultiSurfacePropertyType
     /// </summary>
-    public class WFSProvider : IProvider<IFeature>, IDisposable
+    public class WFSProvider : IProvider, IDisposable
     {
 
         /// <summary>

--- a/Mapsui.Tiling/Provider/RasterizingTileProvider.cs
+++ b/Mapsui.Tiling/Provider/RasterizingTileProvider.cs
@@ -25,7 +25,7 @@ public class RasterizingTileProvider : ITileSource
     private readonly ILayer _layer;
     private ITileSchema? _tileSchema;
     private Attribution? _attribution;
-    private readonly IProvider<IFeature>? _dataSource;
+    private readonly IProvider? _dataSource;
 
     public RasterizingTileProvider(
         ILayer layer,
@@ -41,7 +41,7 @@ public class RasterizingTileProvider : ITileSource
         _pixelDensity = pixelDensity;
         PersistentCache = persistentCache ?? new NullCache();
 
-        if (_layer is ILayerDataSource<IProvider<IFeature>> { DataSource: { } } dataSourceLayer)
+        if (_layer is ILayerDataSource<IProvider> { DataSource: { } } dataSourceLayer)
         {
             _dataSource = dataSourceLayer.DataSource;
 

--- a/Mapsui.Tiling/Provider/TileProvider.cs
+++ b/Mapsui.Tiling/Provider/TileProvider.cs
@@ -17,7 +17,7 @@ using Mapsui.Tiling.Extensions;
 
 namespace Mapsui.Tiling.Provider
 {
-    public class TileProvider : IProvider<IFeature>
+    public class TileProvider : IProvider
     {
         private readonly ITileSource _source;
         private readonly MemoryCache<byte[]> _bitmaps = new(100, 200);

--- a/Mapsui.UI.Forms/MapView.cs
+++ b/Mapsui.UI.Forms/MapView.cs
@@ -112,13 +112,13 @@ namespace Mapsui.UI.Forms
             _pins.CollectionChanged += HandlerPinsOnCollectionChanged;
             _drawable.CollectionChanged += HandlerDrawablesOnCollectionChanged;
 
-            _mapCalloutLayer.DataSource = new ObservableCollectionProvider<Callout, IFeature>(_callouts);
+            _mapCalloutLayer.DataSource = new ObservableCollectionProvider<Callout>(_callouts);
             _mapCalloutLayer.Style = null;  // We don't want a global style for this layer
 
-            _mapPinLayer.DataSource = new ObservableCollectionProvider<Pin, IFeature>(_pins);
+            _mapPinLayer.DataSource = new ObservableCollectionProvider<Pin>(_pins);
             _mapPinLayer.Style = null;  // We don't want a global style for this layer
 
-            _mapDrawableLayer.DataSource = new ObservableCollectionProvider<Drawable, IFeature>(_drawable);
+            _mapDrawableLayer.DataSource = new ObservableCollectionProvider<Drawable>(_drawable);
             _mapDrawableLayer.Style = null;  // We don't want a global style for this layer
         }
 

--- a/Mapsui.UI.Forms/Objects/ObservableCollectionProvider.cs
+++ b/Mapsui.UI.Forms/Objects/ObservableCollectionProvider.cs
@@ -5,7 +5,7 @@ using Mapsui.Providers;
 
 namespace Mapsui.UI.Objects
 {
-    public class ObservableCollectionProvider<T, TU> : IProvider<TU> where T : IFeatureProvider where TU : IFeature
+    public class ObservableCollectionProvider<T> : IProvider where T : IFeatureProvider
     {
         private readonly object _syncRoot = new();
 
@@ -18,12 +18,12 @@ namespace Mapsui.UI.Objects
             Collection = collection;
         }
 
-        public async IAsyncEnumerable<TU> GetFeaturesAsync(FetchInfo fetchInfo)
+        public async IAsyncEnumerable<IFeature> GetFeaturesAsync(FetchInfo fetchInfo)
         {
             if (Collection == null || Collection.Count == 0)
                 yield break;
 
-            var list = new List<TU>();
+            var list = new List<IFeature>();
             lock (_syncRoot)
             {
                 foreach (var item in Collection)
@@ -31,7 +31,7 @@ namespace Mapsui.UI.Objects
                     if (fetchInfo.Extent?.Intersects(item.Feature?.Extent) ?? false)
                     {
                         IFeature feature = item.Feature!;
-                        list.Add((TU)feature);
+                        list.Add(feature);
                     }
                 }
             }

--- a/Mapsui/Fetcher/FeatureFetchDispatcher.cs
+++ b/Mapsui/Fetcher/FeatureFetchDispatcher.cs
@@ -78,7 +78,7 @@ namespace Mapsui.Fetcher
             Busy = true;
         }
 
-        public IProvider<IFeature>? DataSource { get; set; }
+        public IProvider? DataSource { get; set; }
 
         public bool Busy
         {

--- a/Mapsui/Fetcher/FeatureFetcher.cs
+++ b/Mapsui/Fetcher/FeatureFetcher.cs
@@ -13,13 +13,13 @@ namespace Mapsui.Fetcher
     {
         private readonly FetchInfo _fetchInfo;
         private readonly DataArrivedDelegate _dataArrived;
-        private readonly IProvider<IFeature> _provider;
+        private readonly IProvider _provider;
         private readonly SemaphoreSlim _providerLock = new(1, 1);
         private readonly long _timeOfRequest;
 
         public delegate void DataArrivedDelegate(IEnumerable<IFeature> features, object? state = null);
 
-        public FeatureFetcher(FetchInfo fetchInfo, IProvider<IFeature> provider, DataArrivedDelegate dataArrived, long timeOfRequest = default)
+        public FeatureFetcher(FetchInfo fetchInfo, IProvider provider, DataArrivedDelegate dataArrived, long timeOfRequest = default)
         {
             _dataArrived = dataArrived;
             var biggerBox = fetchInfo.Extent.Grow(

--- a/Mapsui/Layers/AnimatedLayers/AnimatedPointLayer.cs
+++ b/Mapsui/Layers/AnimatedLayers/AnimatedPointLayer.cs
@@ -6,13 +6,13 @@ using Mapsui.Providers;
 
 namespace Mapsui.Layers.AnimatedLayers;
 
-public class AnimatedPointLayer : BaseLayer, ILayerDataSource<IProvider<IFeature>>
+public class AnimatedPointLayer : BaseLayer, ILayerDataSource<IProvider>
 {
-    private readonly IProvider<PointFeature> _dataSource;
+    private readonly IProvider _dataSource;
     private FetchInfo? _fetchInfo;
     private readonly AnimatedFeatures _animatedFeatures = new();
 
-    public AnimatedPointLayer(IProvider<PointFeature> dataSource)
+    public AnimatedPointLayer(IProvider dataSource)
     {
         _dataSource = dataSource;
         if (_dataSource is IDynamic dynamic)
@@ -28,7 +28,7 @@ public class AnimatedPointLayer : BaseLayer, ILayerDataSource<IProvider<IFeature
         if (_fetchInfo is null) return;
         if (_dataSource is null) return;
         var features = await _dataSource.GetFeaturesAsync(_fetchInfo).ToListAsync();
-        _animatedFeatures.AddFeatures(features);
+        _animatedFeatures.AddFeatures(features.Cast<PointFeature>());
         OnDataChanged(new DataChangedEventArgs());
     }
 
@@ -49,5 +49,5 @@ public class AnimatedPointLayer : BaseLayer, ILayerDataSource<IProvider<IFeature
         return _animatedFeatures.UpdateAnimations();
     }
 
-    public IProvider<IFeature>? DataSource => _dataSource;
+    public IProvider? DataSource => _dataSource;
 }

--- a/Mapsui/Layers/IDataSourceLayer.cs
+++ b/Mapsui/Layers/IDataSourceLayer.cs
@@ -3,7 +3,7 @@
 namespace Mapsui.Layers;
 
 public interface ILayerDataSource<out T> 
-    where T : IProvider<IFeature>
+    where T : IProvider
 {
     public T? DataSource { get; }
 }

--- a/Mapsui/Layers/ImageLayer.cs
+++ b/Mapsui/Layers/ImageLayer.cs
@@ -16,7 +16,7 @@ using Mapsui.Providers;
 
 namespace Mapsui.Layers
 {
-    public class ImageLayer : BaseLayer, IAsyncDataFetcher, ILayerDataSource<IProvider<IFeature>>, IDisposable
+    public class ImageLayer : BaseLayer, IAsyncDataFetcher, ILayerDataSource<IProvider>, IDisposable
     {
         protected override void Dispose(bool disposing)
         {
@@ -39,7 +39,7 @@ namespace Mapsui.Layers
         private FetchInfo? _fetchInfo;
         private List<FeatureSets> _sets = new();
         private readonly Timer _startFetchTimer;
-        private IProvider<IFeature>? _dataSource;
+        private IProvider? _dataSource;
         private readonly int _numberOfFeaturesReturned;
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Mapsui.Layers
         /// </summary>
         public int FetchDelay { get; set; } = 1000;
 
-        public IProvider<IFeature>? DataSource
+        public IProvider? DataSource
         {
             get => _dataSource;
             set

--- a/Mapsui/Layers/Layer.cs
+++ b/Mapsui/Layers/Layer.cs
@@ -15,9 +15,9 @@ using Mapsui.Styles;
 
 namespace Mapsui.Layers
 {
-    public class Layer : BaseLayer, IAsyncDataFetcher, ILayerDataSource<IProvider<IFeature>>
+    public class Layer : BaseLayer, IAsyncDataFetcher, ILayerDataSource<IProvider>
     {
-        private IProvider<IFeature>? _dataSource;
+        private IProvider? _dataSource;
         private readonly object _syncRoot = new();
         private readonly ConcurrentStack<IFeature> _cache = new();
         private readonly FeatureFetchDispatcher<IFeature> _fetchDispatcher;
@@ -57,7 +57,7 @@ namespace Mapsui.Layers
         /// <summary>
         /// Data source for this layer
         /// </summary>
-        public IProvider<IFeature>? DataSource
+        public IProvider? DataSource
         {
             get => _dataSource;
             set

--- a/Mapsui/Providers/IProjectingProvider.cs
+++ b/Mapsui/Providers/IProjectingProvider.cs
@@ -1,6 +1,6 @@
 namespace Mapsui.Providers
 {
-    public interface IProjectingProvider : IProvider<IFeature>
+    public interface IProjectingProvider : IProvider
     {
         /// <summary>
         /// Queries whether a provider supports projection to a certain CRS.

--- a/Mapsui/Providers/IProvider.cs
+++ b/Mapsui/Providers/IProvider.cs
@@ -11,7 +11,7 @@ namespace Mapsui.Providers
     /// <summary>
     /// Interface for data providers
     /// </summary>
-    public interface IProvider<out T> where T : IFeature
+    public interface IProvider
     {
         /// <summary>
         /// The spatial reference ID (CRS)
@@ -24,6 +24,6 @@ namespace Mapsui.Providers
         /// <returns>BoundingBox</returns>
         MRect? GetExtent();
 
-        IAsyncEnumerable<T> GetFeaturesAsync(FetchInfo fetchInfo);
+        IAsyncEnumerable<IFeature> GetFeaturesAsync(FetchInfo fetchInfo);
     }
 }

--- a/Mapsui/Providers/MemoryProvider.cs
+++ b/Mapsui/Providers/MemoryProvider.cs
@@ -5,7 +5,7 @@ using Mapsui.Layers;
 
 namespace Mapsui.Providers
 {
-    public class MemoryProvider<T> : IProvider<T> where T : IFeature
+    public class MemoryProvider : IProvider
     {
         private readonly MRect? _boundingBox;
         /// <summary>
@@ -14,7 +14,7 @@ namespace Mapsui.Providers
 
         public MemoryProvider()
         {
-            Features = new List<T>();
+            Features = new List<IFeature>();
             _boundingBox = GetExtent(Features);
         }
 
@@ -22,13 +22,13 @@ namespace Mapsui.Providers
         /// Initializes a new instance of the MemoryProvider
         /// </summary>
         /// <param name="feature">Feature to be in this dataSource</param>
-        public MemoryProvider(T feature)
+        public MemoryProvider(IFeature feature)
         {
-            Features = new List<T> { feature };
+            Features = new List<IFeature> { feature };
             _boundingBox = GetExtent(Features);
         }
 
-        public IReadOnlyList<T> Features { get; private set; }
+        public IReadOnlyList<IFeature> Features { get; private set; }
         public double SymbolSize { get; set; } = 64;
 
         /// <summary>
@@ -41,14 +41,14 @@ namespace Mapsui.Providers
         /// Initializes a new instance of the MemoryProvider
         /// </summary>
         /// <param name="features">Features to be included in this dataSource</param>
-        public MemoryProvider(IEnumerable<T> features)
+        public MemoryProvider(IEnumerable<IFeature> features)
         {
             Features = features.ToList();
             _boundingBox = GetExtent(Features);
         }
 
 
-        public virtual async IAsyncEnumerable<T> GetFeaturesAsync(FetchInfo fetchInfo)
+        public virtual async IAsyncEnumerable<IFeature> GetFeaturesAsync(FetchInfo fetchInfo)
         {
             if (fetchInfo == null) throw new ArgumentNullException(nameof(fetchInfo));
             if (fetchInfo.Extent == null) throw new ArgumentNullException(nameof(fetchInfo.Extent));
@@ -70,7 +70,7 @@ namespace Mapsui.Providers
         /// <param name="value">Value to search for</param>
         /// <param name="fieldName">Name of the field to search in. This is the key of the T dictionary</param>
         /// <returns></returns>
-        public T? Find(object? value, string fieldName)
+        public IFeature? Find(object? value, string fieldName)
         {
             return Features.FirstOrDefault(f => value != null && f[fieldName] == value);
         }
@@ -84,7 +84,7 @@ namespace Mapsui.Providers
             return _boundingBox;
         }
 
-        private static MRect? GetExtent(IReadOnlyList<T> features)
+        private static MRect? GetExtent(IReadOnlyList<IFeature> features)
         {
             MRect? box = null;
             foreach (var feature in features)
@@ -99,7 +99,7 @@ namespace Mapsui.Providers
 
         public void Clear()
         {
-            Features = new List<T>();
+            Features = new List<IFeature>();
         }
     }
 }

--- a/Mapsui/Providers/ProjectingProvider.cs
+++ b/Mapsui/Providers/ProjectingProvider.cs
@@ -7,12 +7,12 @@ using Mapsui.Projections;
 
 namespace Mapsui.Providers
 {
-    public class ProjectingProvider : IProvider<IFeature>
+    public class ProjectingProvider : IProvider
     {
-        private readonly IProvider<IFeature> _provider;
+        private readonly IProvider _provider;
         private readonly IProjection _projection;
 
-        public ProjectingProvider(IProvider<IFeature> provider, IProjection? projection = null)
+        public ProjectingProvider(IProvider provider, IProjection? projection = null)
         {
             _provider = provider;
             _projection = projection ?? ProjectionDefaults.Projection;

--- a/Mapsui/Providers/StackedLabelProvider.cs
+++ b/Mapsui/Providers/StackedLabelProvider.cs
@@ -7,15 +7,15 @@ using Mapsui.Styles.Thematics;
 
 namespace Mapsui.Providers
 {
-    public class StackedLabelProvider : IProvider<IFeature>
+    public class StackedLabelProvider : IProvider
     {
         private const int SymbolSize = 32; // todo: determine margin by symbol size
         private const int BoxMargin = SymbolSize / 2;
 
-        private readonly IProvider<IFeature> _provider;
+        private readonly IProvider _provider;
         private readonly LabelStyle _labelStyle;
 
-        public StackedLabelProvider(IProvider<IFeature> provider, LabelStyle labelStyle, Pen? rectangleLine = null,
+        public StackedLabelProvider(IProvider provider, LabelStyle labelStyle, Pen? rectangleLine = null,
             Brush? rectangleFill = null)
         {
             _provider = provider;

--- a/Mapsui/Providers/Wms/WmsProvider.cs
+++ b/Mapsui/Providers/Wms/WmsProvider.cs
@@ -34,7 +34,7 @@ namespace Mapsui.Providers.Wms
     /// and the WmsLayer will set the remaining BoundingBox property and proper requests that changes between the requests.
     /// See the example below.
     /// </remarks>
-    public class WmsProvider : IProvider<IFeature>, IProjectingProvider
+    public class WmsProvider : IProvider, IProjectingProvider
     {
         private string? _mimeType;
         private readonly Client? _wmsClient;

--- a/Samples/Mapsui.Samples.Common.Desktop/GeoGifSample.cs
+++ b/Samples/Mapsui.Samples.Common.Desktop/GeoGifSample.cs
@@ -30,7 +30,7 @@ namespace Mapsui.Samples.Common.Desktop
             return map;
         }
 
-        private static ILayer CreateGifLayer(IProvider<IFeature> gifSource)
+        private static ILayer CreateGifLayer(IProvider gifSource)
         {
             return new Layer
             {

--- a/Samples/Mapsui.Samples.Common.Desktop/GeometrySimplifySample.cs
+++ b/Samples/Mapsui.Samples.Common.Desktop/GeometrySimplifySample.cs
@@ -36,7 +36,7 @@ namespace Mapsui.Samples.Common.Desktop
             return map;
         }
 
-        private static ILayer CreateCountryLayer(IProvider<IFeature> countrySource)
+        private static ILayer CreateCountryLayer(IProvider countrySource)
         {
             return new Layer
             {

--- a/Samples/Mapsui.Samples.Common.Desktop/ShapefileSample.cs
+++ b/Samples/Mapsui.Samples.Common.Desktop/ShapefileSample.cs
@@ -35,7 +35,7 @@ namespace Mapsui.Samples.Common.Desktop
             return map;
         }
 
-        private static ILayer CreateCountryLayer(IProvider<IFeature> countrySource)
+        private static ILayer CreateCountryLayer(IProvider countrySource)
         {
             return new Layer
             {
@@ -45,7 +45,7 @@ namespace Mapsui.Samples.Common.Desktop
             };
         }
 
-        private static ILayer CreateCityLayer(IProvider<IFeature> citySource)
+        private static ILayer CreateCityLayer(IProvider citySource)
         {
             return new Layer
             {
@@ -55,7 +55,7 @@ namespace Mapsui.Samples.Common.Desktop
             };
         }
 
-        private static ILayer CreateCountryLabelLayer(IProvider<IFeature> countryProvider)
+        private static ILayer CreateCountryLabelLayer(IProvider countryProvider)
         {
             return new Layer("Country labels")
             {
@@ -67,7 +67,7 @@ namespace Mapsui.Samples.Common.Desktop
             };
         }
 
-        private static ILayer CreateCityLabelLayer(IProvider<IFeature> citiesProvider)
+        private static ILayer CreateCityLabelLayer(IProvider citiesProvider)
         {
             return new Layer("City labels")
             {

--- a/Samples/Mapsui.Samples.Common.Desktop/ShapefileTilingSample.cs
+++ b/Samples/Mapsui.Samples.Common.Desktop/ShapefileTilingSample.cs
@@ -40,7 +40,7 @@ namespace Mapsui.Samples.Common.Desktop
             return map;
         }
 
-        private static ILayer CreateCountryLayer(IProvider<IFeature> countrySource)
+        private static ILayer CreateCountryLayer(IProvider countrySource)
         {
             return new Layer
             {

--- a/Samples/Mapsui.Samples.Common.Desktop/ThemeStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common.Desktop/ThemeStyleSample.cs
@@ -36,7 +36,7 @@ namespace Mapsui.Samples.Common.Desktop
             return map;
         }
 
-        private static ILayer CreateCountryLayer(IProvider<IFeature> countrySource)
+        private static ILayer CreateCountryLayer(IProvider countrySource)
         {
             return new Layer
             {

--- a/Samples/Mapsui.Samples.Common/GeoData/RandomPointGenerator.cs
+++ b/Samples/Mapsui.Samples.Common/GeoData/RandomPointGenerator.cs
@@ -16,12 +16,12 @@ namespace Mapsui.Samples.Common.Helpers
             return CreateFeatures(GenerateRandomPoints(envelope, count, random));
         }
 
-        public static MemoryProvider<PointFeature> CreateProviderWithRandomPoints(MRect? envelope, int count, Random? random = null)
+        public static MemoryProvider CreateProviderWithRandomPoints(MRect? envelope, int count, Random? random = null)
         {
             if (random == null)
                 random = new Random(123);
 
-            return new MemoryProvider<PointFeature>(CreateFeatures(GenerateRandomPoints(envelope, count, random)));
+            return new MemoryProvider(CreateFeatures(GenerateRandomPoints(envelope, count, random)));
         }
 
         private static IEnumerable<PointFeature> CreateFeatures(IEnumerable<MPoint> randomPoints)

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSampleProvider.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSampleProvider.cs
@@ -15,7 +15,7 @@ using Mapsui.Utilities;
 
 namespace Mapsui.Samples.Common.Maps.Animations;
 
-internal class AnimatedPointsSampleProvider : MemoryProvider<PointFeature>, IDynamic, IDisposable
+internal class AnimatedPointsSampleProvider : MemoryProvider, IDynamic, IDisposable
 {
     // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
     // ReSharper disable once NotAccessedField.Local
@@ -30,7 +30,7 @@ internal class AnimatedPointsSampleProvider : MemoryProvider<PointFeature>, IDyn
 
     public event DataChangedEventHandler? DataChanged;
 
-    public override async IAsyncEnumerable<PointFeature> GetFeaturesAsync(FetchInfo fetchInfo)
+    public override async IAsyncEnumerable<IFeature> GetFeaturesAsync(FetchInfo fetchInfo)
     {
         var features = new List<PointFeature>();
         var points = RandomPointGenerator.GenerateRandomPoints(fetchInfo.Extent, 10, _random).ToList();

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/SymbolAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/SymbolAnimationSample.cs
@@ -38,7 +38,7 @@ namespace Mapsui.Samples.Common.Maps
 
             var layer = new Layer("Points")
             {
-                DataSource = new MemoryProvider<IFeature>(CreatePoints(style)),
+                DataSource = new MemoryProvider(CreatePoints(style)),
             };
             layer.SymbolStyle = style;
 

--- a/Samples/Mapsui.Samples.Common/Maps/Callouts/CustomCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Callouts/CustomCalloutSample.cs
@@ -46,7 +46,7 @@ namespace Mapsui.Samples.Common.Maps.Callouts
             return new Layer
             {
                 Name = "Point",
-                DataSource = new MemoryProvider<IFeature>(GetCitiesFromEmbeddedResource()),
+                DataSource = new MemoryProvider(GetCitiesFromEmbeddedResource()),
                 IsMapInfoLayer = true
             };
         }

--- a/Samples/Mapsui.Samples.Common/Maps/Callouts/SingleCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Callouts/SingleCalloutSample.cs
@@ -54,7 +54,7 @@ namespace Mapsui.Samples.Common.Maps.Callouts
             {
                 Name = "Cities with callouts",
                 IsMapInfoLayer = true,
-                Features = new MemoryProvider<IFeature>(GetCitiesFromEmbeddedResource()).Features,
+                Features = new MemoryProvider(GetCitiesFromEmbeddedResource()).Features,
                 Style = new VectorStyle()
             };
         }

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/ComplexPolygonSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/ComplexPolygonSample.cs
@@ -35,7 +35,7 @@ namespace Mapsui.Samples.Common.Maps
         {
             return new Layer("Polygons")
             {
-                DataSource = new MemoryProvider<IFeature>(CreatePolygon().ToFeatures()),
+                DataSource = new MemoryProvider(CreatePolygon().ToFeatures()),
                 Style = new VectorStyle
                 {
                     Fill = new Brush(new Color(150, 150, 30, 128)),

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/PolygonSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/PolygonSample.cs
@@ -31,7 +31,7 @@ namespace Mapsui.Samples.Common.Maps
         {
             return new Layer("Polygons")
             {
-                DataSource = new MemoryProvider<IFeature>(CreatePolygon().ToFeatures()),
+                DataSource = new MemoryProvider(CreatePolygon().ToFeatures()),
                 Style = new VectorStyle
                 {
                     Fill = new Brush(new Color(150, 150, 30, 128)),

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/VariousSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/VariousSample.cs
@@ -39,7 +39,7 @@ namespace Mapsui.Samples.Common.Maps
         {
             return new Layer("Style on Layer")
             {
-                DataSource = new MemoryProvider<PointFeature>(RandomPointGenerator.GenerateRandomPoints(envelope, count).ToFeatures()),
+                DataSource = new MemoryProvider(RandomPointGenerator.GenerateRandomPoints(envelope, count).ToFeatures()),
                 Style = CreateBitmapStyle("Images.ic_place_black_24dp.png")
             };
         }
@@ -50,7 +50,7 @@ namespace Mapsui.Samples.Common.Maps
 
             return new Layer("Style on feature")
             {
-                DataSource = new MemoryProvider<IFeature>(GenerateRandomFeatures(envelope, count, style)),
+                DataSource = new MemoryProvider(GenerateRandomFeatures(envelope, count, style)),
                 Style = null
             };
         }

--- a/Samples/Mapsui.Samples.Common/Maps/Projection/MultiPolygonProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Projection/MultiPolygonProjectionSample.cs
@@ -52,7 +52,7 @@ namespace Mapsui.Samples.Common.Maps.Projection
                 new() {Geometry = new WKTReader().Read(WktOfAmsterdam)}
             };
 
-            var memoryProvider = new MemoryProvider<GeometryFeature>(features)
+            var memoryProvider = new MemoryProvider(features)
             {
                 CRS = "EPSG:4326" // The DataSource CRS needs to be set
             };

--- a/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
@@ -44,7 +44,7 @@ namespace Mapsui.Samples.Common.Maps.Projection
         {
             var features = WorldCities.GenerateTop100();
 
-            var memoryProvider = new MemoryProvider<IFeature>(features)
+            var memoryProvider = new MemoryProvider(features)
             {
                 CRS = "EPSG:4326" // The DataSource CRS needs to be set
             };

--- a/Samples/Mapsui.Samples.Common/Maps/Special/AsyncFetchSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/AsyncFetchSample.cs
@@ -46,7 +46,7 @@ namespace Mapsui.Samples.Common.Maps
             {
                 Name = "Async Layer",
                 IsMapInfoLayer = true,
-                DataSource = new MemoryProvider<IFeature>(GetCitiesFromEmbeddedResource()),
+                DataSource = new MemoryProvider(GetCitiesFromEmbeddedResource()),
                 Style = CreateBitmapStyle()
             };
         }

--- a/Samples/Mapsui.Samples.Common/Maps/Special/StackedLabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/StackedLabelsSample.cs
@@ -29,7 +29,7 @@ namespace Mapsui.Samples.Common.Maps
             return map;
         }
 
-        private static ILayer CreateStackedLabelLayer(IProvider<PointFeature> provider, string labelColumn)
+        private static ILayer CreateStackedLabelLayer(IProvider provider, string labelColumn)
         {
             return new Layer
             {
@@ -45,7 +45,7 @@ namespace Mapsui.Samples.Common.Maps
             };
         }
 
-        private static ILayer CreateLayer(IProvider<PointFeature> dataSource)
+        private static ILayer CreateLayer(IProvider dataSource)
         {
             return new Layer("Point Layer")
             {

--- a/Samples/Mapsui.Samples.Common/Maps/Symbols/OpacityStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Symbols/OpacityStyleSample.cs
@@ -33,7 +33,7 @@ namespace Mapsui.Samples.Common.Maps
         {
             return new Layer("Polygons")
             {
-                DataSource = new MemoryProvider<IFeature>(CreatePolygon().ToFeature()),
+                DataSource = new MemoryProvider(CreatePolygon().ToFeature()),
                 Style = new VectorStyle
                 {
                     Fill = new Brush(new Color(150, 150, 30)),
@@ -52,7 +52,7 @@ namespace Mapsui.Samples.Common.Maps
         {
             return new Layer("Polygons")
             {
-                DataSource = new MemoryProvider<IFeature>(CreateLineString().ToFeature()),
+                DataSource = new MemoryProvider(CreateLineString().ToFeature()),
                 Style = new VectorStyle
                 {
                     Line = new Pen

--- a/Samples/Mapsui.Samples.Common/Maps/Symbols/PenStrokeCapSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Symbols/PenStrokeCapSample.cs
@@ -34,7 +34,7 @@ namespace Mapsui.Samples.Common.Maps
         {
             return new Layer("Polygons")
             {
-                DataSource = new MemoryProvider<IFeature>(CreatePolygon()),
+                DataSource = new MemoryProvider(CreatePolygon()),
                 Style = null
             };
         }

--- a/Tests/Mapsui.Tests.Common/Maps/StackedLabelsSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/StackedLabelsSample.cs
@@ -44,7 +44,7 @@ namespace Mapsui.Tests.Common.Maps
         {
             return new TestLayer
             {
-                DataSource = new StackedLabelProvider(new MemoryProvider<IFeature>(provider), new LabelStyle { LabelColumn = labelColumn }),
+                DataSource = new StackedLabelProvider(new MemoryProvider(provider), new LabelStyle { LabelColumn = labelColumn }),
                 Style = null
             };
         }

--- a/Tests/Mapsui.Tests.Common/TestTools/TestLayer.cs
+++ b/Tests/Mapsui.Tests.Common/TestTools/TestLayer.cs
@@ -16,9 +16,9 @@ namespace Mapsui.Tests.Common.TestTools
     /// testing this can be useful when wnat to generate an image from the data source without 
     /// having to wait for the asynchronous data fetch call.
     /// </summary>
-    public class TestLayer : BaseLayer, ILayerDataSource<IProvider<IFeature>>
+    public class TestLayer : BaseLayer, ILayerDataSource<IProvider>
     {
-        public IProvider<IFeature>? DataSource { get; set; }
+        public IProvider? DataSource { get; set; }
         public string? CRS { get; set; }
         public override IEnumerable<IFeature> GetFeatures(MRect box, double resolution)
         {
@@ -41,7 +41,7 @@ namespace Mapsui.Tests.Common.TestTools
 
         public override MRect? Extent => DataSource?.GetExtent();
 
-        IProvider<IFeature>? ILayerDataSource<IProvider<IFeature>>.DataSource => throw new NotImplementedException();
+        IProvider? ILayerDataSource<IProvider>.DataSource => throw new NotImplementedException();
 
         public override void RefreshData(FetchInfo fetchInfo)
         {

--- a/Tests/Mapsui.Tests/Fetcher/FeatureFetcherTests.cs
+++ b/Tests/Mapsui.Tests/Fetcher/FeatureFetcherTests.cs
@@ -17,7 +17,7 @@ namespace Mapsui.Tests.Fetcher
             var extent = new MRect(0, 0, 10, 10);
             using var layer = new Layer
             {
-                DataSource = new MemoryProvider<IFeature>(GenerateRandomPoints(extent, 25))
+                DataSource = new MemoryProvider(GenerateRandomPoints(extent, 25))
             };
             layer.Delayer.MillisecondsToWait = 0;
 

--- a/Tests/Mapsui.Tests/Layers/ILayerSourceTests.cs
+++ b/Tests/Mapsui.Tests/Layers/ILayerSourceTests.cs
@@ -14,9 +14,9 @@ namespace Mapsui.Tests.Layers
         [Test]
         public void TestTypes()
         {
-            var memoryLayer = new TestLayer() { DataSource = new MemoryProvider<IFeature>() };
+            var memoryLayer = new TestLayer() { DataSource = new MemoryProvider() };
 
-            if (memoryLayer is ILayerDataSource<IProvider<IFeature>> source)
+            if (memoryLayer is ILayerDataSource<IProvider> source)
             {
                 Assert.IsTrue(true, "should be true");
             }

--- a/Tests/Mapsui.Tests/Layers/ImageLayerTests.cs
+++ b/Tests/Mapsui.Tests/Layers/ImageLayerTests.cs
@@ -13,7 +13,7 @@ namespace Mapsui.Tests.Layers
     {
         private const string ExceptionMessage = "This exception should return on OnDataChange";
 
-        private class FakeProvider : IProvider<IFeature>
+        private class FakeProvider : IProvider
         {
             public string? CRS { get; set; }
             public IAsyncEnumerable<IFeature> GetFeaturesAsync(FetchInfo fetchInfo)

--- a/Tests/Mapsui.Tests/Layers/RasterizingLayerTests.cs
+++ b/Tests/Mapsui.Tests/Layers/RasterizingLayerTests.cs
@@ -56,7 +56,7 @@ namespace Mapsui.Tests.Layers
                 features.Add(new GeometryFeature(
                     new Point(random.Next(100000, 5000000), random.Next(100000, 5000000))));
             }
-            return new TestLayer() { DataSource = new MemoryProvider<IFeature>(features) };
+            return new TestLayer() { DataSource = new MemoryProvider(features) };
         }
     }
 }


### PR DESCRIPTION
Only one cast was needed in the entire code base so the generic IProvider did not provide enough added value.