### PR TITLE
remove .nuget\nuget.exe

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -172,7 +172,7 @@ jobs:
     - name: install maui macos android ios maccatalyst wasm-tools wasm-tools-net6
       run: dotnet workload install maui macos android ios maccatalyst wasm-tools wasm-tools-net6
     - name: Restore dependencies
-      run: .nuget\nuget restore Mapsui.sln     
+      run: nuget restore Mapsui.sln     
     # Test Build
     - name: Mapsui.Nts.Tests
       run: dotnet build --no-restore --configuration Debug Tests/Mapsui.Nts.Tests/Mapsui.Nts.Tests.csproj
@@ -206,7 +206,7 @@ jobs:
       run: |
         ./Scripts/SamplesMapsuiNugetReferences.ps1 $(git describe --tags)       
     - name: Restore dependencies
-      run: .nuget\nuget restore Mapsui.sln      
+      run: nuget restore Mapsui.sln      
     # Samples Build 
     - name: Mapsui.Samples.Avalonia
       run: dotnet build --no-restore --configuration Debug Samples/Mapsui.Samples.Avalonia/Mapsui.Samples.Avalonia.csproj

--- a/Mapsui.sln
+++ b/Mapsui.sln
@@ -21,13 +21,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scripts", "Scripts", "{B2DB6CAC-1C30-42C9-B628-BACEBF790AB9}"
 	ProjectSection(SolutionItems) = preProject
 		Scripts\buildpack.bat = Scripts\buildpack.bat
-		Scripts\buildpackpush.bat = Scripts\buildpackpush.bat
 		.github\workflows\dotnet-docs.yml = .github\workflows\dotnet-docs.yml
 		.github\workflows\dotnet-release-nugets.yml = .github\workflows\dotnet-release-nugets.yml
 		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
 		Scripts\NugetRestore.cmd = Scripts\NugetRestore.cmd
-		Scripts\readme.txt = Scripts\readme.txt
-		Scripts\rename.ps1 = Scripts\rename.ps1
 		Scripts\SamplesMapsuiNugetReferences.ps1 = Scripts\SamplesMapsuiNugetReferences.ps1
 		Scripts\test-image-copier.cmd = Scripts\test-image-copier.cmd
 	EndProjectSection

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Mobile/Mapsui.Samples.Uno.WinUI.Mobile.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Mobile/Mapsui.Samples.Uno.WinUI.Mobile.csproj
@@ -80,8 +80,4 @@
     </When>
   </Choose>
   <Import Project="..\Mapsui.Samples.Uno.WinUI.Shared\Mapsui.Samples.Uno.WinUI.Shared.projitems" Label="Shared" />
-  <PropertyGroup>
-    <!-- Workaround for Error NU1008 Projects that use central package version management should not define the version on the PackageReference ..-->
-    <!--<PreBuildEvent>"$(MSBuildProjectDirectory)\..\..\..\.nuget\nuget" restore $(MSBuildProjectDirectory)\Mapsui.Samples.Uno.WinUI.Mobile.csproj</PreBuildEvent>-->
-  </PropertyGroup>
 </Project>

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Windows/Mapsui.Samples.Uno.WinUI.Windows.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Windows/Mapsui.Samples.Uno.WinUI.Windows.csproj
@@ -80,8 +80,6 @@
 
 	<Import Project="..\Mapsui.Samples.Uno.WinUI.Shared\Mapsui.Samples.Uno.WinUI.Shared.projitems" Label="Shared" />
   <PropertyGroup>
-    <!-- Workaround for Error NU1008 Projects that use central package version management should not define the version on the PackageReference ..-->
-	<!-- <PreBuildEvent>"$(MSBuildProjectDirectory)\..\..\..\.nuget\nuget" restore $(MSBuildProjectDirectory)\Mapsui.Samples.Uno.WinUI.Windows.csproj</PreBuildEvent>-->
     <DefaultLanguage>en</DefaultLanguage>
   </PropertyGroup>
 </Project>

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Mobile/Mapsui.Samples.Uno.Mobile.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Mobile/Mapsui.Samples.Uno.Mobile.csproj
@@ -77,8 +77,4 @@
     <ProjectReference Include="..\..\Mapsui.Samples.CustomWidget\Mapsui.Samples.CustomWidget.csproj" />
   </ItemGroup>
   <Import Project="..\Mapsui.Samples.Uno.Shared\Mapsui.Samples.Uno.Shared.projitems" Label="Shared" />
-  <PropertyGroup>
-    <!-- Workaround for Error NU1008 Projects that use central package version management should not define the version on the PackageReference ..-->
-    <!-- <PreBuildEvent>"$(MSBuildProjectDirectory)\..\..\..\.nuget\nuget" restore $(MSBuildProjectDirectory)\Mapsui.Samples.Uno.Mobile.csproj</PreBuildEvent>-->
-  </PropertyGroup>
 </Project>

--- a/Scripts/NugetRestore.cmd
+++ b/Scripts/NugetRestore.cmd
@@ -1,4 +1,4 @@
 cd..
 git clean -fx -d -e .vs
 mkdir Artifacts
-.\.nuget\nuget restore Mapsui.sln
+nuget restore Mapsui.sln


### PR DESCRIPTION
Removes the local nuget.exe (was a workaround because the nuget update task didn't update to the latest nuget)