### PR TITLE
ThreadwarningsAsErrors in Mapsui

### DIFF
--- a/Mapsui/Mapsui.csproj
+++ b/Mapsui/Mapsui.csproj
@@ -4,8 +4,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(SolutionName)' != 'Mapsui.Mac.Legacy'">$(TargetFrameworks);net6.0</TargetFrameworks>
     <Configurations>Release;Debug</Configurations>
-    <!--Revert TreatWarningsAsErrors to false because of vague build error on server -->
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Description>Mapsui - Library for mapping</Description>
 		<IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/Mapsui/Viewport.cs
+++ b/Mapsui/Viewport.cs
@@ -247,7 +247,6 @@ public class Viewport : IViewport
     public void Transform(MPoint positionScreen, MPoint previousPositionScreen, double deltaResolution = 1, double deltaRotation = 0)
     {
         _animations = new();
-        bool changes = false;
         var previous = ScreenToWorld(previousPositionScreen.X, previousPositionScreen.Y);
         var current = ScreenToWorld(positionScreen.X, positionScreen.Y);
 


### PR DESCRIPTION
This was turned of because of some build server error. The build has changed now. Let's try again.