### PR TITLE
Refresh graphics on ViewportChanged

### DIFF
--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -238,7 +238,6 @@ public partial class MapControl : ViewGroup, IMapControl
                             if (_previousTouch != null)
                             {
                                 Map.Navigator.Drag(touch, _previousTouch);
-                                RefreshGraphics();
                             }
                             _previousTouch = touch;
                         }
@@ -262,7 +261,6 @@ public partial class MapControl : ViewGroup, IMapControl
                             }
 
                             Map.Navigator.Pinch(touch, previousTouch, radius / previousRadius, rotationDelta);
-                            RefreshGraphics(); // Todo: ViewportChanged should trigger RefreshGraphics
 
                             (_previousTouch, _previousRadius, _previousAngle) = (touch, radius, angle);
 

--- a/Mapsui.UI.Avalonia/MapControl.cs
+++ b/Mapsui.UI.Avalonia/MapControl.cs
@@ -124,7 +124,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
             }
 
             Map.Navigator.Drag(_currentMousePosition, _previousMousePosition);
-            RefreshGraphics();
             _previousMousePosition = _currentMousePosition;
         }
     }

--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -268,9 +268,6 @@ public partial class MapControl : ComponentBase, IMapControl
 
                     var currentPosition = e.Location(await BoundingClientRectAsync()).ToMapsui();
                     Map.Navigator.Drag(currentPosition, _downMousePosition.ToMapsui());
-
-                    RefreshGraphics();
-
                     _downMousePosition = e.Location(await BoundingClientRectAsync());
                 }
             }
@@ -285,9 +282,6 @@ public partial class MapControl : ComponentBase, IMapControl
     {
         var box = new MRect(beginPoint.X, beginPoint.Y, endPoint.X, endPoint.Y);
         Map.Navigator.ZoomToBox(box, duration: 300); ;
-
-        RefreshData();
-        RefreshGraphics();
         ClearBBoxDrawing();
     }
 

--- a/Mapsui.UI.Eto/MapControl.cs
+++ b/Mapsui.UI.Eto/MapControl.cs
@@ -169,9 +169,6 @@ public partial class MapControl : SkiaDrawable, IMapControl
                 Cursor = MoveCursor;
 
                 Map.Navigator.Drag(e.Location.ToMapsui(), _downMousePosition.Value.ToMapsui());
-
-                RefreshGraphics();
-
                 _downMousePosition = e.Location;
             }
         }
@@ -181,9 +178,6 @@ public partial class MapControl : SkiaDrawable, IMapControl
     {
         var box = new MRect(beginPoint.X, beginPoint.Y, endPoint.X, endPoint.Y);
         Map.Navigator.ZoomToBox(box, duration: 300); ;
-
-        RefreshData();
-        RefreshGraphics();
         ClearBBoxDrawing();
     }
 

--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -655,8 +655,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
                     if (!Map.Navigator.Limiter.PanLock && _previousCenter != null)
                     {
                         Map.Navigator.Drag(touchPosition, _previousCenter);
-
-                        RefreshGraphics();
                     }
 
                     _previousCenter = touchPosition;

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -294,12 +294,12 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     /// <param name="map">Map, to which events to subscribe</param>
     private void SubscribeToMapEvents(Map map)
     {
-        map.DataChanged += MapDataChanged;
-        map.PropertyChanged += MapPropertyChanged;
-        map.RefreshGraphicsRequest += MapRefreshGraphics;
+        map.DataChanged += Map_DataChanged;
+        map.PropertyChanged += Map_PropertyChanged;
+        map.RefreshGraphicsRequest += Map_RefreshGraphicsRequest;
     }
 
-    private void MapRefreshGraphics(object? sender, EventArgs e)
+    private void Map_RefreshGraphicsRequest(object? sender, EventArgs e)
     {
         RefreshGraphics();
     }
@@ -311,9 +311,9 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     private void UnsubscribeFromMapEvents(Map map)
     {
         var localMap = map;
-        localMap.DataChanged -= MapDataChanged;
-        localMap.PropertyChanged -= MapPropertyChanged;
-        localMap.RefreshGraphicsRequest -= MapRefreshGraphics;
+        localMap.DataChanged -= Map_DataChanged;
+        localMap.PropertyChanged -= Map_PropertyChanged;
+        localMap.RefreshGraphicsRequest -= Map_RefreshGraphicsRequest;
         localMap.AbortFetch();
     }
 
@@ -327,7 +327,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         _refresh = true;
     }
 
-    private void MapDataChanged(object? sender, DataChangedEventArgs? e)
+    private void Map_DataChanged(object? sender, DataChangedEventArgs? e)
     {
         RunOnUIThread(() =>
         {
@@ -356,13 +356,13 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             }
             catch (Exception exception)
             {
-                Logger.Log(LogLevel.Warning, $"Unexpected exception in {nameof(MapDataChanged)}", exception);
+                Logger.Log(LogLevel.Warning, $"Unexpected exception in {nameof(Map_DataChanged)}", exception);
             }
         });
     }
     // ReSharper disable RedundantNameQualifier - needed for iOS for disambiguation
 
-    private void MapPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    private void Map_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(Layers.Layer.Enabled))
         {

--- a/Mapsui.UI.WinUI/MapControl.cs
+++ b/Mapsui.UI.WinUI/MapControl.cs
@@ -243,7 +243,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         }
 
         Map.Navigator.Pinch(center, previousCenter, radius / previousRadius, rotationDelta);
-        RefreshGraphics();
         e.Handled = true;
     }
 

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -309,7 +309,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
             _flingTracker.AddEvent(1, _currentMousePosition, DateTime.Now.Ticks);
             Map.Navigator.Drag(_currentMousePosition, _previousMousePosition);
-            RefreshGraphics();
             _previousMousePosition = _currentMousePosition;
         }
     }
@@ -318,9 +317,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
     {
         var box = new MRect(beginPoint.X, beginPoint.Y, endPoint.X, endPoint.Y);
         Map.Navigator.ZoomToBox(box, duration: 300); ;
-
-        RefreshData();
-        RefreshGraphics();
         ClearBBoxDrawing();
     }
 
@@ -397,7 +393,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         }
 
         Map.Navigator.Pinch(center, previousCenter, radius / previousRadius, rotationDelta);
-        RefreshGraphics();
         e.Handled = true;
     }
 

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -186,10 +186,7 @@ public partial class MapControl : UIView, IMapControl
             {
                 var position = touch.LocationInView(this).ToMapsui();
                 var previousPosition = touch.PreviousLocationInView(this).ToMapsui();
-
                 Map.Navigator.Drag(position, previousPosition);
-                RefreshGraphics();
-
                 _virtualRotation = Map.Navigator.Viewport.Rotation;
             }
         }
@@ -215,7 +212,6 @@ public partial class MapControl : UIView, IMapControl
             }
 
             Map.Navigator.Pinch(center, previousCenter, radius / previousRadius, rotationDelta);
-            RefreshGraphics();
         }
     }
 

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using Mapsui.Extensions;
 using Mapsui.Fetcher;
 using Mapsui.Layers;
-using Mapsui.Limiting;
 using Mapsui.Styles;
 using Mapsui.Widgets;
 
@@ -36,7 +35,13 @@ public class Map : INotifyPropertyChanged, IDisposable
     {
         BackColor = Color.White;
         Layers = new LayerCollection();
-        Navigator.RequestDataRefresh += NavigatorRequestDataRefresh;
+        Navigator.RefreshDataRequest += Navigator_RefreshDataRequest;
+        Navigator.ViewportChanged += Navigator_ViewportChanged;
+    }
+
+    private void Navigator_ViewportChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        RefreshGraphics();
     }
 
     /// <summary>
@@ -127,7 +132,7 @@ public class Map : INotifyPropertyChanged, IDisposable
     /// </summary>
     public Navigator Navigator { get; private set; } =  new Navigator();
 
-    private void NavigatorRequestDataRefresh(object? sender, EventArgs e)
+    private void Navigator_RefreshDataRequest(object? sender, EventArgs e)
     {
         RefreshData(ChangeType.Discrete);
     }

--- a/Mapsui/Navigator.cs
+++ b/Mapsui/Navigator.cs
@@ -20,7 +20,7 @@ public class Navigator
     /// Called when a data refresh is needed. This directly after a non-animated viewport change
     /// is made and after an animation has completed.
     /// </summary>
-    public event EventHandler? RequestDataRefresh;
+    public event EventHandler? RefreshDataRequest;
     public event PropertyChangedEventHandler? ViewportChanged;
 
     /// <summary>
@@ -346,13 +346,12 @@ public class Navigator
     {
         ClearAnimations();
         SetViewportWithLimit(Viewport with { Width = width, Height = height });
-        OnRequestDataRefresh();
-
+        OnRefreshDataRequest();
     }
 
-    private void OnRequestDataRefresh()
+    private void OnRefreshDataRequest()
     {
-        RequestDataRefresh?.Invoke(this, EventArgs.Empty);
+        RefreshDataRequest?.Invoke(this, EventArgs.Empty);
     }
 
     private static Viewport TransformState(Viewport viewport, MPoint positionScreen, MPoint previousPositionScreen, double deltaResolution, double deltaRotation)
@@ -416,7 +415,7 @@ public class Navigator
         if (_animations.All(a => a.Done))
         {
             ClearAnimations();
-            OnRequestDataRefresh();
+            OnRefreshDataRequest();
         }
         var animationResult = Animation.UpdateAnimations(Viewport, _animations);
 
@@ -425,7 +424,7 @@ public class Navigator
         if (ShouldAnimationsBeHaltedBecauseOfLimiting(animationResult.State, Viewport))
         {
             ClearAnimations();
-            OnRequestDataRefresh();
+            OnRefreshDataRequest();
             return false; // Not running
         }
 
@@ -477,12 +476,12 @@ public class Navigator
         {
             ClearAnimations();
             SetViewportWithLimit(viewport);
-            OnRequestDataRefresh();
+            OnRefreshDataRequest();
         }
         else
         {
             if (_animations.Any())
-                OnRequestDataRefresh();
+                OnRefreshDataRequest();
             _animations = ViewportAnimation.Create(Viewport, viewport, duration, easing);
         }
     }

--- a/Samples/Mapsui.Samples.Avalonia/Views/MainWindow.axaml.cs
+++ b/Samples/Mapsui.Samples.Avalonia/Views/MainWindow.axaml.cs
@@ -116,7 +116,6 @@ public partial class MainWindow : Window
         // This is probably not the proper event handler for this but I don't know what is.
         var percent = RotationSlider.Value / (RotationSlider.Maximum - RotationSlider.Minimum);
         MapControl.Map.Navigator.RotateTo(percent * 360);
-        MapControl.Refresh();
     }
 
 }

--- a/Samples/Mapsui.Samples.Eto/MainForm.cs
+++ b/Samples/Mapsui.Samples.Eto/MainForm.cs
@@ -171,7 +171,6 @@ public class MainForm : Form
     {
         var percent = (double)RotationSlider.Value / (RotationSlider.MaxValue - RotationSlider.MinValue);
         MapControl.Map.Navigator.RotateTo(percent * 360);
-        MapControl.Refresh();
     }
 
     private void MapControlOnInfo(object? sender, MapInfoEventArgs args)

--- a/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
@@ -86,7 +86,7 @@ public sealed partial class MainPageLarge : ContentPage, IDisposable
                 }
             }
 
-            mapView.Refresh();
+            mapView.RefreshGraphics();
         }
     }
 

--- a/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
@@ -91,7 +91,7 @@ public sealed partial class MapPage : ContentPage, IDisposable
                 }
             }
 
-            mapView.Refresh();
+            mapView.RefreshGraphics();
         }
     }
 

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Shared/MainPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Shared/MainPage.xaml.cs
@@ -111,6 +111,5 @@ public sealed partial class MainPage : Page
     {
         var percent = RotationSlider.Value / (RotationSlider.Maximum - RotationSlider.Minimum);
         MapControl.Map.Navigator.RotateTo(percent * 360);
-        MapControl.Refresh();
     }
 }

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Shared/MainPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Shared/MainPage.xaml.cs
@@ -106,6 +106,5 @@ public sealed partial class MainPage : Page
     {
         var percent = RotationSlider.Value / (RotationSlider.Maximum - RotationSlider.Minimum);
         MapControl.Map.Navigator.RotateTo(percent * 360);
-        MapControl.Refresh();
     }
 }

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/MainWindow.xaml.cs
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/MainWindow.xaml.cs
@@ -109,6 +109,5 @@ public sealed partial class MainWindow : Window
     {
         var percent = RotationSlider.Value / (RotationSlider.Maximum - RotationSlider.Minimum);
         MapControl.Map.Navigator.RotateTo(percent * 360);
-        MapControl.Refresh();
     }
 }

--- a/Samples/Mapsui.Samples.Wpf.Editing/MainWindow.xaml.cs
+++ b/Samples/Mapsui.Samples.Wpf.Editing/MainWindow.xaml.cs
@@ -141,7 +141,6 @@ public partial class MainWindow
     {
         var percent = RotationSlider.Value / (RotationSlider.Maximum - RotationSlider.Minimum);
         MapControl.Map.Navigator.RotateTo(percent * 360);
-        MapControl.Refresh();
     }
 
     private void ZoomSliderChanged(object sender, RoutedPropertyChangedEventArgs<double> args)

--- a/Samples/Mapsui.Samples.Wpf/Window1.xaml.cs
+++ b/Samples/Mapsui.Samples.Wpf/Window1.xaml.cs
@@ -137,7 +137,6 @@ public partial class Window1
     {
         var percent = RotationSlider.Value / (RotationSlider.Maximum - RotationSlider.Minimum);
         MapControl.Map.Navigator.RotateTo(percent * 360);
-        MapControl.Refresh();
     }
 
     private void MapControlOnInfo(object? sender, MapInfoEventArgs args)

--- a/Tests/Mapsui.Tests/NavigatorTests.cs
+++ b/Tests/Mapsui.Tests/NavigatorTests.cs
@@ -14,7 +14,7 @@ public class NavigatorTests
         var navigator = new Navigator();
         int navigatedCounter = 0;
         navigator.SetViewportAnimations(CreateAnimation());
-        navigator.RequestDataRefresh += (s, e) => navigatedCounter++;
+        navigator.RefreshDataRequest += (s, e) => navigatedCounter++;
 
         // Act
         navigator.CenterOn(10, 20);


### PR DESCRIPTION
The Map now listens to Navigator.ViewportChanged and calls RefreshGraphics() in the event handler. As a consequence calls that change the Viewport, like Navigator.Drag, do not have to be followed by a GraphicsRefresh call, so these were removed.