### PR TITLE
Use Official DotSpatial.Projections

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="BruTile" Version="5.0" />
     <PackageVersion Include="BruTile.MbTiles" Version="5.0" />
     <PackageVersion Include="coverlet.collector" Version="3.0.2" />
-    <PackageVersion Include="DotSpatial.Projections.NetStandard" Version="1.0.0" />
+    <PackageVersion Include="DotSpatial.Projections" Version="4.0.656" />
     <PackageVersion Include="CommandLineParser" Version="2.8.0" />
     <PackageVersion Include="CommunityToolkit.Maui.Markup" Version="1.0.0" />
     <PackageVersion Include="Eto.Forms" Version="2.6.0" />

--- a/Mapsui.Extensions/Mapsui.Extensions.csproj
+++ b/Mapsui.Extensions/Mapsui.Extensions.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="BitMiracle.LibTiff.NET" />
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="sqlite-net-pcl" />
-    <PackageReference Include="DotSpatial.Projections.NetStandard" />
+    <PackageReference Include="DotSpatial.Projections" />
   </ItemGroup>
 
 </Project>

--- a/NuSpec/Mapsui.Extensions.nuspec
+++ b/NuSpec/Mapsui.Extensions.nuspec
@@ -18,13 +18,13 @@
         <dependency id="Mapsui" version="$version$"/>
         <dependency id="sqlite-net-pcl" version="[1.6.292, 2.0.0)" />
         <dependency id="BitMiracle.LibTiff.NET" version="[2.4.649, 3.0.0)" />
-        <dependency id="DotSpatial.Projections.NetStandard" version="[1.0.0, 2.0.0)" />
+        <dependency id="DotSpatial.Projections" version="[4.0.656, 5.0.0)" />
       </group>
       <group targetFramework="net6.0">
         <dependency id="Mapsui" version="$version$"/>
         <dependency id="sqlite-net-pcl" version="[1.6.292, 2.0.0)" />
         <dependency id="BitMiracle.LibTiff.NET" version="[2.4.649, 3.0.0)" />
-        <dependency id="DotSpatial.Projections.NetStandard" version="[1.0.0, 2.0.0)" />
+        <dependency id="DotSpatial.Projections" version="[4.0.656, 5.0.0)" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Use the Official DotSpatial.Projections (which targets .NetStandard 2.0 and NET6.0) instead of the inofficial DotSpatial.Projections.NetStandard