### PR TITLE
(WIP) Comment Out Central Package Management

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,17 +28,17 @@
 
   <ItemGroup>
     <!--Specify Compiler for Mac Builds-->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.3.0-1.final">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <!--Disposable Analyzer-->
-    <PackageReference Include="IDisposableAnalyzers">
+    <PackageReference Include="IDisposableAnalyzers" Version="4.0.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!--Threading Analyzer mainly Async Code-->
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,10 +1,11 @@
 <Project>
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-		<CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  <PropertyGroup>
+		<!--The Central Package Management does not work on MAC (Visual Studio) and Uno (needs workarounds) therefore I disable it for now until the Tooling is there-->
+		<!--<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+		<CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>-->
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="Appveyor.TestLogger" Version="2.0.0" />
+		<!--<PackageVersion Include="Appveyor.TestLogger" Version="2.0.0" />
 		<PackageVersion Include="Avalonia" Version="0.10.12" />
 		<PackageVersion Include="Avalonia.Desktop" Version="0.10.12" />
 		<PackageVersion Include="Avalonia.Diagnostics" Version="0.10.12" />
@@ -39,7 +40,7 @@
 		<PackageVersion Include="Microsoft.NETCore.Platforms" Version="5.0.0" />
 		<PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13" />
 		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.6.2" />
-		<PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32"/>
+		<PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32" />
 		<PackageVersion Include="Microsoft.Win32.Primitives" Version="4.3.0" />
 		<PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.1.588-beta" />
 		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.1.0" />
@@ -62,8 +63,8 @@
 		<PackageVersion Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.63" />
 		<PackageVersion Include="SkiaSharp.Views.WinUI" Version="2.88.1-preview.63" />
 		<PackageVersion Include="SkiaSharp.Views.WPF" Version="2.88.1-preview.63" />
-		<PackageVersion Include="SkiaSharp.Views.Forms.WPF" Version="2.88.1-preview.63"/>
-    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="2.88.1-preview.63"/>
+		<PackageVersion Include="SkiaSharp.Views.Forms.WPF" Version="2.88.1-preview.63" />
+    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="2.88.1-preview.63" />
 		<PackageVersion Include="sqlite-net-pcl" Version="1.6.292" />
 		<PackageVersion Include="Svg.Skia" Version="0.5.12" />
 		<PackageVersion Include="System.AppContext" Version="4.3.0" />
@@ -88,7 +89,7 @@
 		<PackageVersion Include="System.Net.Http" Version="4.3.4" />
 		<PackageVersion Include="System.Net.Primitives" Version="4.3.1" />
 		<PackageVersion Include="System.Net.Sockets" Version="4.3.0" />
-		<PackageVersion Include="System.ObjectModel" Version="4.3.0"/>
+		<PackageVersion Include="System.ObjectModel" Version="4.3.0" />
 		<PackageVersion Include="System.Reflection" Version="4.3.0" />
 		<PackageVersion Include="System.Reflection.Extensions" Version="4.3.0" />
 		<PackageVersion Include="System.Reflection.Primitives" Version="4.3.0" />
@@ -137,10 +138,10 @@
 		<PackageVersion Include="Xamarin.AndroidX.Core" Version="1.7.0.2" />
 		<PackageVersion Include="Xamarin.AndroidX.MediaRouter" Version="1.2.0.1" />
 		<PackageVersion Include="Xamarin.AndroidX.Palette" Version="1.0.0.6" />
-		<PackageVersion Include="Xamarin.AndroidX.RecyclerView " Version="1.2.1.6" />
+		<PackageVersion Include="Xamarin.AndroidX.RecyclerView" Version="1.2.1.6" />
 		<PackageVersion Include="Xamarin.Essentials" Version="1.7.0" />
 		<PackageVersion Include="Xamarin.Forms" Version="5.0.0.2125" />
 		<PackageVersion Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2125" />
-		<PackageVersion Include="Xamarin.Google.Android.Material" Version="1.6.0" />
+		<PackageVersion Include="Xamarin.Google.Android.Material" Version="1.6.0" />-->
 	</ItemGroup>
 </Project>

--- a/Mapsui.ArcGIS/Mapsui.ArcGIS.csproj
+++ b/Mapsui.ArcGIS/Mapsui.ArcGIS.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" />
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="BruTile" Version="5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.Extensions/Mapsui.Extensions.csproj
+++ b/Mapsui.Extensions/Mapsui.Extensions.csproj
@@ -11,11 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" />
-    <PackageReference Include="BitMiracle.LibTiff.NET" />
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="sqlite-net-pcl" />
-    <PackageReference Include="DotSpatial.Projections.NetStandard" />
+    <PackageReference Include="BruTile" Version="5.0" />
+    <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />
+    <PackageReference Include="sqlite-net-pcl" Version="1.6.292" />
+    <PackageReference Include="DotSpatial.Projections.NetStandard" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Mapsui.Nts/Mapsui.Nts.csproj
+++ b/Mapsui.Nts/Mapsui.Nts.csproj
@@ -6,11 +6,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NetTopologySuite" />
+		<PackageReference Include="NetTopologySuite" Version="2.4.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="System.Text.Encoding.CodePages" />
+		<PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj
+++ b/Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="Svg.Skia" />
-    <PackageReference Include="Topten.RichTextKit" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />
+    <PackageReference Include="Svg.Skia" Version="0.5.12" />
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.145" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.Tiling/Mapsui.Tiling.csproj
+++ b/Mapsui.Tiling/Mapsui.Tiling.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" />
+    <PackageReference Include="BruTile" Version="5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.Android/Mapsui.UI.Android.csproj
+++ b/Mapsui.UI.Android/Mapsui.UI.Android.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\Mapsui\Mapsui.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.1-preview.63" />
   </ItemGroup>
   <Import Project="..\Mapsui.UI.Shared\Mapsui.UI.Shared.projitems" Label="Shared" />
 </Project>

--- a/Mapsui.UI.Avalonia/Mapsui.UI.Avalonia.csproj
+++ b/Mapsui.UI.Avalonia/Mapsui.UI.Avalonia.csproj
@@ -17,11 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" />
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="Avalonia" />
-    <PackageReference Include="Avalonia.Desktop" />
-    <PackageReference Include="Avalonia.ReactiveUI" />
+    <PackageReference Include="BruTile" Version="5.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />
+    <PackageReference Include="Avalonia" Version="0.10.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.Eto/Mapsui.UI.Eto.csproj
+++ b/Mapsui.UI.Eto/Mapsui.UI.Eto.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.SkiaDraw" />
+    <PackageReference Include="Eto.SkiaDraw" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.Forms.Tests/Mapsui.UI.Forms.Tests.csproj
+++ b/Mapsui.UI.Forms.Tests/Mapsui.UI.Forms.Tests.csproj
@@ -11,15 +11,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Appveyor.TestLogger" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" />
-		<PackageReference Include="NUnit" />
-		<PackageReference Include="NUnit3TestAdapter" />
-		<PackageReference Include="SkiaSharp.Views.Forms.WPF"/>
-		<PackageReference Include="Xamarin.Forms.Platform.WPF" />
-		<PackageReference Include="Xamarin.Forms" />
-		<PackageReference Include="OpenTK.GLControl"/>
-		<PackageReference Include="OpenTK"/>
+		<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+		<PackageReference Include="NUnit" Version="3.12.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+		<PackageReference Include="SkiaSharp.Views.Forms.WPF" Version="2.88.1-preview.63"/>
+		<PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2125" />
+		<PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />
+		<PackageReference Include="OpenTK.GLControl" Version="3.1.0"/>
+		<PackageReference Include="OpenTK" Version="3.1.0"/>
 	</ItemGroup>
 
 </Project>

--- a/Mapsui.UI.Forms/Mapsui.UI.Forms.csproj
+++ b/Mapsui.UI.Forms/Mapsui.UI.Forms.csproj
@@ -15,10 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="SkiaSharp.Views.Forms" />
-    <PackageReference Include="Xamarin.Essentials" />
-    <PackageReference Include="Xamarin.Forms" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.1-preview.63" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
+++ b/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
@@ -42,9 +42,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls" />
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls.Compatibility" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls.Compatibility" Version="2.88.1-preview.63" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.Uno/Mapsui.UI.Uno.csproj
+++ b/Mapsui.UI.Uno/Mapsui.UI.Uno.csproj
@@ -14,12 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Uno.UI" />
-    <PackageReference Include="SkiaSharp.Views.Uno" />    
+    <PackageReference Include="Uno.UI" Version="4.3.8" />
+    <PackageReference Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.63" />    
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='uap10.0.19041'">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -17,9 +17,9 @@
 	</Target>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.WindowsAppSDK" GeneratePathProperty="true" />
-	  <PackageReference Include="Microsoft.Graphics.Win2D" />
-    <PackageReference Include="SkiaSharp.Views.WinUI" />
+	  <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0" GeneratePathProperty="true" />
+	  <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.3.1" />
+    <PackageReference Include="SkiaSharp.Views.WinUI" Version="2.88.1-preview.63" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.Wpf/Mapsui.UI.Wpf.csproj
+++ b/Mapsui.UI.Wpf/Mapsui.UI.Wpf.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" />
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="SkiaSharp.Views.WPF" />
+    <PackageReference Include="BruTile" Version="5.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.1-preview.63" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.iOS/Mapsui.UI.iOS.csproj
+++ b/Mapsui.UI.iOS/Mapsui.UI.iOS.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\Mapsui\Mapsui.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.1-preview.63" />
   </ItemGroup>
   <Import Project="..\Mapsui.UI.Shared\Mapsui.UI.Shared.projitems" Label="Shared" />
 </Project>

--- a/Mapsui/Mapsui.csproj
+++ b/Mapsui/Mapsui.csproj
@@ -13,11 +13,11 @@
   </ItemGroup>
 	 
   <ItemGroup>
-    <PackageReference Include="System.Linq.Async" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Samples/Mapsui.Samples.Avalonia/Mapsui.Samples.Avalonia.csproj
+++ b/Samples/Mapsui.Samples.Avalonia/Mapsui.Samples.Avalonia.csproj
@@ -11,11 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" />
-    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia" Version="0.10.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
-    <PackageReference Include="Avalonia.ReactiveUI" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.Common.Desktop/Mapsui.Samples.Common.Desktop.csproj
+++ b/Samples/Mapsui.Samples.Common.Desktop/Mapsui.Samples.Common.Desktop.csproj
@@ -75,8 +75,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" />
-    <PackageReference Include="BruTile.MbTiles" />
+    <PackageReference Include="BruTile" Version="5.0" />
+    <PackageReference Include="BruTile.MbTiles" Version="5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.Common/Mapsui.Samples.Common.csproj
+++ b/Samples/Mapsui.Samples.Common/Mapsui.Samples.Common.csproj
@@ -65,9 +65,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" />
-    <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="BruTile.MbTiles" />
+    <PackageReference Include="BruTile" Version="5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="BruTile.MbTiles" Version="5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.Droid/Mapsui.Samples.Droid.csproj
+++ b/Samples/Mapsui.Samples.Droid/Mapsui.Samples.Droid.csproj
@@ -36,11 +36,11 @@
     <None Remove="Resources\values\styles.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile.MbTiles" />
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" />
-    <PackageReference Include="Xamarin.AndroidX.CoordinatorLayout" />
-    <PackageReference Include="Xamarin.Google.Android.Material" />
+    <PackageReference Include="BruTile.MbTiles" Version="5.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.4.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.CoordinatorLayout" Version="1.2.0.1" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj" />

--- a/Samples/Mapsui.Samples.Eto/Mapsui.Samples.Eto.csproj
+++ b/Samples/Mapsui.Samples.Eto/Mapsui.Samples.Eto.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <!-- Explicitly reference Linux native dlls to get them included -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
-    <PackageReference Include="Eto.Forms" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.1-preview.63" />
+    <PackageReference Include="Eto.Forms" Version="2.6.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(BuildPlatform)'=='' and $([MSBuild]::IsOSPlatform(Windows))">
@@ -41,19 +41,19 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BuildPlatform)'=='Wpf'">
-    <PackageReference Include="Eto.Platform.Wpf" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.6.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(BuildPlatform)'=='Windows'">
-    <PackageReference Include="Eto.Platform.Windows" />
+    <PackageReference Include="Eto.Platform.Windows" Version="2.6.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(BuildPlatform)'=='Mac64'">
-    <PackageReference Include="Eto.Platform.Mac64" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.6.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(BuildPlatform)'=='XamMac2'">
-    <PackageReference Include="Eto.Platform.XamMac2" />
+    <PackageReference Include="Eto.Platform.XamMac2" Version="2.6.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(BuildPlatform)'=='Gtk'">
-    <PackageReference Include="Eto.Platform.Gtk" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Android/Mapsui.Samples.Forms.Android.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Android/Mapsui.Samples.Forms.Android.csproj
@@ -42,9 +42,7 @@
     <Reference Include="Java.Interop" />
     <Reference Include="Mono.Android" />
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Core" />        
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Serialization" />
@@ -97,64 +95,64 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile.MbTiles" />
-    <PackageReference Include="Itinero" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" />     
-    <PackageReference Include="Microsoft.Win32.Primitives" />
-    <PackageReference Include="Plugin.CurrentActivity" />     
-    <PackageReference Include="SkiaSharp.Views.Forms" />     
-    <PackageReference Include="sqlite-net-pcl" />     
-    <PackageReference Include="Svg.Skia" />     
-    <PackageReference Include="System.AppContext" />     
-    <PackageReference Include="System.Collections" />     
-    <PackageReference Include="System.Collections.Concurrent" />     
-    <PackageReference Include="System.Console" />     
-    <PackageReference Include="System.Diagnostics.Debug" />     
-    <PackageReference Include="System.Diagnostics.Tools" />     
-    <PackageReference Include="System.Diagnostics.Tracing" />
-    <PackageReference Include="System.Globalization" />     
-    <PackageReference Include="System.Globalization.Calendars" />     
-    <PackageReference Include="System.IO" />     
-    <PackageReference Include="System.IO.Compression" />     
-    <PackageReference Include="System.IO.Compression.ZipFile" />     
-    <PackageReference Include="System.IO.FileSystem" />     
-    <PackageReference Include="System.IO.FileSystem.Primitives" />     
-    <PackageReference Include="System.Linq" />     
-    <PackageReference Include="System.Linq.Expressions" />     
-    <PackageReference Include="System.Memory" />     
-    <PackageReference Include="System.Net.Http" />     
-    <PackageReference Include="System.Net.Primitives" />     
-    <PackageReference Include="System.Net.Sockets" />     
-    <PackageReference Include="System.ObjectModel" />     
-    <PackageReference Include="System.Reflection" />     
-    <PackageReference Include="System.Reflection.Extensions" />
-    <PackageReference Include="System.Reflection.Primitives" />      
-    <PackageReference Include="System.Reflection.TypeExtensions" />     
-    <PackageReference Include="System.Resources.ResourceManager" />     
-    <PackageReference Include="System.Runtime" />     
-    <PackageReference Include="System.Runtime.Extensions" />     
-    <PackageReference Include="System.Runtime.Handles" />     
-    <PackageReference Include="System.Runtime.InteropServices" />     
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />     
-    <PackageReference Include="System.Runtime.Numerics" />     
-    <PackageReference Include="System.Security.Cryptography.Algorithms" />     
-    <PackageReference Include="System.Security.Cryptography.Encoding" />     
-    <PackageReference Include="System.Security.Cryptography.Primitives" />     
-    <PackageReference Include="System.Security.Cryptography.X509Certificates" />     
-    <PackageReference Include="System.Text.Encoding" />     
-    <PackageReference Include="System.Text.Encoding.Extensions" />     
-    <PackageReference Include="System.Text.RegularExpressions" />     
-    <PackageReference Include="System.Threading" />     
-    <PackageReference Include="System.Threading.Tasks" />     
-    <PackageReference Include="System.Threading.Timer" />     
-    <PackageReference Include="System.Xml.ReaderWriter" />     
-    <PackageReference Include="System.Xml.XDocument" />     
-    <PackageReference Include="Topten.RichTextKit" />     
-    <PackageReference Include="Xam.Plugin.Geolocator" />     
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" />     
-    <PackageReference Include="Xamarin.Forms" />     
-    <PackageReference Include="Xamarin.AndroidX.MediaRouter" />     
-    <PackageReference Include="Xamarin.AndroidX.Palette" />
+    <PackageReference Include="BruTile.MbTiles" Version="5.0" />
+    <PackageReference Include="Itinero" Version="1.5.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="5.0.0" />     
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="Plugin.CurrentActivity" Version="2.1.0.4" />     
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.1-preview.63" />     
+    <PackageReference Include="sqlite-net-pcl" Version="1.6.292" />     
+    <PackageReference Include="Svg.Skia" Version="0.5.12" />     
+    <PackageReference Include="System.AppContext" Version="4.3.0" />     
+    <PackageReference Include="System.Collections" Version="4.3.0" />     
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />     
+    <PackageReference Include="System.Console" Version="4.3.1" />     
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />     
+    <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />     
+    <PackageReference Include="System.Diagnostics.Tracing"  Version="4.3.0" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />     
+    <PackageReference Include="System.Globalization.Calendars" Version="4.3.0" />     
+    <PackageReference Include="System.IO" Version="4.3.0" />     
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />     
+    <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />     
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />     
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />     
+    <PackageReference Include="System.Linq" Version="4.3.0" />     
+    <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />     
+    <PackageReference Include="System.Memory" Version="4.5.4" />     
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />     
+    <PackageReference Include="System.Net.Primitives" Version="4.3.1" />     
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />     
+    <PackageReference Include="System.ObjectModel" Version="4.3.0" />     
+    <PackageReference Include="System.Reflection" Version="4.3.0" />     
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Primitives" Version="4.3.0" />      
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />     
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />     
+    <PackageReference Include="System.Runtime" Version="4.3.1" />     
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />     
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />     
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />     
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />     
+    <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />     
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />     
+    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />     
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />     
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />     
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0" />     
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />     
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />     
+    <PackageReference Include="System.Threading" Version="4.3.0" />     
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />     
+    <PackageReference Include="System.Threading.Timer" Version="4.3.0" />     
+    <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />     
+    <PackageReference Include="System.Xml.XDocument" Version="4.3.0" />     
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.145" />     
+    <PackageReference Include="Xam.Plugin.Geolocator" Version="4.5.0.6" />     
+    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.3" />     
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />     
+    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.0.1" />     
+    <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.6" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Mac/Mapsui.Samples.Forms.Mac.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Mac/Mapsui.Samples.Forms.Mac.csproj
@@ -108,60 +108,60 @@
     <InterfaceDefinition Include="MainMenu.xib" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile.MbTiles" />
-    <PackageReference Include="Itinero" />     
-    <PackageReference Include="Microsoft.NETCore.Platforms" />     
-    <PackageReference Include="Microsoft.Win32.Primitives" />
-    <PackageReference Include="SkiaSharp.Views.Forms" />     
-    <PackageReference Include="sqlite-net-pcl" />     
-    <PackageReference Include="Svg.Skia" />     
-    <PackageReference Include="System.AppContext" />     
-    <PackageReference Include="System.Collections" />     
-    <PackageReference Include="System.Collections.Concurrent" />     
-    <PackageReference Include="System.Console" />     
-    <PackageReference Include="System.Diagnostics.Debug" />     
-    <PackageReference Include="System.Diagnostics.Tools" />     
-    <PackageReference Include="System.Diagnostics.Tracing" />     
-    <PackageReference Include="System.Globalization" />     
-    <PackageReference Include="System.Globalization.Calendars" />     
-    <PackageReference Include="System.IO" />     
-    <PackageReference Include="System.IO.Compression" />     
-    <PackageReference Include="System.IO.Compression.ZipFile" />     
-    <PackageReference Include="System.IO.FileSystem" />     
-    <PackageReference Include="System.IO.FileSystem.Primitives" />     
-    <PackageReference Include="System.Linq" />     
-    <PackageReference Include="System.Linq.Expressions" />     
-    <PackageReference Include="System.Memory" IncludeAssets="None" />     
-    <PackageReference Include="System.Net.Http" />     
-    <PackageReference Include="System.Net.Primitives" />     
-    <PackageReference Include="System.Net.Sockets" />     
-    <PackageReference Include="System.ObjectModel" />     
-    <PackageReference Include="System.Reflection" />     
-    <PackageReference Include="System.Reflection.Extensions" />     
-    <PackageReference Include="System.Reflection.Primitives" />     
-    <PackageReference Include="System.Reflection.TypeExtensions" />     
-    <PackageReference Include="System.Resources.ResourceManager" />     
-    <PackageReference Include="System.Runtime" />     
-    <PackageReference Include="System.Runtime.Extensions" />     
-    <PackageReference Include="System.Runtime.Handles" />     
-    <PackageReference Include="System.Runtime.InteropServices" />     
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />     
-    <PackageReference Include="System.Runtime.Numerics" />     
-    <PackageReference Include="System.Security.Cryptography.Algorithms" />     
-    <PackageReference Include="System.Security.Cryptography.Encoding" />     
-    <PackageReference Include="System.Security.Cryptography.Primitives" />     
-    <PackageReference Include="System.Security.Cryptography.X509Certificates" />
-    <PackageReference Include="System.Text.Encoding" />     
-    <PackageReference Include="System.Text.Encoding.Extensions" />     
-    <PackageReference Include="System.Text.RegularExpressions" />     
-    <PackageReference Include="System.Threading" />     
-    <PackageReference Include="System.Threading.Tasks" />     
-    <PackageReference Include="System.Threading.Timer" />     
-    <PackageReference Include="System.Xml.ReaderWriter" />     
-    <PackageReference Include="System.Xml.XDocument" />     
-    <PackageReference Include="Topten.RichTextKit" />     
-    <PackageReference Include="Xam.Plugin.Geolocator" />     
-    <PackageReference Include="Xamarin.Forms" />     
+    <PackageReference Include="BruTile.MbTiles" Version="5.0" />
+    <PackageReference Include="Itinero" Version="1.5.0" />     
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="5.0.0" />     
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.1-preview.63" />     
+    <PackageReference Include="sqlite-net-pcl" Version="1.6.292" />     
+    <PackageReference Include="Svg.Skia" Version="0.5.12" />     
+    <PackageReference Include="System.AppContext" Version="4.3.0" />     
+    <PackageReference Include="System.Collections" Version="4.3.0" />     
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />     
+    <PackageReference Include="System.Console" Version="4.3.1" />     
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />     
+    <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />     
+    <PackageReference Include="System.Diagnostics.Tracing"  Version="4.3.0" />     
+    <PackageReference Include="System.Globalization" Version="4.3.0" />     
+    <PackageReference Include="System.Globalization.Calendars" Version="4.3.0" />     
+    <PackageReference Include="System.IO" Version="4.3.0" />     
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />     
+    <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />     
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />     
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />     
+    <PackageReference Include="System.Linq" Version="4.3.0" />     
+    <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />     
+    <PackageReference Include="System.Memory" Version="4.5.4" IncludeAssets="None" />     
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />     
+    <PackageReference Include="System.Net.Primitives" Version="4.3.1" />     
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />     
+    <PackageReference Include="System.ObjectModel" Version="4.3.0" />     
+    <PackageReference Include="System.Reflection" Version="4.3.0" />     
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />     
+    <PackageReference Include="System.Reflection.Primitives" Version="4.3.0" />     
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />     
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />     
+    <PackageReference Include="System.Runtime" Version="4.3.1" />     
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />     
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />     
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />     
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />     
+    <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />     
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />     
+    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />     
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />     
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0" />     
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />     
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />     
+    <PackageReference Include="System.Threading" Version="4.3.0" />     
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />     
+    <PackageReference Include="System.Threading.Timer" Version="4.3.0" />     
+    <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />     
+    <PackageReference Include="System.Xml.XDocument" Version="4.3.0" />     
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.145" />     
+    <PackageReference Include="Xam.Plugin.Geolocator" Version="4.5.0.6" />     
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />     
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/Mapsui.Samples.Forms.Shared.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/Mapsui.Samples.Forms.Shared.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xam.Plugin.Geolocator" />
-    <PackageReference Include="Xamarin.Essentials" />
+    <PackageReference Include="Xam.Plugin.Geolocator" Version="4.5.0.6" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.UWP/Mapsui.Samples.Forms.UWP.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.UWP/Mapsui.Samples.Forms.UWP.csproj
@@ -112,15 +112,15 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile" />
-    <PackageReference Include="BruTile.MbTiles" />
-    <PackageReference Include="SkiaSharp" />     
-    <PackageReference Include="SkiaSharp.Views" />     
-    <PackageReference Include="SkiaSharp.Views.Forms" />     
-    <PackageReference Include="Topten.RichTextKit" />     
-    <PackageReference Include="Xam.Plugin.Geolocator" />     
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" />
-    <PackageReference Include="Xamarin.Forms" />
+    <PackageReference Include="BruTile" Version="5.0" />
+    <PackageReference Include="BruTile.MbTiles" Version="5.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />     
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.1-preview.63" />     
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.1-preview.63" />     
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.145" />     
+    <PackageReference Include="Xam.Plugin.Geolocator" Version="4.5.0.6" />     
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj">

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.WPF/Mapsui.Samples.Forms.WPF.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.WPF/Mapsui.Samples.Forms.WPF.csproj
@@ -14,21 +14,21 @@
     <ProjectReference Include="..\Mapsui.Samples.Forms.Shared\Mapsui.Samples.Forms.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile.MbTiles" />
-    <PackageReference Include="Microsoft.CSharp" />
-    <PackageReference Include="OpenTK.GLControl" />
-    <PackageReference Include="SkiaSharp.Views.Forms.WPF" />
-    <PackageReference Include="sqlite-net-pcl" />
-    <PackageReference Include="Svg.Skia" />
-    <PackageReference Include="System.Data.DataSetExtensions" />
-    <PackageReference Include="System.Memory" />
-    <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" />
-    <PackageReference Include="System.Security.Cryptography.X509Certificates" />
-    <PackageReference Include="Topten.RichTextKit" />
-    <PackageReference Include="Xam.Plugin.Geolocator" />
-    <PackageReference Include="Xamarin.Forms" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" />
+    <PackageReference Include="BruTile.MbTiles" Version="5.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
+    <PackageReference Include="SkiaSharp.Views.Forms.WPF" Version="2.88.1-preview.63" />
+    <PackageReference Include="sqlite-net-pcl" Version="1.6.292" />
+    <PackageReference Include="Svg.Skia" Version="0.5.12" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.145" />
+    <PackageReference Include="Xam.Plugin.Geolocator" Version="4.5.0.6" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2125" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Remove="App.xaml" />

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.iOS/Mapsui.Samples.Forms.iOS.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.iOS/Mapsui.Samples.Forms.iOS.csproj
@@ -133,16 +133,16 @@
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile" />     
-    <PackageReference Include="SkiaSharp" />     
-    <PackageReference Include="SkiaSharp.Views" />     
-    <PackageReference Include="SkiaSharp.Views.Forms" />     
-    <PackageReference Include="Topten.RichTextKit" />     
-    <PackageReference Include="Xam.Plugin.Geolocator" />     
-    <PackageReference Include="Xamarin.Forms" />     
-    <PackageReference Include="sqlite-net-pcl" />     
-    <PackageReference Include="BruTile.MbTiles" />
-    <PackageReference Include="System.Memory" IncludeAssets="None" />     
+    <PackageReference Include="BruTile" Version="5.0" />     
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />     
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.1-preview.63" />     
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.1-preview.63" />     
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.145" />     
+    <PackageReference Include="Xam.Plugin.Geolocator" Version="4.5.0.6" />     
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />     
+    <PackageReference Include="sqlite-net-pcl" Version="1.6.292" />     
+    <PackageReference Include="BruTile.MbTiles" Version="5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" IncludeAssets="None" />     
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mapsui.Rendering.Skia\Mapsui.Rendering.Skia.csproj">

--- a/Samples/Mapsui.Samples.Maui.MapView/Mapsui.Samples.Maui.MapView.csproj
+++ b/Samples/Mapsui.Samples.Maui.MapView/Mapsui.Samples.Maui.MapView.csproj
@@ -51,8 +51,8 @@
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
     <!-- Required - WinUI does not yet have buildTransitive for everything -->
-    <PackageReference Include="Microsoft.WindowsAppSDK" />
-    <PackageReference Include="Microsoft.Graphics.Win2D" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.3.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -64,10 +64,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" />
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls" />
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls.Compatibility" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" Version=" 2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls.Compatibility" Version="2.88.1-preview.63" />
   </ItemGroup>
 
   <ItemGroup>	  	  

--- a/Samples/Mapsui.Samples.Maui/Mapsui.Samples.Maui.csproj
+++ b/Samples/Mapsui.Samples.Maui/Mapsui.Samples.Maui.csproj
@@ -48,7 +48,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="CommunityToolkit.Maui.Markup" />
+	  <PackageReference Include="CommunityToolkit.Maui.Markup" Version="1.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Mobile/Mapsui.Samples.Uno.Mobile.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Mobile/Mapsui.Samples.Uno.Mobile.csproj
@@ -18,18 +18,18 @@
     <SupportedOSPlatformVersion Condition="'$(TargetFramework)'=='net6.0-macos'">10.14</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" />
-    <PackageReference Include="Uno.UI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="SkiaSharp.Views.Uno" />
+    <PackageReference Include="Uno.UI" Version="4.3.8" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.63" />
   </ItemGroup>
  <Choose>
     <When Condition="'$(TargetFramework)'=='net6.0-android'">
       <ItemGroup>
-        <PackageReference Include="Xamarin.Google.Android.Material" />
-        <PackageReference Include="Uno.UniversalImageLoader" />
+        <PackageReference Include="Xamarin.Google.Android.Material" Version="1.6.0" />
+        <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.36" />
       </ItemGroup>
       <ItemGroup>
         <AndroidEnvironment Include="Android/environment.conf" />
@@ -42,7 +42,7 @@
         <MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Uno.Extensions.Logging.OSLog" />
+        <PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />
       </ItemGroup>
     </When>
     <When Condition="'$(TargetFramework)'=='net6.0-maccatalyst'">
@@ -57,7 +57,7 @@
         <InvariantGlobalization>false</InvariantGlobalization>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Uno.Extensions.Logging.OSLog" />
+        <PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />
       </ItemGroup>
     </When>
     <When Condition="'$(TargetFramework)'=='net6.0-macos'">

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Gtk/Mapsui.Samples.Uno.Skia.Gtk.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Gtk/Mapsui.Samples.Uno.Skia.Gtk.csproj
@@ -13,12 +13,12 @@
     <UpToDateCheckInput Include="..\Mapsui.Samples.Uno.Shared\**\*.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="Uno.UI.Skia.Gtk" />
-    <PackageReference Include="Uno.UI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
-    <PackageReference Include="SkiaSharp.Views.Uno" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Uno.UI.Skia.Gtk" Version="4.3.8" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
+    <PackageReference Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.63" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mapsui.Nts\Mapsui.Nts.csproj" />

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Linux.FrameBuffer/Mapsui.Samples.Uno.Skia.Linux.FrameBuffer.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Linux.FrameBuffer/Mapsui.Samples.Uno.Skia.Linux.FrameBuffer.csproj
@@ -13,12 +13,12 @@
     <UpToDateCheckInput Include="..\Mapsui.Samples.Uno.Shared\**\*.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="Uno.UI.Skia.Linux.FrameBuffer" />
-    <PackageReference Include="Uno.UI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
-    <PackageReference Include="SkiaSharp.Views.Uno" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.3.8" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
+    <PackageReference Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.63" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Mapsui.Nts\Mapsui.Nts.csproj" />

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Tizen/Mapsui.Samples.Uno.Skia.Tizen.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Tizen/Mapsui.Samples.Uno.Skia.Tizen.csproj
@@ -21,12 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="SkiaSharp.Views" />
-    <PackageReference Include="Uno.UI.Skia.Tizen" />
-    <PackageReference Include="Uno.UI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="SkiaSharp.Views.Uno" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.1-preview.63" />
+    <PackageReference Include="Uno.UI.Skia.Tizen" Version="4.3.8" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.63" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Wpf.Host/Mapsui.Samples.Uno.Skia.Wpf.Host.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Wpf.Host/Mapsui.Samples.Uno.Skia.Wpf.Host.csproj
@@ -6,10 +6,10 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI.Skia.Wpf" />
-    <PackageReference Include="Uno.UI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
-    <PackageReference Include="SkiaSharp.Views.Uno" />
+    <PackageReference Include="Uno.UI.Skia.Wpf" Version="4.3.8" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
+    <PackageReference Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.63" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\Fonts\uno-fluentui-assets.ttf" />

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Wpf/Mapsui.Samples.Uno.Skia.Wpf.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Skia.Wpf/Mapsui.Samples.Uno.Skia.Wpf.csproj
@@ -3,12 +3,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="Uno.UI.Skia.Wpf" />
-    <PackageReference Include="Uno.UI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
-    <PackageReference Include="SkiaSharp.Views.Uno"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Uno.UI.Skia.Wpf" Version="4.3.8" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
+    <PackageReference Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.63"/>
   </ItemGroup>
   <ItemGroup>
     <UpToDateCheckInput Include="..\Mapsui.Samples.Uno.Shared\**\*.xaml" />

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.UWP/Mapsui.Samples.Uno.UWP.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.UWP/Mapsui.Samples.Uno.UWP.csproj
@@ -2,15 +2,15 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" />
-    <PackageReference Include="Microsoft.UI.Xaml" />
-    <PackageReference Include="Uno.Core" />
-    <PackageReference Include="Uno.UI" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
-    <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
-    <PackageReference Include="SkiaSharp.Views.Uno" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13" />
+    <PackageReference Include="Microsoft.UI.Xaml" Version="2.6.2" />
+    <PackageReference Include="Uno.Core" Version="4.0.1" />
+    <PackageReference Include="Uno.UI" Version="4.3.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
+    <PackageReference Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.63" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13">
       <!--
 			If, in the same solution, you are referencing a project that uses https://github.com/onovotny/MSBuildSdkExtras,
 			you need to make sure that the version provided here matches https://github.com/novotnyllc/MSBuildSdkExtras/blob/main/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets#L11.

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
@@ -48,23 +48,23 @@
   </ItemGroup>
   <ItemGroup>
     <!--Don't remove this Reference it is a workaround for Central Package Management-->
-    <PackageReference Include="Microsoft.Windows.Compatibility" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" />
-    <PackageReference Include="Uno.UI.WebAssembly" />
-    <PackageReference Include="Uno.UI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" />
-    <PackageReference Include="SkiaSharp.Views.Uno" />
-    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
+    <PackageReference Include="Uno.UI.WebAssembly" Version="4.3.8" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
+    <PackageReference Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.1-preview.63" />
   </ItemGroup>
 
   <!--Harfbuzz Sharp references Workaround for this issue-->
   <!--https://github.com/mono/SkiaSharp/issues/1725-->
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.1-preview.63" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="2.8.2.1-preview.63" />
     <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\2.8.2\*.a" />
   </ItemGroup>
 

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" />
-    <PackageReference Include="Microsoft.Graphics.Win2D" />
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="SkiaSharp.Views.WinUI" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.3.1" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.Views.WinUI" Version="2.88.1-preview.63" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.1.588-beta" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.iOS/Mapsui.Samples.iOS.csproj
+++ b/Samples/Mapsui.Samples.iOS/Mapsui.Samples.iOS.csproj
@@ -27,12 +27,12 @@
     <ProjectReference Include="..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BruTile.MbTiles" />
-    <PackageReference Include="Itinero" />
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="SkiaSharp.Views" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" />
-    <PackageReference Include="SkiaSharp.NativeAssets.iOS" />
-    <PackageReference Include="Svg.Skia" />
+    <PackageReference Include="BruTile.MbTiles" Version="5.0" />
+    <PackageReference Include="Itinero" Version="1.5.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" Version=" 2.88.1-preview.63" />
+    <PackageReference Include="SkiaSharp.NativeAssets.iOS" Version=" 2.88.1-preview.63" />
+    <PackageReference Include="Svg.Skia" Version="0.5.12" />
   </ItemGroup>
 </Project>

--- a/Tests/Mapsui.Nts.Tests/Mapsui.Nts.Tests.csproj
+++ b/Tests/Mapsui.Nts.Tests/Mapsui.Nts.Tests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" >
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Tests/Mapsui.Rendering.Skia.Tests/Mapsui.Rendering.Skia.Tests.csproj
+++ b/Tests/Mapsui.Rendering.Skia.Tests/Mapsui.Rendering.Skia.Tests.csproj
@@ -28,20 +28,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Appveyor.TestLogger" />
-    <PackageReference Include="BruTile" />
-    <PackageReference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.Win32.Primitives" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" >
+    <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
+    <PackageReference Include="BruTile" Version="5.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="Svg.Skia" />
-    <PackageReference Include="OpenTK" />
-    <PackageReference Include="OpenTK.GLControl" />
+    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Svg.Skia" Version="0.5.12" />
+    <PackageReference Include="OpenTK" Version="3.1.0" />
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Mapsui.Tests.Common/Mapsui.Tests.Common.csproj
+++ b/Tests/Mapsui.Tests.Common/Mapsui.Tests.Common.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BruTile" />
+    <PackageReference Include="BruTile" Version="5.0" />
   </ItemGroup>
 
 </Project>

--- a/Tests/Mapsui.Tests/Mapsui.Tests.csproj
+++ b/Tests/Mapsui.Tests/Mapsui.Tests.csproj
@@ -31,17 +31,17 @@
 
 	<ItemGroup>
 		<Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-		<PackageReference Include="Appveyor.TestLogger" />
-		<PackageReference Include="BruTile" />
-		<PackageReference Include="System.Diagnostics.Debug" />
-		<PackageReference Include="System.Security.Cryptography.Algorithms" />
-		<PackageReference Include="System.Security.Cryptography.X509Certificates" />
-		<PackageReference Include="System.Threading" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" />
-		<PackageReference Include="coverlet.collector" />
-		<PackageReference Include="Microsoft.CodeCoverage" />
-		<PackageReference Include="NUnit" />
-		<PackageReference Include="NUnit3TestAdapter" >
+		<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
+		<PackageReference Include="BruTile" Version="5.0" />
+		<PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+		<PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+		<PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+		<PackageReference Include="System.Threading" Version="4.3.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+		<PackageReference Include="coverlet.collector" Version="3.0.2" />
+		<PackageReference Include="Microsoft.CodeCoverage" Version="16.11.0" />
+		<PackageReference Include="NUnit" Version="3.12.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" >
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Tools/VersionUpdater/VersionUpdater.csproj
+++ b/Tools/VersionUpdater/VersionUpdater.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The Central Package Management does not work on MAC (Visual Studio) and Uno (needs workarounds) therefore I disable it for now until the Tooling is there.

In the Next Round of Tooling updates this could be enabled again easily (With Regex Remove Version Attributes from PackageReferences) and enabling the commented out code in Directory.Packages.props .