### PR TITLE
Use ViewportState

### DIFF
--- a/Mapsui/Fetcher/Postponer.cs
+++ b/Mapsui/Fetcher/Postponer.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+
+namespace Mapsui.Fetcher;
+
+/// <summary>
+/// Makes sure a method is always called 'MillisecondsToDelay' after the previous call.
+/// </summary>
+public class Postponer : IDisposable
+{
+    private readonly Timer _waitTimer;
+    private Action? _action;
+    private int _millisecondsToWait;
+
+    public Postponer(int millisecondsToWait = 500)
+    {
+        _millisecondsToWait = millisecondsToWait;
+        _waitTimer = new Timer(WaitTimerElapsed, null, millisecondsToWait, Timeout.Infinite);
+    }
+
+    public void ExecuteDelayed(Action action)
+    {
+        _action = action;
+         Restart();
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _waitTimer.Dispose();
+        }
+    }
+
+    private void WaitTimerElapsed(object? state)
+    {
+        if (_action is not null)
+        {
+            _action?.Invoke();
+            Restart();
+        }
+    }
+
+    public void Restart()
+    {
+        _waitTimer.Change(_millisecondsToWait, Timeout.Infinite);
+    }
+}

--- a/Mapsui/IViewport.cs
+++ b/Mapsui/IViewport.cs
@@ -20,6 +20,8 @@ public interface IViewport : IReadOnlyViewport, IAnimatable
     void SetSize(double width, double height);
     void SetAnimations(List<AnimationEntry<Viewport>> animations);
 
+    public ViewportState State { get; set; }
+
     /// <summary>
     /// Moving the position of viewport to a new one
     /// </summary>

--- a/Mapsui/LimitedViewport.cs
+++ b/Mapsui/LimitedViewport.cs
@@ -25,6 +25,7 @@ public class LimitedViewport : IViewport
     public double Width => _viewport.Width;
     public double Height => _viewport.Height;
     public double Rotation => _viewport.Rotation;
+    public ViewportState State { get => ((IViewport)_viewport).State; set => ((IViewport)_viewport).State = value; }
 
     public void Transform(MPoint position, MPoint previousPosition, double deltaResolution = 1, double deltaRotation = 0)
     {

--- a/Mapsui/Viewport.cs
+++ b/Mapsui/Viewport.cs
@@ -137,6 +137,17 @@ public class Viewport : IViewport
             OnViewportChanged();
         }
     }
+    public ViewportState State
+    {
+        get => _state;
+        set
+        {
+            if (_state == value) return;
+            _state = value;
+            UpdateExtent();
+            OnViewportChanged();
+        }
+    }
 
     /// <inheritdoc />
     public MRect Extent => _extent;

--- a/Mapsui/Viewport.cs
+++ b/Mapsui/Viewport.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Mapsui.Extensions;
+using Mapsui.Fetcher;
 using Mapsui.Logging;
 using Mapsui.Utilities;
 using Mapsui.ViewportAnimations;
@@ -33,7 +34,8 @@ public class Viewport : IViewport
     private double _rotation;
     private double _width;
     private double _height;
-
+    Postponer _delayer = new(1000);
+    long _counter;
     // Derived from state
     private readonly MRect _extent;
 
@@ -45,6 +47,7 @@ public class Viewport : IViewport
     public Viewport()
     {
         _extent = new MRect(0, 0, 0, 0);
+        _delayer.ExecuteDelayed(() => _counter = 0);
     }
 
     /// <summary>
@@ -440,7 +443,9 @@ public class Viewport : IViewport
     /// <param name="propertyName">Name of property that changed</param>
     private void OnViewportChanged([CallerMemberName] string? propertyName = null)
     {
-        Logger.Log(LogLevel.Debug, $@"Viewport Extent Changed: {_extent}");
+        _counter++;
+        _delayer.Restart(); // Restart to postpone _counter = 0
+        Logger.Log(LogLevel.Debug, $@"OnViewportChanged called {_counter} times");
         ViewportChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 

--- a/Mapsui/Viewport.cs
+++ b/Mapsui/Viewport.cs
@@ -29,7 +29,8 @@ public class Viewport : IViewport
 
     // State
     private ViewportState _state = new(0, 0, 1, 0, 0, 0);
-    Postponer _delayer = new(1000);
+    // Add postponer only for debugging.
+    Postponer _postponer = new(1000);
     long _counter;
     // Derived from state
     private readonly MRect _extent;
@@ -42,7 +43,7 @@ public class Viewport : IViewport
     public Viewport()
     {
         _extent = new MRect(0, 0, 0, 0);
-        _delayer.ExecuteDelayed(() => _counter = 0);
+        _postponer.ExecuteDelayed(() => _counter = 0);
     }
 
     /// <summary>
@@ -434,7 +435,7 @@ public class Viewport : IViewport
     private void OnViewportChanged([CallerMemberName] string? propertyName = null)
     {
         _counter++;
-        _delayer.Restart(); // Restart to postpone _counter = 0
+        _postponer.Restart(); // Restart to postpone _counter = 0
         Logger.Log(LogLevel.Debug, $@"OnViewportChanged called {_counter} times");
         ViewportChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }

--- a/Mapsui/ViewportAnimations/ZoomOnCenterAnimation.cs
+++ b/Mapsui/ViewportAnimations/ZoomOnCenterAnimation.cs
@@ -10,8 +10,8 @@ internal class ZoomOnCenterAnimation
         var animations = new List<AnimationEntry<Viewport>>();
 
         var entry = new AnimationEntry<Viewport>(
-            start: (viewport.CenterX, viewport.CenterY, viewport.Resolution),
-            end: (centerX, centerY, resolution),
+            start: viewport.State,
+            end: viewport.State with { CenterX = centerX, CenterY = centerY, Resolution = resolution },
             animationStart: 0,
             animationEnd: 1,
             easing: Easing.SinInOut,
@@ -27,19 +27,13 @@ internal class ZoomOnCenterAnimation
 
     private static void CenterAndResolutionTick(Viewport viewport, AnimationEntry<Viewport> entry, double value)
     {
-        var start = ((double CenterX, double CenterY, double Resolution))entry.Start;
-        var end = ((double CenterX, double CenterY, double Resolution))entry.End;
-
-        viewport.CenterX = start.CenterX + (end.CenterX - start.CenterX) * entry.Easing.Ease(value);
-        viewport.CenterY = start.CenterY + (end.CenterY - start.CenterY) * entry.Easing.Ease(value);
-        viewport.Resolution = start.Resolution + (end.Resolution - start.Resolution) * entry.Easing.Ease(value);
+        var start = (ViewportState)entry.Start;
+        var end = (ViewportState)entry.End;
+        viewport.State = start + (end - start) * entry.Easing.Ease(value);
     }
 
     private static void CenterAndResolutionFinal(Viewport viewport, AnimationEntry<Viewport> entry)
     {
-        var end = ((double CenterX, double CenterY, double Resolution))entry.End;
-        viewport.CenterX = end.CenterX;
-        viewport.CenterY = end.CenterY;
-        viewport.Resolution = end.Resolution;
+        viewport.State = (ViewportState)entry.End;
     }
 }

--- a/Mapsui/ViewportState.cs
+++ b/Mapsui/ViewportState.cs
@@ -47,4 +47,56 @@ public record class ViewportState
         Width = width;
         Height = height;
     }
+
+    public static ViewportState operator +(ViewportState a, ViewportState b)
+    {
+        return a with
+        {
+            CenterX = a.CenterX + b.CenterX,
+            CenterY = a.CenterY + b.CenterY,
+            Resolution = a.Resolution + b.Resolution,
+            Rotation = a.Rotation + b.Rotation,
+            Width = a.Width + b.Width,
+            Height = a.Height + b.Height
+        };
+    }
+
+    public static ViewportState operator -(ViewportState a, ViewportState b)
+    {
+        return a with
+        {
+            CenterX = a.CenterX - b.CenterX,
+            CenterY = a.CenterY - b.CenterY,
+            Resolution = a.Resolution - b.Resolution,
+            Rotation = a.Rotation - b.Rotation,
+            Width = a.Width - b.Width,
+            Height = a.Height - b.Height
+        };
+    }
+
+    public static ViewportState operator *(ViewportState v, double m)
+    {
+        return v with
+        {
+            CenterX = v.CenterX * m,
+            CenterY = v.CenterY * m,
+            Resolution = v.Resolution * m,
+            Rotation = v.Rotation * m,
+            Width = v.Width * m,
+            Height = v.Height * m
+        };
+    }
+
+    public static ViewportState operator /(ViewportState v, double d)
+    {
+        return v with
+        {
+            CenterX = v.CenterX / d,
+            CenterY = v.CenterY / d,
+            Resolution = v.Resolution / d,
+            Rotation = v.Rotation / d,
+            Width = v.Width / d,
+            Height = v.Height / d
+        };
+    }
 }


### PR DESCRIPTION
The Viewport now holds all state in the ViewportState. The existing properties now se the properties of the ViewportState. They can probably be remove altogether at some point.

The ZoomOnCenterAnimation now sets the ViewportState as one statement instead of setting CenterX, CenterY and Resolution separately. 

https://github.com/Mapsui/Mapsui/blob/7fd495cd3aef71e12a8b54f108fb452c2db057fa/Mapsui/ViewportAnimations/ZoomOnCenterAnimation.cs#L28-L36

In the old code a single mousewheel click caused around 192 notifications
![Screenshot 2023-02-15 113639](https://user-images.githubusercontent.com/963462/219038225-a7bb4a3e-f075-489d-af1b-98567f379334.png)

With the new code about one third (there is some variation between events)
![image](https://user-images.githubusercontent.com/963462/219038523-546f4c91-7fda-475d-a672-dc2f18588dcd.png)




