### PR TITLE
Fix editing and caching

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,7 +65,7 @@
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="[2.0.0,3.0.0)" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="[1.2.230217.4,2.0.0)" />
     <PackageVersion Include="NeoSmart.AsyncLock" Version="[3.2.1,4.0.0)" />
-    <PackageVersion Include="NetTopologySuite" Version="[2.4.0,3.0.0)" />
+    <PackageVersion Include="NetTopologySuite" Version="[2.5.0,3.0.0)" />
     <PackageVersion Include="NetTopologySuite.IO.GeoJSON4STJ" Version="[3.0.0,4.0.0)" />
     <PackageVersion Include="Newtonsoft.Json" Version="[13.0.1,14.0.0)" />
     <PackageVersion Include="NUnit" Version="[3.12.0,4.0.0)" />

--- a/Mapsui.Nts/Providers/Wfs/WFSProvider.cs
+++ b/Mapsui.Nts/Providers/Wfs/WFSProvider.cs
@@ -396,6 +396,7 @@ public class WFSProvider : IProvider, IDisposable
     public WFSProvider(IXPathQueryManager getCapabilitiesCache, string nsPrefix, string featureType,
                GeometryTypeEnum geometryType, WFSVersionEnum wfsVersion, IUrlPersistentCache? persistentCache = null)
     {
+        _httpClientUtil?.Dispose();
         _httpClientUtil = new HttpClientUtil(persistentCache);
         _persistentCache = persistentCache;
         _featureTypeInfoQueryManager = getCapabilitiesCache;

--- a/Mapsui.Nts/Providers/Wfs/WFSProvider.cs
+++ b/Mapsui.Nts/Providers/Wfs/WFSProvider.cs
@@ -302,6 +302,7 @@ public class WFSProvider : IProvider, IDisposable
     /// <param name="persistentCache">Persistent Cache</param>
     public WFSProvider(WfsFeatureTypeInfo featureTypeInfo, WFSVersionEnum wfsVersion, IUrlPersistentCache? persistentCache = null)
     {
+        _httpClientUtil?.Dispose();
         _httpClientUtil = new HttpClientUtil(persistentCache);
         _persistentCache = persistentCache;
         _featureTypeInfo = featureTypeInfo;
@@ -337,6 +338,7 @@ public class WFSProvider : IProvider, IDisposable
     public WFSProvider(string serviceUri, string nsPrefix, string featureTypeNamespace, string featureType,
                string geometryName, GeometryTypeEnum geometryType, WFSVersionEnum wfsVersion, IUrlPersistentCache? persistentCache = null)
     {
+        _httpClientUtil?.Dispose();
         _httpClientUtil = new HttpClientUtil(persistentCache);
         _persistentCache = persistentCache;
         _featureTypeInfo = new WfsFeatureTypeInfo(serviceUri, nsPrefix, featureTypeNamespace, featureType,

--- a/Mapsui.Rendering.Skia/SkiaStyles/LineStringRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/LineStringRenderer.cs
@@ -12,7 +12,7 @@ namespace Mapsui.Rendering.Skia;
 public static class LineStringRenderer
 {
     [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP001:Dispose created")]
-    public static void Draw(SKCanvas canvas, ViewportState viewport, VectorStyle? vectorStyle,
+    public static void Draw(SKCanvas canvas, ViewportState viewport, ILayer layer, VectorStyle? vectorStyle,
         LineString lineString, float opacity, IVectorCache? vectorCache = null)
     {
         if (vectorStyle == null)
@@ -20,7 +20,7 @@ public static class LineStringRenderer
 
         SKPaint paint;
         SKPath path;
-        if (vectorCache == null)
+        if (vectorCache == null || layer is IWritableLayer)
         {
             paint = CreateSkPaint(vectorStyle.Line, opacity);
             path = lineString.ToSkiaPath(viewport, canvas.LocalClipBounds);

--- a/Mapsui.Rendering.Skia/SkiaStyles/PolygonRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/PolygonRenderer.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
+using Mapsui.Layers;
 using Mapsui.Rendering.Skia.Extensions;
 using Mapsui.Styles;
 using NetTopologySuite.Geometries;
@@ -15,7 +17,7 @@ internal static class PolygonRenderer
     private const float Scale = 10.0f;
 
     [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP001:Dispose created")]
-    public static void Draw(SKCanvas canvas, ViewportState viewport, VectorStyle vectorStyle, IFeature feature,
+    public static void Draw(SKCanvas canvas, ViewportState viewport, ILayer layer, VectorStyle vectorStyle, IFeature feature,
         Polygon polygon, float opacity, ISymbolCache? symbolCache = null, IVectorCache? vectorCache = null)
     {
 
@@ -24,14 +26,14 @@ internal static class PolygonRenderer
         SKPaint paint;
         SKPaint paintFill;
         SKPath path;
-        if (vectorCache == null)
+        if (vectorCache == null || layer is IWritableLayer)
         {
             paint = CreateSkPaint(vectorStyle?.Outline, opacity);
             paintFill = CreateSkPaint(vectorStyle?.Fill, opacity, viewport.Rotation, symbolCache);
             path = polygon.ToSkiaPath(viewport, canvas.LocalClipBounds, lineWidth);
         }
         else
-        {
+        {            
             paint = vectorCache.GetOrCreatePaint(vectorStyle?.Outline, opacity, CreateSkPaint);
             paintFill = vectorCache.GetOrCreatePaint(vectorStyle?.Fill, opacity, viewport.Rotation, CreateSkPaint);
             path = vectorCache.GetOrCreatePath(viewport, polygon, lineWidth, (geometry, viewport, lineWidth) => geometry.ToSkiaPath(viewport, viewport.ToSkiaRect(), lineWidth));

--- a/Mapsui.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
@@ -23,7 +23,7 @@ public class VectorStyleRenderer : ISkiaStyleRenderer, IFeatureSize
             {
                 case RectFeature rectFeature:
                     if (rectFeature.Rect != null)
-                        PolygonRenderer.Draw(canvas, viewport, vectorStyle, rectFeature, rectFeature.Rect.ToPolygon(), opacity, renderCache, renderCache);
+                        PolygonRenderer.Draw(canvas, viewport, layer, vectorStyle, rectFeature, rectFeature.Rect.ToPolygon(), opacity, renderCache, renderCache);
                     break;
                 case PointFeature pointFeature:
                     SymbolStyleRenderer.DrawSymbol(canvas, viewport, layer, pointFeature.Point.X, pointFeature.Point.Y, new SymbolStyle { Outline = vectorStyle.Outline, Fill = vectorStyle.Fill, Line = vectorStyle.Line });
@@ -39,10 +39,10 @@ public class VectorStyleRenderer : ISkiaStyleRenderer, IFeatureSize
                             Draw(canvas, viewport, layer, new PointFeature(point.X, point.Y), style, renderCache, iteration);
                             break;
                         case Polygon polygon:
-                            PolygonRenderer.Draw(canvas, viewport, vectorStyle, feature, polygon, opacity, renderCache, renderCache);
+                            PolygonRenderer.Draw(canvas, viewport, layer, vectorStyle, feature, polygon, opacity, renderCache, renderCache);
                             break;
                         case LineString lineString:
-                            LineStringRenderer.Draw(canvas, viewport, vectorStyle, lineString, opacity, renderCache);
+                            LineStringRenderer.Draw(canvas, viewport, layer, vectorStyle, lineString, opacity, renderCache);
                             break;
                         case null:
                             throw new ArgumentException($"Geometry is null, Layer: {layer.Name}");

--- a/Mapsui/Layers/IWritableLayer.cs
+++ b/Mapsui/Layers/IWritableLayer.cs
@@ -1,0 +1,4 @@
+﻿namespace Mapsui.Layers;
+
+/// <summary> Tags a Layer as Modifiable, so that caching is disabled. </summary>
+public interface IWritableLayer { }

--- a/Mapsui/Layers/WritableLayer.cs
+++ b/Mapsui/Layers/WritableLayer.cs
@@ -6,7 +6,7 @@ using Mapsui.Styles;
 
 namespace Mapsui.Layers;
 
-public class WritableLayer : BaseLayer
+public class WritableLayer : BaseLayer, IWritableLayer
 {
     private readonly ConcurrentHashSet<IFeature> _cache = new();
 

--- a/Samples/Mapsui.Samples.Wpf.Editing/Layers/VertexOnlyLayer.cs
+++ b/Samples/Mapsui.Samples.Wpf.Editing/Layers/VertexOnlyLayer.cs
@@ -8,7 +8,7 @@ using NetTopologySuite.Geometries;
 
 namespace Mapsui.Samples.Wpf.Editing.Layers;
 
-public class VertexOnlyLayer : BaseLayer
+public class VertexOnlyLayer : BaseLayer, IWritableLayer
 {
     private readonly WritableLayer _source;
 


### PR DESCRIPTION
1) Updated NTS to newest Version, some Bugfixes when Manipulating and Editing Geometries.
fixing for example https://github.com/NetTopologySuite/NetTopologySuite/pull/604

2) Writable Layers are not cached, because when I want to cache mutable objects I would have to clone them and put them into the cache (Which would destroy the Performance wins). But when they are mutated the cache state becomes invalid causing this problems, They are equal but different in Geometry.

Fixes:
https://github.com/Mapsui/Mapsui/issues/1902