### PR TITLE
Don't override user set resolutions, zoomextremes panextent

### DIFF
--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -236,13 +236,10 @@ public class Map : INotifyPropertyChanged, IDisposable
 
     private void LayersChanged()
     {
-        // Todo: It is possible for the user to assign the three fields below override
-        // this initialization. However, whenever a layer changes this will override the
-        // the users settings again. This is a bug that needs to be fixed with a better
-        // design.
-        Navigator.Resolutions = DetermineResolutions(Layers);
-        Navigator.ZoomExtremes = GetMinMaxResolution(Navigator.Resolutions);
-        Navigator.PanExtent = Extent?.Copy();
+        // Sets the default values this are taken if not set otherwise
+        Navigator.DefaultResolutions = DetermineResolutions(Layers);
+        Navigator.DefaultZoomExtremes = GetMinMaxResolution(Navigator.Resolutions);
+        Navigator.DefaultPanExtent = Extent?.Copy();
         OnPropertyChanged(nameof(Layers));
     }
 

--- a/Mapsui/Navigator.cs
+++ b/Mapsui/Navigator.cs
@@ -15,6 +15,9 @@ public class Navigator
 {
     private Viewport _viewport = new(0, 0, 1, 0, 0, 0);
     private IEnumerable<AnimationEntry<Viewport>> _animations = Enumerable.Empty<AnimationEntry<Viewport>>();
+    private IReadOnlyList<double>? _resolutions;
+    private MMinMax? _zoomExtremes;
+    private MRect? _panExtent;
 
     /// <summary>
     /// Called when a data refresh is needed. This directly after a non-animated viewport change
@@ -27,13 +30,21 @@ public class Navigator
     /// Sets the extent used to restrict panning. Exactly how this extent affects panning
     /// depends on the implementation of the IViewportLimiter.
     /// </summary>
-    public MRect? PanExtent { get; set; }
+    public MRect? PanExtent
+    {
+        get => _panExtent ?? DefaultPanExtent;
+        set => _panExtent = value;
+    }
 
     /// <summary>
     /// A pair of the most extreme resolutions (smallest and biggest). How these extremes affect zooming
     /// depends on the implementation of the IViewportLimiter.
     /// </summary>
-    public MMinMax? ZoomExtremes { get; set; }
+    public MMinMax? ZoomExtremes
+    {
+        get => _zoomExtremes ?? DefaultZoomExtremes;
+        set => _zoomExtremes = value;
+    }
 
     public IViewportLimiter Limiter { get; set; } = new ViewportLimiter();
 
@@ -56,7 +67,11 @@ public class Navigator
     /// background layers with different resolutions. Also note that when pinch zooming these resolutions 
     /// are not used.
     /// </summary>
-    public IReadOnlyList<double> Resolutions { get; set; } = new List<double>();
+    public IReadOnlyList<double> Resolutions
+    {
+        get => _resolutions ?? DefaultResolutions;
+        set => _resolutions = value;
+    }
 
     public MouseWheelAnimation MouseWheelAnimation { get; } = new();
 
@@ -487,4 +502,13 @@ public class Navigator
     }
 
     internal int GetAnimationsCount => _animations.Count();
+    
+    /// <summary> Default Resolutions automatically set on Layers changed </summary>
+    internal IReadOnlyList<double> DefaultResolutions { get; set; }  = new List<double>();
+    
+    /// <summary> Default Zoom Extremes automatically set on Layers changed </summary>
+    internal MMinMax? DefaultZoomExtremes { get; set; }
+    
+    /// <summary> Default Pan Extent automatically set on Layers changed </summary>
+    internal MRect? DefaultPanExtent { get; set; }
 }


### PR DESCRIPTION
Fixes this https://github.com/Mapsui/Mapsui/issues/1938

When resolutions, zoomextremes and panextent are set externally they have priority over default (zoomextrems,panextent, resoultions) which are set during layerchanged events.