### PR TITLE
Move RefreshData to IAsyncDataFetcher

### DIFF
--- a/Mapsui.Tiling/Layers/TileLayer.cs
+++ b/Mapsui.Tiling/Layers/TileLayer.cs
@@ -102,7 +102,7 @@ namespace Mapsui.Tiling.Layers
         }
 
         /// <inheritdoc />
-        public override void RefreshData(FetchInfo fetchInfo)
+        public void RefreshData(FetchInfo fetchInfo)
         {
             if (Enabled
                 && fetchInfo.Extent?.GetArea() > 0

--- a/Mapsui.Tiling/Provider/RenderLayer.cs
+++ b/Mapsui.Tiling/Provider/RenderLayer.cs
@@ -18,8 +18,4 @@ internal class RenderLayer : BaseLayer
     {
         return _features;
     }
-
-    public override void RefreshData(FetchInfo fetchInfo)
-    {
-    }
 }

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -623,16 +623,6 @@ namespace Mapsui.UI.Wpf
             Refresh();
         }
 
-        /// <summary>
-        /// Clear cache and repaint map
-        /// </summary>
-        public void Clear()
-        {
-            // not sure if we need this method
-            _map?.ClearCache();
-            RefreshGraphics();
-        }
-
         private void CommonDispose(bool disposing)
         {
             if (disposing)

--- a/Mapsui/Fetcher/IAsyncDataFetcher.cs
+++ b/Mapsui/Fetcher/IAsyncDataFetcher.cs
@@ -4,6 +4,7 @@
 
 // This file was originally created by Paul den Dulk (Geodan) as part of SharpMap
 
+using Mapsui.Layers;
 using System;
 
 namespace Mapsui.Fetcher
@@ -20,6 +21,15 @@ namespace Mapsui.Fetcher
         /// Clear cache of layer
         /// </summary>
         void ClearCache();
+
+        /// <summary>
+        /// Indicates that there has been a change in the view of the map
+        /// </summary>
+        /// If Discrete an implementation should always refresh it's data. If Continuous the
+        /// implementation could ignore it. Example: During dragging a map a WMS layer would not want
+        /// to fetch data, only on the drag end.
+        /// <param name="fetchInfo">FetchInfo</param>
+        void RefreshData(FetchInfo fetchInfo);
     }
 
     public delegate void DataChangedEventHandler(object sender, DataChangedEventArgs e);

--- a/Mapsui/Layers/AnimatedLayers/AnimatedPointLayer.cs
+++ b/Mapsui/Layers/AnimatedLayers/AnimatedPointLayer.cs
@@ -6,7 +6,7 @@ using Mapsui.Providers;
 
 namespace Mapsui.Layers.AnimatedLayers;
 
-public class AnimatedPointLayer : BaseLayer, ILayerDataSource<IProvider>
+public class AnimatedPointLayer : BaseLayer, IAsyncDataFetcher, ILayerDataSource<IProvider>
 {
     private readonly IProvider _dataSource;
     private FetchInfo? _fetchInfo;
@@ -39,7 +39,7 @@ public class AnimatedPointLayer : BaseLayer, ILayerDataSource<IProvider>
         return _animatedFeatures.GetFeatures();
     }
 
-    public override void RefreshData(FetchInfo fetchInfo)
+    public void RefreshData(FetchInfo fetchInfo)
     {
         _fetchInfo = fetchInfo;
     }
@@ -47,6 +47,14 @@ public class AnimatedPointLayer : BaseLayer, ILayerDataSource<IProvider>
     public override bool UpdateAnimations()
     {
         return _animatedFeatures.UpdateAnimations();
+    }
+
+    public void AbortFetch()
+    {
+    }
+
+    public void ClearCache()
+    {
     }
 
     public IProvider? DataSource => _dataSource;

--- a/Mapsui/Layers/BaseLayer.cs
+++ b/Mapsui/Layers/BaseLayer.cs
@@ -183,9 +183,6 @@ namespace Mapsui.Layers
         /// <inheritdoc />
         public abstract IEnumerable<IFeature> GetFeatures(MRect box, double resolution);
 
-        /// <inheritdoc />
-        public abstract void RefreshData(FetchInfo fetchInfo);
-
         public void DataHasChanged()
         {
             DataChanged?.Invoke(this, new DataChangedEventArgs());

--- a/Mapsui/Layers/ILayer.cs
+++ b/Mapsui/Layers/ILayer.cs
@@ -99,15 +99,6 @@ namespace Mapsui.Layers
         event DataChangedEventHandler DataChanged;
 
         /// <summary>
-        /// Indicates that there has been a change in the view of the map
-        /// </summary>
-        /// If Discrete an implementation should always refresh it's data. If Continuous the
-        /// implementation could ignore it. Example: During dragging a map a WMS layer would not want
-        /// to fetch data, only on the drag end.
-        /// <param name="fetchInfo">FetchInfo</param>
-        void RefreshData(FetchInfo fetchInfo);
-
-        /// <summary>
         /// To indicate the data withing the layer has changed. This triggers a DataChanged event.
         /// This is necessary for situations where the layer can not know about changes to it's data
         /// as in the case of editing of a geometry.

--- a/Mapsui/Layers/ImageLayer.cs
+++ b/Mapsui/Layers/ImageLayer.cs
@@ -114,7 +114,7 @@ namespace Mapsui.Layers
             // not implemented for ImageLayer
         }
 
-        public override void RefreshData(FetchInfo fetchInfo)
+        public void RefreshData(FetchInfo fetchInfo)
         {
             if (!Enabled) return;
             // Fetching an image, that often covers the whole map, is expensive. Only do it on Discrete changes.

--- a/Mapsui/Layers/Layer.cs
+++ b/Mapsui/Layers/Layer.cs
@@ -130,7 +130,7 @@ namespace Mapsui.Layers
         }
 
         /// <inheritdoc />
-        public override void RefreshData(FetchInfo fetchInfo)
+        public void RefreshData(FetchInfo fetchInfo)
         {
             if (!Enabled) return;
             if (MinVisible > fetchInfo.Resolution) return;

--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -39,14 +39,6 @@ namespace Mapsui.Layers
             return Features.Where(f => f.Extent?.Intersects(biggerRect) == true);
         }
 
-        public override void RefreshData(FetchInfo fetchInfo)
-        {
-            // RefreshData needs no implementation for the MemoryLayer. Calling OnDataChanged here
-            // would trigger an extra needless render iteration.
-            // If a user changed the data in the provider and needs to update the graphics
-            // DataHasChanged should be called.
-        }
-
         public override MRect? Extent => Features.GetExtent();
     }
 }

--- a/Mapsui/Layers/RasterizingLayer.cs
+++ b/Mapsui/Layers/RasterizingLayer.cs
@@ -119,7 +119,8 @@ namespace Mapsui.Layers
                         OnDataChanged(new DataChangedEventArgs());
                     }
 
-                    if (_modified) Delayer.ExecuteDelayed(() => _layer.RefreshData(_fetchInfo));
+                    if (_modified && _layer is IAsyncDataFetcher asyncDataFetcher) 
+                            Delayer.ExecuteDelayed(() => asyncDataFetcher.RefreshData(_fetchInfo));
                 }
                 finally
                 {
@@ -169,7 +170,7 @@ namespace Mapsui.Layers
             if (_layer is IAsyncDataFetcher asyncLayer) asyncLayer.AbortFetch();
         }
 
-        public override void RefreshData(FetchInfo fetchInfo)
+        public void RefreshData(FetchInfo fetchInfo)
         {
             if (fetchInfo.Extent == null)
                 return;
@@ -186,8 +187,8 @@ namespace Mapsui.Layers
             {
                 // Explicitly set the change type to discrete for rasterization
                 _fetchInfo = new FetchInfo(fetchInfo.Extent, fetchInfo.Resolution, fetchInfo.CRS);
-                if (_layer is IAsyncDataFetcher)
-                    Delayer.ExecuteDelayed(() => _layer.RefreshData(_fetchInfo));
+                if (_layer is IAsyncDataFetcher asyncDataFetcher)
+                    Delayer.ExecuteDelayed(() => asyncDataFetcher.RefreshData(_fetchInfo));
                 else
                     Delayer.ExecuteDelayed(Rasterize);
             }

--- a/Mapsui/Layers/WritableLayer.cs
+++ b/Mapsui/Layers/WritableLayer.cs
@@ -42,11 +42,6 @@ namespace Mapsui.Layers
 
         public override MRect? Extent => GetExtent();
 
-        public override void RefreshData(FetchInfo fetchInfo)
-        {
-            //The MemoryLayer always has it's data ready so can fire a DataChanged event immediately so that listeners can act on it.
-            OnDataChanged(new DataChangedEventArgs());
-        }
         public IEnumerable<IFeature> GetFeatures()
         {
             return _cache;

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -197,7 +197,8 @@ namespace Mapsui
         {
             foreach (var layer in _layers.ToList())
             {
-                layer.RefreshData(fetchInfo);
+                if (layer is IAsyncDataFetcher asyncDataFetcher)
+                    asyncDataFetcher.RefreshData(fetchInfo);
             }
         }
 

--- a/Samples/Mapsui.Samples.Wpf.Editing/Editing/EditManager.cs
+++ b/Samples/Mapsui.Samples.Wpf.Editing/Editing/EditManager.cs
@@ -86,6 +86,7 @@ namespace Mapsui.Samples.Wpf.Editing.Editing
             {
 #pragma warning disable IDISP004 // Don't ignore created IDisposable
                 Layer?.Add(new GeometryFeature { Geometry = worldPosition.ToMPoint().ToPoint() });
+                Layer?.DataHasChanged();
 #pragma warning restore IDISP004 // Don't ignore created IDisposable
             }
             else if (EditMode == EditMode.AddLine)

--- a/Samples/Mapsui.Samples.Wpf.Editing/Layers/VertexOnlyLayer.cs
+++ b/Samples/Mapsui.Samples.Wpf.Editing/Layers/VertexOnlyLayer.cs
@@ -34,10 +34,5 @@ namespace Mapsui.Samples.Wpf.Editing.Layers
                     }
             }
         }
-
-        public override void RefreshData(FetchInfo fetchInfo)
-        {
-            OnDataChanged(new DataChangedEventArgs());
-        }
     }
 }

--- a/Tests/Mapsui.Tests.Common/TestTools/TestLayer.cs
+++ b/Tests/Mapsui.Tests.Common/TestTools/TestLayer.cs
@@ -42,10 +42,5 @@ namespace Mapsui.Tests.Common.TestTools
         public override MRect? Extent => DataSource?.GetExtent();
 
         IProvider? ILayerDataSource<IProvider>.DataSource => throw new NotImplementedException();
-
-        public override void RefreshData(FetchInfo fetchInfo)
-        {
-
-        }
     }
 }


### PR DESCRIPTION
The purpose of RefreshData is to fetch new data from the source of the layer (This source could be an IProvider or ITileSource), so it does not apply to all layers and should be in a more specific interface. This allowed to remove some implementations that made no sense.