### PR TITLE
Catch NRE on SKCanvasView.InvalidateSurface

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Mapsui.Layers;
 using Mapsui.Logging;
 using Mapsui.Utilities;
+using Mapsui.Extensions;
 #if __MAUI__
 using Mapsui.UI.Maui.Extensions;
 using Microsoft.Maui;
@@ -157,7 +158,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
             // Events
             _canvasView.Touch += OnTouch;
             _canvasView.PaintSurface += OnPaintSurface;
-            _invalidate = () => { RunOnUIThread(() => _canvasView.InvalidateSurface()); };
+            _invalidate = () => { RunOnUIThread(() => Catch.Exceptions(() => _canvasView.InvalidateSurface())); };
             view = _canvasView;
         }
 

--- a/Mapsui/Extensions/CatchExceptions.cs
+++ b/Mapsui/Extensions/CatchExceptions.cs
@@ -7,6 +7,18 @@ namespace Mapsui.Extensions;
 
 public static class Catch
 {
+    public static void Exceptions(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception e)
+        {
+            Logger.Log(LogLevel.Error, e.Message, e);
+        }
+    }
+
     public static async void Exceptions(Func<Task> func)
     {
         try


### PR DESCRIPTION
Once in about eight times that I close Mapsui.Samples.Maui I get a null reference exception on `_canvasView.InvalidateSurface()` in the MapControl. The _canvasView field itself is not null, and seems to have normal values. So the problem is something inside SKCanvasView.  It is not Disposable (perhaps I could have checks some IsDisposed field), and I don't see any other properties that I could check for it being in a shutdown stage. So, I think it is a minor bug in Skia which is now caught, so the user will not get a crash on shutdown.