### PR TITLE
Prerender CalloutStyle only if it is visible

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
@@ -12,6 +12,9 @@ namespace Mapsui.Rendering.Skia
     {
         public bool Draw(SKCanvas canvas, IReadOnlyViewport viewport, ILayer layer, IFeature feature, Styles.IStyle style, ISymbolCache symbolCache, long iteration)
         {
+            if (!style.Enabled)
+                return false;
+
             var centroid = feature.Extent?.Centroid;
 
             if (centroid is null)


### PR DESCRIPTION
In the moment the `CalloutStyleRenderer` creates a bitmap even if the callout style isn't enabled. With this, the `CalloutStyleRenderer` render the callout and register a bitmap only, if the style is enabled.