### PR TITLE
Move ConcurrentHashSet to corresponding namespace

### DIFF
--- a/Mapsui.Tiling/Fetcher/TileFetchDispatcher.cs
+++ b/Mapsui.Tiling/Fetcher/TileFetchDispatcher.cs
@@ -6,12 +6,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using BruTile;
 using BruTile.Cache;
-using ConcurrentCollections;
 using Mapsui.Extensions;
 using Mapsui.Fetcher;
 using Mapsui.Layers;
 using Mapsui.Logging;
 using Mapsui.Tiling.Extensions;
+using Mapsui.Utilities;
 
 namespace Mapsui.Tiling.Fetcher;
 

--- a/Mapsui.UI.Forms/Objects/ObservableCollectionProvider.cs
+++ b/Mapsui.UI.Forms/Objects/ObservableCollectionProvider.cs
@@ -4,9 +4,9 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
-using ConcurrentCollections;
 using Mapsui.Layers;
 using Mapsui.Providers;
+using Mapsui.Utilities;
 
 namespace Mapsui.UI.Objects;
 

--- a/Mapsui/Layers/ObservableMemoryLayer.cs
+++ b/Mapsui/Layers/ObservableMemoryLayer.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using ConcurrentCollections;
+using Mapsui.Utilities;
 
 namespace Mapsui.Layers;
 

--- a/Mapsui/Layers/WritableLayer.cs
+++ b/Mapsui/Layers/WritableLayer.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using ConcurrentCollections;
 using Mapsui.Styles;
+using Mapsui.Utilities;
 
 namespace Mapsui.Layers;
 

--- a/Mapsui/Utilities/ConcurrentHashSet.cs
+++ b/Mapsui/Utilities/ConcurrentHashSet.cs
@@ -2,6 +2,7 @@
 // https://github.com/i3arnon/ConcurrentHashSet
 // because with nuget package it resulted in an error on the build server
 
+using ConcurrentCollections;
 using Mapsui.Logging;
 using System;
 using System.Collections;
@@ -10,7 +11,7 @@ using System.Diagnostics;
 using System.Threading;
 
 // ReSharper disable All - This is a workaround for a limitation of the nuget package
-namespace ConcurrentCollections;
+namespace Mapsui.Utilities;
 
 /// <summary>
 /// Represents a thread-safe hash-based unique collection.
@@ -355,7 +356,7 @@ public class ConcurrentHashSet<T> : IReadOnlyCollection<T>, ICollection<T>
                 Node? previous = null;
                 for (var current = tables.Buckets[bucketNo]; current != null; current = current.Next)
                 {
-                    Debug.Assert((previous == null && current == tables.Buckets[bucketNo]) || previous?.Next == current);
+                    Debug.Assert(previous == null && current == tables.Buckets[bucketNo] || previous?.Next == current);
 
                     if (hashcode == current.Hashcode && _comparer.Equals(current.Item, item))
                     {


### PR DESCRIPTION
Making a local copy was intended as a temporary solution and it can be removed if we go to .NET 6 in v5, but right now it is weird to see this alien namespace at the top of the api documentation.