### PR TITLE
Turn MemoryLayer.Feature into a ConcurrentBag

### DIFF
--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Mapsui.Extensions;
@@ -23,7 +24,7 @@ namespace Mapsui.Layers
         /// <param name="layerName">Name to use for layer</param>
         public MemoryLayer(string layerName) : base(layerName) { }
 
-        public IEnumerable<IFeature> Features { get; set; } = new List<IFeature>();
+        public IEnumerable<IFeature> Features { get; set; } = new ConcurrentBag<IFeature>();
 
 
         public override IEnumerable<IFeature> GetFeatures(MRect? rect, double resolution)


### PR DESCRIPTION
Why: Avoid possible exceptions caused by cross thread access of the List

This is a small change. There is nothing specific so far that indicated that cross thread access of the MemoryLayer.Feature is a problem, but there will undoubtedly be some users that want to update it on a background thread.

Using a ConcurrentBag instead of a List will be some hit on performance. I do not know how much. There may be other thread save alternatives as well. For our purpose we would like to have an implementation that is fast in reading the features, and can be slower when updating them. I did not do any research here at all.