### PR TITLE
Use the same mouse wheel animation code on all platforms

### DIFF
--- a/Mapsui.UI.Avalonia/MapControl.cs
+++ b/Mapsui.UI.Avalonia/MapControl.cs
@@ -31,8 +31,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
     private double _mouseWheelPos = 0.0;
 
     public event EventHandler<FeatureInfoEventArgs>? FeatureInfo;
-    public MouseWheelAnimation MouseWheelAnimation { get; } = new() { Duration = 0 };
-
+    
     public MapControl()
     {
         ClipToBounds = true;
@@ -103,8 +102,8 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         }
         if (!navigate) return;
 
-        var resolution = MouseWheelAnimation.GetResolution(delta, Map.Viewport, _map);
-        Map.Navigator.ZoomTo(resolution, _currentMousePosition, MouseWheelAnimation.Duration, MouseWheelAnimation.Easing);
+        var resolution = Map.Navigator.MouseWheelAnimation.GetResolution(delta, Map.Viewport, Map.Resolutions);
+        Map.Navigator.ZoomTo(resolution, _currentMousePosition, Map.Navigator.MouseWheelAnimation.Duration, Map.Navigator.MouseWheelAnimation.Easing);
     }
 
     private void MapControlMouseLeftButtonDown(PointerPressedEventArgs e)

--- a/Mapsui.UI.Avalonia/MapControl.cs
+++ b/Mapsui.UI.Avalonia/MapControl.cs
@@ -102,8 +102,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         }
         if (!navigate) return;
 
-        var resolution = Map.Navigator.MouseWheelAnimation.GetResolution(delta, Map.Viewport, Map.Resolutions);
-        Map.Navigator.ZoomTo(resolution, _currentMousePosition, Map.Navigator.MouseWheelAnimation.Duration, Map.Navigator.MouseWheelAnimation.Easing);
+        ZoomInOrOut(delta, _currentMousePosition);
     }
 
     private void MapControlMouseLeftButtonDown(PointerPressedEventArgs e)

--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -38,7 +38,7 @@ public partial class MapControl : ComponentBase, IMapControl
     public int MoveModifier { get; set; } = Keys.None;
     public int ZoomButton { get; set; } = MouseButtons.Primary;
     public int ZoomModifier { get; set; } = Keys.Control;
-    public MouseWheelAnimation MouseWheelAnimation { get; } = new();
+
     protected readonly string _elementId = Guid.NewGuid().ToString("N");
     private MapsuiJsInterop? _interop;
 
@@ -142,9 +142,9 @@ public partial class MapControl : ComponentBase, IMapControl
             if (!Map.Viewport.State.HasSize()) return;
 
             var delta = e.DeltaY * -1; // so that it zooms like on windows
-            var resolution = MouseWheelAnimation.GetResolution((int)delta, Map.Viewport, Map);
+            var resolution = Map.Navigator.MouseWheelAnimation.GetResolution((int)delta, Map.Viewport, Map.Resolutions);
             Map.Navigator.ZoomTo(resolution, e.Location(await BoundingClientRectAsync()).ToMapsui(), 
-                MouseWheelAnimation.Duration, MouseWheelAnimation.Easing);
+                Map.Navigator.MouseWheelAnimation.Duration, Map.Navigator.MouseWheelAnimation.Easing);
         }
         catch (Exception ex)
         {

--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -142,9 +142,10 @@ public partial class MapControl : ComponentBase, IMapControl
             if (!Map.Viewport.State.HasSize()) return;
 
             var delta = e.DeltaY * -1; // so that it zooms like on windows
-            var resolution = Map.Navigator.MouseWheelAnimation.GetResolution((int)delta, Map.Viewport, Map.Resolutions);
-            Map.Navigator.ZoomTo(resolution, e.Location(await BoundingClientRectAsync()).ToMapsui(), 
-                Map.Navigator.MouseWheelAnimation.Duration, Map.Navigator.MouseWheelAnimation.Easing);
+
+            var currentMousePosition = e.Location(await BoundingClientRectAsync()).ToMapsui();
+                       
+            ZoomInOrOut((int)delta, currentMousePosition);
         }
         catch (Exception ex)
         {

--- a/Mapsui.UI.Eto/MapControl.cs
+++ b/Mapsui.UI.Eto/MapControl.cs
@@ -21,7 +21,6 @@ public partial class MapControl : SkiaDrawable, IMapControl
     public Keys MoveModifier { get; set; } = Keys.None;
     public MouseButtons ZoomButton { get; set; } = MouseButtons.Primary;
     public Keys ZoomModifier { get; set; } = Keys.Control;
-    public MouseWheelAnimation MouseWheelAnimation { get; } = new();
 
     public MapControl()
     {
@@ -77,8 +76,8 @@ public partial class MapControl : SkiaDrawable, IMapControl
         if (Map.Viewport.Limiter.ZoomLock) return;
         if (!Map.Viewport.State.HasSize()) return;
 
-        var resolution = MouseWheelAnimation.GetResolution((int)e.Delta.Height, Map.Viewport, _map);
-        Map.Navigator.ZoomTo(resolution, e.Location.ToMapsui(), MouseWheelAnimation.Duration, MouseWheelAnimation.Easing);
+        var resolution = Map.Navigator.MouseWheelAnimation.GetResolution((int)e.Delta.Height, Map.Viewport, Map.Resolutions);
+        Map.Navigator.ZoomTo(resolution, e.Location.ToMapsui(), Map.Navigator.MouseWheelAnimation.Duration, Map.Navigator.MouseWheelAnimation.Easing);
     }
 
     protected override void OnSizeChanged(EventArgs e)

--- a/Mapsui.UI.Eto/MapControl.cs
+++ b/Mapsui.UI.Eto/MapControl.cs
@@ -10,6 +10,7 @@ using global::Eto.Drawing;
 using global::Eto.Forms;
 using System.Diagnostics;
 using Mapsui.Extensions;
+using NetTopologySuite.GeometriesGraph;
 
 public partial class MapControl : SkiaDrawable, IMapControl
 {
@@ -76,8 +77,9 @@ public partial class MapControl : SkiaDrawable, IMapControl
         if (Map.Viewport.Limiter.ZoomLock) return;
         if (!Map.Viewport.State.HasSize()) return;
 
-        var resolution = Map.Navigator.MouseWheelAnimation.GetResolution((int)e.Delta.Height, Map.Viewport, Map.Resolutions);
-        Map.Navigator.ZoomTo(resolution, e.Location.ToMapsui(), Map.Navigator.MouseWheelAnimation.Duration, Map.Navigator.MouseWheelAnimation.Easing);
+        var delta = (int)e.Delta.Height;
+        var currentMousePosition = e.Location.ToMapsui();
+        ZoomInOrOut(delta, currentMousePosition);
     }
 
     protected override void OnSizeChanged(EventArgs e)

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -336,14 +336,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
             }
             else if (e.ActionType == SKTouchAction.WheelChanged)
             {
-                if (e.WheelDelta > 0)
-                {
-                    OnZoomIn(location);
-                }
-                else
-                {
-                    OnZoomOut(location);
-                }
+                OnZoomInOrOut(e.WheelDelta, location);
             }
         }
         catch (Exception ex)
@@ -467,49 +460,24 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     public event EventHandler<ZoomedEventArgs>? Zoomed;
 
     /// <summary>
-    /// Called, when map should zoom out
+    /// Called, when map should zoom in or out
     /// </summary>
     /// <param name="screenPosition">Center of zoom out event</param>
-    private bool OnZoomOut(MPoint screenPosition)
+    private bool OnZoomInOrOut(int delta, MPoint screenPosition)
     {
         if (Map.Viewport.Limiter.ZoomLock)
         {
             return true;
         }
 
-        var args = new ZoomedEventArgs(screenPosition, ZoomDirection.ZoomOut);
+        var args = new ZoomedEventArgs(screenPosition, delta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
 
         Zoomed?.Invoke(this, args);
 
         if (args.Handled)
             return true;
 
-        // Perform standard behavior
-        Map.Navigator.ZoomOut(screenPosition);
-
-        return true;
-    }
-
-    /// <summary>
-    /// Called, when map should zoom in
-    /// </summary>
-    /// <param name="screenPosition">Center of zoom in event</param>
-    private bool OnZoomIn(MPoint screenPosition)
-    {
-        if (Map.Viewport.Limiter.ZoomLock)
-        {
-            return true;
-        }
-
-        var args = new ZoomedEventArgs(screenPosition, ZoomDirection.ZoomIn);
-
-        Zoomed?.Invoke(this, args);
-
-        if (args.Handled)
-            return true;
-
-        // Perform standard behavior
-        Map.Navigator.ZoomIn(screenPosition);
+        ZoomInOrOut(delta, screenPosition);
 
         return true;
     }
@@ -753,7 +721,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
             return true;
 
         // Double tap as zoom
-        return OnZoomIn(screenPosition);
+        return OnZoomInOrOut(1, screenPosition); // delta > 0 to zoom in
     }
 
     /// <summary>

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -615,4 +615,17 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         }
         _invalidateTimer = null;
     }
+
+    private void ZoomInOrOut(int delta, MPoint centerOfZoom)
+    {
+        var resolution = Map.Navigator.MouseWheelAnimation.GetResolution(delta, Map.Viewport, Map.Resolutions);
+        if (delta > Constants.Epsilon)
+        {
+            Map.Navigator.ZoomTo(resolution, centerOfZoom, Map.Navigator.MouseWheelAnimation.Duration, Map.Navigator.MouseWheelAnimation.Easing);
+        }
+        else if (delta < Constants.Epsilon)
+        {
+            Map.Navigator.ZoomTo(resolution, centerOfZoom, Map.Navigator.MouseWheelAnimation.Duration, Map.Navigator.MouseWheelAnimation.Easing);
+        }
+    }
 }

--- a/Mapsui.UI.WinUI/MapControl.cs
+++ b/Mapsui.UI.WinUI/MapControl.cs
@@ -56,8 +56,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
     private readonly SKXamlCanvas _canvas = CreateRenderTarget();
     private double _virtualRotation;
 
-    public MouseWheelAnimation MouseWheelAnimation { get; } = new MouseWheelAnimation { Duration = 0 };
-
     public MapControl()
     {
         CommonInitialize();
@@ -165,8 +163,8 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         var mousePosition = new MPoint(currentPoint.RawPosition.X, currentPoint.RawPosition.Y);
 #endif
 
-        var resolution = MouseWheelAnimation.GetResolution(currentPoint.Properties.MouseWheelDelta, Map.Viewport, _map);
-        Map.Navigator.ZoomTo(resolution, mousePosition, MouseWheelAnimation.Duration, MouseWheelAnimation.Easing);
+        var resolution = Map.Navigator.MouseWheelAnimation.GetResolution(currentPoint.Properties.MouseWheelDelta, Map.Viewport, Map.Resolutions);
+        Map.Navigator.ZoomTo(resolution, mousePosition, Map.Navigator.MouseWheelAnimation.Duration, Map.Navigator.MouseWheelAnimation.Easing);
 
         e.Handled = true;
     }

--- a/Mapsui.UI.WinUI/MapControl.cs
+++ b/Mapsui.UI.WinUI/MapControl.cs
@@ -14,6 +14,7 @@ using Windows.System;
 using Mapsui.Extensions;
 using Mapsui.Logging;
 using Mapsui.Utilities;
+using NetTopologySuite.GeometriesGraph;
 #if __WINUI__
 using System.Runtime.Versioning;
 using Mapsui.UI.WinUI.Extensions;
@@ -162,9 +163,9 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 #else
         var mousePosition = new MPoint(currentPoint.RawPosition.X, currentPoint.RawPosition.Y);
 #endif
+        var delta = currentPoint.Properties.MouseWheelDelta;
 
-        var resolution = Map.Navigator.MouseWheelAnimation.GetResolution(currentPoint.Properties.MouseWheelDelta, Map.Viewport, Map.Resolutions);
-        Map.Navigator.ZoomTo(resolution, mousePosition, Map.Navigator.MouseWheelAnimation.Duration, Map.Navigator.MouseWheelAnimation.Easing);
+        ZoomInOrOut(delta, mousePosition);
 
         e.Handled = true;
     }

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -32,8 +32,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
     private double _virtualRotation;
     private readonly FlingTracker _flingTracker = new();
 
-    public MouseWheelAnimation MouseWheelAnimation { get; } = new();
-
     /// <summary>
     /// Fling is called, when user release mouse button or lift finger while moving with a certain speed, higher than speed of swipe 
     /// </summary>
@@ -144,9 +142,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
         _currentMousePosition = e.GetPosition(this).ToMapsui();
 
-        // Todo: Move GetResolution inside the Navigator and use ZoomIn/Out with screenPosition
-        var resolution = MouseWheelAnimation.GetResolution(e.Delta, Map.Viewport, _map);
-        Map.Navigator.ZoomTo(resolution, _currentMousePosition, MouseWheelAnimation.Duration, MouseWheelAnimation.Easing);
+        ZoomInOrOut(e.Delta, _currentMousePosition);
     }
 
     private void MapControlSizeChanged(object sender, SizeChangedEventArgs e)

--- a/Mapsui/INavigator.cs
+++ b/Mapsui/INavigator.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using Mapsui.UI;
 using Mapsui.Utilities;
 
 namespace Mapsui;
 
 public interface INavigator
 {
+    MouseWheelAnimation MouseWheelAnimation { get; }
+
     /// <summary>
     /// Called each time one of the navigation methods is called
     /// </summary>

--- a/Mapsui/Limiting/LimitResult.cs
+++ b/Mapsui/Limiting/LimitResult.cs
@@ -10,7 +10,6 @@ public class LimitResult
     }
 
     public bool ZoomLimited { get; }
-    public bool PanLimited => PanXLimited && PanYLimited;
     public bool PanXLimited { get; }
     public bool PanYLimited { get; }
     public bool FullyLimited { get; }

--- a/Mapsui/Navigator.cs
+++ b/Mapsui/Navigator.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Mapsui.Animations;
 using Mapsui.Extensions;
+using Mapsui.UI;
 using Mapsui.Utilities;
 using Mapsui.ViewportAnimations;
 
@@ -21,6 +22,9 @@ public class Navigator : INavigator
         _map = map;
         _viewport = viewport;
     }
+
+    public MouseWheelAnimation MouseWheelAnimation { get; } = new();
+
 
     /// <summary>
     /// Navigate center of viewport to center of extent and change resolution

--- a/Mapsui/UI/MouseWheelAnimation.cs
+++ b/Mapsui/UI/MouseWheelAnimation.cs
@@ -9,7 +9,7 @@ public class MouseWheelAnimation
     private int _tickCount = int.MinValue;
     private double _toResolution;
 
-    public int Duration { get; set; } = 1000;
+    public int Duration { get; set; } = 600;
     public Easing Easing { get; set; } = Easing.QuarticOut;
 
     public double GetResolution(int delta, Viewport viewport, IReadOnlyList<double> resolutions)

--- a/Mapsui/UI/MouseWheelAnimation.cs
+++ b/Mapsui/UI/MouseWheelAnimation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Mapsui.Utilities;
 
 namespace Mapsui.UI;
@@ -7,10 +8,11 @@ public class MouseWheelAnimation
 {
     private int _tickCount = int.MinValue;
     private double _toResolution;
+
     public int Duration { get; set; } = 1000;
     public Easing Easing { get; set; } = Easing.QuarticOut;
 
-    public double GetResolution(int delta, Viewport viewport, Map map)
+    public double GetResolution(int delta, Viewport viewport, IReadOnlyList<double> resolutions)
     {
         // If the animation has ended then start from the current resolution.
         // The alternative is to use the previous resolution target and add an extra
@@ -20,14 +22,14 @@ public class MouseWheelAnimation
 
         if (delta > Constants.Epsilon)
         {
-            _toResolution = ZoomHelper.ZoomIn(map.Resolutions, _toResolution);
+            _toResolution = ZoomHelper.ZoomIn(resolutions, _toResolution);
             // Todo: Move this to ZoomIn. Make limiting consistent.
             if (viewport.Limiter.ZoomLimits is not null)
                 _toResolution = Math.Max(_toResolution, viewport.Limiter.ZoomLimits.Min);
         }
         else if (delta < Constants.Epsilon)
         {
-            _toResolution = ZoomHelper.ZoomOut(map.Resolutions, _toResolution);
+            _toResolution = ZoomHelper.ZoomOut(resolutions, _toResolution);
             // Todo: Move this to ZoomOut. Make limiting consistent.
             if (viewport.Limiter.ZoomLimits is not null)
                 _toResolution = Math.Min(_toResolution, viewport.Limiter.ZoomLimits.Max);
@@ -42,6 +44,6 @@ public class MouseWheelAnimation
     private bool IsAnimating()
     {
         var tickProgress = Environment.TickCount - _tickCount;
-        return (tickProgress >= 0) && (tickProgress < Duration);
+        return (tickProgress >= 0) && (tickProgress < Duration); 
     }
 }


### PR DESCRIPTION
The same code is now used on all platforms. So, the same way to determine the destination resolution. The same way to animate. Using the same properties for the animation. The same way to alter the animation settings, or disable the animations (set `Map.Navigator.MouseWheelAnimation.Duration = 0`).

We have eleven platforms. Tested on these platforms:
- Mapsui.Eto	
- Mapsui.Wpf	
- Mapsui.Avalonia	
- Mapsui.Blazor	
- Mapsui.WinUI
- Mapsui.Maui	

Not tested but has shared code with the tested platforms:
- Mapsui.Forms (Same as MAUI)
- Mapsui.Uno.WinUI (Same as WinUI)
- Mapsui.Uno	(Same as WinUI)

Does not support mouse:
- Mapsui.Android
- Mapsui.iOS	