### PR TITLE
Throw if RenderToBitmapStream and GetSnapshot fail

### DIFF
--- a/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToBitmapPerformance.cs
+++ b/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToBitmapPerformance.cs
@@ -124,7 +124,7 @@ namespace Mapsui.Rendering.Benchmarks
             await map.WaitForLoadingAsync();
             using var bitmap = mapRenderer.RenderToBitmapStream(map.Viewport, map.Map!.Layers, Color.White);
 #if DEBUG
-            File.WriteAllBytes(@$"{OutputFolder()}\Test.png", bitmap!.ToArray());
+            File.WriteAllBytes(@$"{OutputFolder()}\Test.png", bitmap.ToArray());
 #endif
         }
 
@@ -134,7 +134,7 @@ namespace Mapsui.Rendering.Benchmarks
             await pngMap.WaitForLoadingAsync();
             using var bitmap = mapRenderer.RenderToBitmapStream(pngMap.Viewport, pngMap.Map!.Layers, Color.White);
 #if DEBUG
-            File.WriteAllBytes(@$"{OutputFolder()}\Testpng.png", bitmap!.ToArray());
+            File.WriteAllBytes(@$"{OutputFolder()}\Testpng.png", bitmap.ToArray());
 #endif
         }
 
@@ -144,7 +144,7 @@ namespace Mapsui.Rendering.Benchmarks
             await webpMap.WaitForLoadingAsync();
             using var bitmap = mapRenderer.RenderToBitmapStream(webpMap.Viewport, webpMap.Map!.Layers, Color.White);
 #if DEBUG
-            File.WriteAllBytes(@$"{OutputFolder()}\Testwebp.png", bitmap!.ToArray());
+            File.WriteAllBytes(@$"{OutputFolder()}\Testwebp.png", bitmap.ToArray());
 #endif
         }
         
@@ -154,7 +154,7 @@ namespace Mapsui.Rendering.Benchmarks
             await skpMap.WaitForLoadingAsync();
             using var bitmap = mapRenderer.RenderToBitmapStream(skpMap.Viewport, skpMap.Map!.Layers, Color.White);
 #if DEBUG
-            File.WriteAllBytes(@$"{OutputFolder()}\Testskp.png", bitmap!.ToArray());
+            File.WriteAllBytes(@$"{OutputFolder()}\Testskp.png", bitmap.ToArray());
 #endif
         }              
 

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -246,6 +246,7 @@ namespace Mapsui.UI.Wpf
             get => _renderer;
             set
             {
+                if (value is null) throw new NullReferenceException(nameof(Renderer));
                 if (_renderer != value)
                 {
                     _renderer = value;
@@ -578,17 +579,10 @@ namespace Mapsui.UI.Wpf
         }
 
         /// <inheritdoc />
-        public byte[]? GetSnapshot(IEnumerable<ILayer>? layers = null)
+        public byte[] GetSnapshot(IEnumerable<ILayer>? layers = null)
         {
-            byte[]? result = null;
-
-            using (var stream = Renderer?.RenderToBitmapStream(Viewport, layers ?? Map?.Layers ?? new LayerCollection(), pixelDensity: PixelDensity))
-            {
-                if (stream != null)
-                    result = stream.ToArray();
-            }
-
-            return result;
+            using var stream = Renderer.RenderToBitmapStream(Viewport, layers ?? Map?.Layers ?? new LayerCollection(), pixelDensity: PixelDensity);
+            return stream.ToArray();
         }
 
         /// <summary>

--- a/Mapsui/Layers/RasterizingLayer.cs
+++ b/Mapsui/Layers/RasterizingLayer.cs
@@ -110,18 +110,14 @@ namespace Mapsui.Layers
                     using var bitmapStream = _rasterizer.RenderToBitmapStream(viewport, new[] { _layer }, pixelDensity: _pixelDensity, renderFormat: _renderFormat);
                     RemoveExistingFeatures();
 
-                    if (bitmapStream != null)
-                    {
-                        _cache.Clear();
-                        var features = new RasterFeature[1];
-                        features[0] = new RasterFeature(new MRaster(bitmapStream.ToArray(), viewport.Extent));
-                        _cache.PushRange(features);
+                    _cache.Clear();
+                    var features = new RasterFeature[1];
+                    features[0] = new RasterFeature(new MRaster(bitmapStream.ToArray(), viewport.Extent));
+                    _cache.PushRange(features);
 #if DEBUG
-                        Logger.Log(LogLevel.Debug, $"Memory after rasterizing layer {GC.GetTotalMemory(true):N0}");
+                    Logger.Log(LogLevel.Debug, $"Memory after rasterizing layer {GC.GetTotalMemory(true):N0}");
 #endif
-
-                        OnDataChanged(new DataChangedEventArgs());
-                    }
+                    OnDataChanged(new DataChangedEventArgs());
 
                     if (_modified && _layer is IAsyncDataFetcher asyncDataFetcher) 
                             Delayer.ExecuteDelayed(() => asyncDataFetcher.RefreshData(_fetchInfo));

--- a/Mapsui/Rendering/IRenderer.cs
+++ b/Mapsui/Rendering/IRenderer.cs
@@ -1,20 +1,18 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
 using Mapsui.Layers;
 using Mapsui.Styles;
 using Mapsui.Widgets;
 
-namespace Mapsui.Rendering
+namespace Mapsui.Rendering;
+
+public interface IRenderer : IRenderInfo
 {
-    public interface IRenderer : IRenderInfo
-    {
-        void Render(object target, IReadOnlyViewport viewport, IEnumerable<ILayer> layers, IEnumerable<IWidget> widgets, Color? background = null);
-        MemoryStream? RenderToBitmapStream(IReadOnlyViewport viewport, IEnumerable<ILayer> layers, 
-            Color? background = null, float pixelDensity = 1, IEnumerable<IWidget>? widgets = null, RenderFormat renderFormat = RenderFormat.Png);
-        IRenderCache RenderCache { get; }
-        IDictionary<Type, IWidgetRenderer> WidgetRenders { get; }
-        IDictionary<Type, IStyleRenderer> StyleRenderers { get; }
-    }
+    void Render(object target, IReadOnlyViewport viewport, IEnumerable<ILayer> layers, IEnumerable<IWidget> widgets, Color? background = null);
+    MemoryStream RenderToBitmapStream(IReadOnlyViewport viewport, IEnumerable<ILayer> layers, 
+        Color? background = null, float pixelDensity = 1, IEnumerable<IWidget>? widgets = null, RenderFormat renderFormat = RenderFormat.Png);
+    IRenderCache RenderCache { get; }
+    IDictionary<Type, IWidgetRenderer> WidgetRenders { get; }
+    IDictionary<Type, IStyleRenderer> StyleRenderers { get; }
 }

--- a/Mapsui/UI/IMapControl.cs
+++ b/Mapsui/UI/IMapControl.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Mapsui.Layers;
 using Mapsui.Rendering;
 using Mapsui.Utilities;
@@ -62,7 +61,7 @@ namespace Mapsui.UI
         /// </summary>
         /// <param name="layers">Layers that should be included in snapshot</param>
         /// <returns>Byte array with snapshot in png format. If there are any problems than returns null.</returns>
-        byte[]? GetSnapshot(IEnumerable<ILayer>? layers = null);
+        byte[] GetSnapshot(IEnumerable<ILayer>? layers = null);
 
         INavigator? Navigator { get; }
 

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/SnapshotSample.cs
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Shared/SnapshotSample.cs
@@ -33,11 +33,7 @@ namespace Mapsui.Samples.Forms
                 return false;
 
             var snapshot = mapView.GetSnapshot();
-
-            if (snapshot != null)
-            {
-                var test = ImageSource.FromStream(() => new MemoryStream(snapshot));
-            }
+            var test = ImageSource.FromStream(() => new MemoryStream(snapshot));
 
             return true;
         }

--- a/Tests/Mapsui.Rendering.Skia.Tests/RegressionMapControl.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/RegressionMapControl.cs
@@ -88,7 +88,7 @@ public class RegressionMapControl : IMapControl
         throw new NotImplementedException();
     }
 
-    public byte[]? GetSnapshot(IEnumerable<ILayer>? layers = null)
+    public byte[] GetSnapshot(IEnumerable<ILayer>? layers = null)
     {
         throw new NotImplementedException();
     }


### PR DESCRIPTION
I think we should throw more and allow less null. This may have consequences for our users:
- Sometimes they may have an implicit bug which now becomes apparent and they become happier.
- Sometimes they have a glitch that they don't care about and now they have to deal with the exception and they become less happy, but we tell them it is all for the greater good and we hope to get away with it.
- Sometimes we will make a mistake to throw and have to rethink our design. In some cases we will have to revert it in others we will have to rewrite other parts as well. The users will have more reason to be unhappy, but still I think trying to allow less null is for the greater good.

This PR does not allow null RenderToBitmapStream and GetSnapshot and throws instead. There are many other places where we could throw.