### PR TITLE
Remove the 'Time for drawing control' log line

### DIFF
--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -89,9 +89,6 @@ namespace Mapsui.UI.Wpf
             // If we are interested in performance measurements, we save the new drawing time
             _performance?.Add(_stopwatch.Elapsed.TotalMilliseconds);
 
-            // Log drawing time
-            Logger.Log(LogLevel.Debug, $"Time for drawing control [ms]: {_stopwatch.Elapsed.TotalMilliseconds}");
-
             // End drawing
             _drawing = false;
         }


### PR DESCRIPTION
When starting on this change I intended to store the list of the last X times somewhere so that others would at least have to opportunity to draw it somewhere. The 'Performance' class seemed the proper place to add this list but it turns out this class already stores the last x (default is 20) drawing times (thanks @charlenni ). Users can request this list with MapControl.Performance.DrawingTimes. It may also be an option for users to create their own version of the performance widget and draw the last x drawing times there.

This PR simply removes the log line.