### PR TITLE
Fix version in winbuild for #1835

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -203,7 +203,7 @@ jobs:
     - name: nuget ProjectReferences to PackageReferences
       shell: pwsh
       run: |
-        ./Scripts/SamplesMapsuiNugetReferences.ps1        
+        ./Scripts/SamplesMapsuiNugetReferences.ps1 $(git describe --tags)       
     - name: Restore dependencies
       run: .nuget\nuget restore Mapsui.sln      
     # Samples Build 

--- a/Mapsui.sln
+++ b/Mapsui.sln
@@ -20,6 +20,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapsui.UI.Android", "Mapsui
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scripts", "Scripts", "{B2DB6CAC-1C30-42C9-B628-BACEBF790AB9}"
 	ProjectSection(SolutionItems) = preProject
+		Scripts\buildpack.bat = Scripts\buildpack.bat
 		.github\workflows\dotnet-docs.yml = .github\workflows\dotnet-docs.yml
 		.github\workflows\dotnet-release-nugets.yml = .github\workflows\dotnet-release-nugets.yml
 		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml

--- a/Scripts/SamplesMapsuiNugetReferences.ps1
+++ b/Scripts/SamplesMapsuiNugetReferences.ps1
@@ -1,4 +1,32 @@
+Param (
+    [string]$Version
+)
+
 $Packages = (Get-Content -raw -path $PSScriptRoot\..\Directory.Packages.props -Encoding UTF8)
+
+# for debubbing Version setting in Directory.Packages.props
+# $Version = "4.0.0-beta.9"
+
+if (-Not [string]::IsNullOrWhiteSpace($Version))
+{
+    [string] $currentVersion;
+    $Packages | Select-Xml -XPath "//PackageVersion" | ForEach-Object {  
+        if ($_.node.Include -eq "Mapsui") {                    
+            $currentVersion = $_.node.Version
+        }
+    }
+
+    $currentVersionString = "Version=`"$currentVersion`""
+    $versionString = "Version=`"$Version`""
+
+    $Packages = $Packages -replace $currentVersionString, $versionString
+
+    # Normalize to no Cariage Return at the End
+    $fileContent = $fileContent -replace "</Project>`r`n", "</Project>"
+
+    Set-Content -Path $PSScriptRoot\..\Directory.Packages.props $Packages -Encoding UTF8
+}
+
 $fileNames = Get-ChildItem -Path $PSScriptRoot\..\Samples, $PSScriptRoot\..\Tests -Recurse -Include *.csproj
 
 foreach ($file in $fileNames) {

--- a/Scripts/buildpack.bat
+++ b/Scripts/buildpack.bat
@@ -8,38 +8,38 @@ rmdir Release /s /q
 REM create Artifacts if not exists
 if not exist "Artifacts" mkdir Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui/Mapsui.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui/Mapsui.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.Tiling/Mapsui.Tiling.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.Tiling/Mapsui.Tiling.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.Nts/Mapsui.Nts.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.Nts/Mapsui.Nts.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.ArcGIS/Mapsui.ArcGIS.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.ArcGIS/Mapsui.ArcGIS.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.Extensions/Mapsui.Extensions.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.Extensions/Mapsui.Extensions.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.UI.Wpf/Mapsui.UI.Wpf.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.UI.Wpf/Mapsui.UI.Wpf.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.UI.Android/Mapsui.UI.Android.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.UI.Android/Mapsui.UI.Android.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.UI.iOS/Mapsui.UI.iOS.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.UI.iOS/Mapsui.UI.iOS.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.UI.Forms/Mapsui.UI.Forms.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.UI.Forms/Mapsui.UI.Forms.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.UI.Avalonia/Mapsui.UI.Avalonia.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.UI.Avalonia/Mapsui.UI.Avalonia.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.UI.Eto/Mapsui.UI.Eto.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.UI.Eto/Mapsui.UI.Eto.csproj --output Artifacts
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.UI.Maui/Mapsui.UI.Maui.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.UI.Maui/Mapsui.UI.Maui.csproj --output Artifacts
 
-msbuild /p:RestorePackages=true /p:Configuration=Release Mapsui.UI.Uno/Mapsui.UI.Uno.csproj /t:Pack 
+msbuild /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.UI.Uno/Mapsui.UI.Uno.csproj /t:Pack 
 xcopy Mapsui.UI.Uno\bin\Release\*.nupkg Artifacts /Y
 
-dotnet pack /p:RestorePackages=true /p:Configuration=Release Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj --output Artifacts
+dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj --output Artifacts
 
-msbuild /p:RestorePackages=true /p:Configuration=Release Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj /t:Pack
+msbuild /p:RestorePackages=true /p:Configuration=Release /p:Version=%Version% Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj /t:Pack
 xcopy Mapsui.UI.WinUI\bin\Release\*.nupkg Artifacts /Y


### PR DESCRIPTION
The versionupdater was removed without alternative. In this PR the /p:Version parameter is used.