### PR TITLE
Use Override solutions for Resolutions and Pan/Zoom bounds

### DIFF
--- a/Mapsui.sln
+++ b/Mapsui.sln
@@ -3442,6 +3442,7 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Samples\Mapsui.Samples.Uno\Mapsui.Samples.Uno.Shared\Mapsui.Samples.Uno.Shared.projitems*{07b41a7b-6b33-48d6-aa55-b64964d7c5ea}*SharedItemsImports = 5
 		Samples\Mapsui.Samples.Uno\Mapsui.Samples.Uno.Shared\Mapsui.Samples.Uno.Shared.projitems*{08acb538-5b84-40ba-9653-a74ee6c2b18d}*SharedItemsImports = 4
+		Mapsui.UI.Shared\Mapsui.UI.Shared.projitems*{217bcf74-1da0-4fe5-a907-4a44f1b046ff}*SharedItemsImports = 5
 		Mapsui.UI.Shared\Mapsui.UI.Shared.projitems*{239f2b0d-13cb-4bcf-83bf-f52d696a47b7}*SharedItemsImports = 13
 		Mapsui.UI.Shared\Mapsui.UI.Shared.projitems*{27b81fbb-f6e9-49bb-bae9-f99f0e01db73}*SharedItemsImports = 5
 		Samples\Mapsui.Samples.Uno.WinUI\Mapsui.Samples.Uno.WinUI.Shared\Mapsui.Samples.Uno.WinUI.Shared.projitems*{3381b72b-c135-43e2-be16-ed3d279fc84d}*SharedItemsImports = 5

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -236,10 +236,9 @@ public class Map : INotifyPropertyChanged, IDisposable
 
     private void LayersChanged()
     {
-        // Sets the default values this are taken if not set otherwise
         Navigator.DefaultResolutions = DetermineResolutions(Layers);
-        Navigator.DefaultZoomExtremes = GetMinMaxResolution(Navigator.Resolutions);
-        Navigator.DefaultPanExtent = Extent?.Copy();
+        Navigator.DefaultZoomBounds = GetMinMaxResolution(Navigator.Resolutions);
+        Navigator.DefaultPanBounds = Extent?.Copy();
         OnPropertyChanged(nameof(Layers));
     }
 

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -310,7 +310,7 @@ public class Map : INotifyPropertyChanged, IDisposable
         DataChanged?.Invoke(sender, e);
     }
 
-    public Action<Navigator> Home { get; set; } = n => n.ZoomToPanExtent();
+    public Action<Navigator> Home { get; set; } = n => n.ZoomToPanBounds();
 
     public IEnumerable<IWidget> GetWidgetsOfMapAndLayers()
     {

--- a/Mapsui/Navigator.cs
+++ b/Mapsui/Navigator.cs
@@ -15,7 +15,6 @@ public class Navigator
 {
     private Viewport _viewport = new(0, 0, 1, 0, 0, 0);
     private IEnumerable<AnimationEntry<Viewport>> _animations = Enumerable.Empty<AnimationEntry<Viewport>>();
-    private IReadOnlyList<double>? _resolutions;
     
     /// <summary>
     /// Called when a data refresh is needed. This directly after a non-animated viewport change
@@ -25,26 +24,32 @@ public class Navigator
     public event PropertyChangedEventHandler? ViewportChanged;
 
     /// <summary>
-    /// Sets the extent used to restrict panning. Exactly how this extent affects panning
+    /// The bounds to restrict panning. Exactly how these bounds affects panning
     /// depends on the implementation of the IViewportLimiter.
     /// </summary>
-    public MRect? PanBounds
-    {
-        get => OverridePanBounds ?? DefaultPanBounds;
-    }
+    public MRect? PanBounds => OverridePanBounds ?? DefaultPanBounds;
 
     /// <summary>
-    /// A pair of the most extreme resolutions (smallest and biggest). How these extremes affect zooming
-    /// depends on the implementation of the IViewportLimiter.
+    /// The bounds of zooming, i.e. the smallest and biggest resolutions. 
+    /// How these bounds affect zooming depends on the implementation of the 
+    /// IViewportLimiter.
     /// </summary>
-    public MMinMax? ZoomBounds
-    {
-        get => OverrideZoomBounds ?? DefaultZoomBounds;
-    }
+    public MMinMax? ZoomBounds => OverrideZoomBounds ?? DefaultZoomBounds;
 
+    /// <summary>
+    /// Overrides the default zoom bounds which are derived from the Map resolutions.
+    /// </summary>
     public MMinMax? OverrideZoomBounds { get; set; }
-
+    
+    /// <summary>
+    /// Overrides the default pan bounds which come from the Map extent.
+    /// </summary>
     public MRect? OverridePanBounds { get; set; }
+
+    /// <summary>
+    /// Overrides the default resolutions which are derived from the Map.Layers resolutions.
+    /// </summary>
+    public IReadOnlyList<double>? OverrideResolutions { get; set; }
 
     public IViewportLimiter Limiter { get; set; } = new ViewportLimiter();
 
@@ -67,10 +72,7 @@ public class Navigator
     /// background layers with different resolutions. Also note that when pinch zooming these resolutions 
     /// are not used.
     /// </summary>
-    public IReadOnlyList<double> Resolutions
-    {
-        get => _resolutions ?? DefaultResolutions;
-    }
+    public IReadOnlyList<double> Resolutions => OverrideResolutions ?? DefaultResolutions;
 
     public MouseWheelAnimation MouseWheelAnimation { get; } = new();
 
@@ -119,7 +121,7 @@ public class Navigator
     /// <param name="boxFit">Scale method to use to determine resolution</param>
     /// <param name="duration">Duration for animation in milliseconds.</param>
     /// <param name="easing">The type of easing function used to transform from begin tot end state</param>
-    public void ZoomToPanExtent(MBoxFit boxFit = MBoxFit.Fill, long duration = -1, Easing? easing = default)
+    public void ZoomToPanBounds(MBoxFit boxFit = MBoxFit.Fill, long duration = -1, Easing? easing = default)
     {
         if (!Viewport.HasSize()) return;
         if (PanBounds is null)

--- a/Samples/Mapsui.Samples.Common/Maps/Navigation/KeepCenterInMapSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Navigation/KeepCenterInMapSample.cs
@@ -23,8 +23,8 @@ public class KeepCenterInMapSample : ISample
 
         var extent = GetLimitsOfMadagaskar();
 
-        map.Navigator.PanExtent = extent;
-        map.Navigator.ZoomExtremes = new MMinMax(0.15, 2500);
+        map.Navigator.OverridePanBounds = extent;
+        map.Navigator.OverrideZoomBounds = new MMinMax(0.15, 2500);
         map.Home = n => n.ZoomToBox(extent);
         return Task.FromResult(map);
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Navigation/KeepWithinExtentSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Navigation/KeepWithinExtentSample.cs
@@ -17,7 +17,7 @@ public class KeepWithinExtentSample : ISample
 
         var panLimits = GetLimitsOfMadagaskar();
         map.Navigator.Limiter = new ViewportLimiterKeepWithinExtent();
-        map.Navigator.PanExtent = panLimits;
+        map.Navigator.OverridePanBounds = panLimits;
         map.Home = n => n.ZoomToBox(panLimits);
         return Task.FromResult(map);
     }

--- a/Tests/Mapsui.Tests.Common/Maps/LineSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/LineSample.cs
@@ -21,7 +21,7 @@ public class LineSample : ISample
         var map = new Map
         {
             BackColor = Color.FromString("WhiteSmoke"),
-            Home = n => n.ZoomToPanExtent(MBoxFit.Fit)
+            Home = n => n.ZoomToPanBounds(MBoxFit.Fit)
         };
 
         map.Layers.Add(CreateLayer());

--- a/Tests/Mapsui.Tests.Common/Maps/PolygonSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/PolygonSample.cs
@@ -30,7 +30,7 @@ public class PolygonTestSample : ISample
         var map = new Map
         {
             BackColor = Color.FromString("WhiteSmoke"),
-            Home = n => n.ZoomToPanExtent(MBoxFit.Fit)
+            Home = n => n.ZoomToPanBounds(MBoxFit.Fit)
         };
 
         map.Layers.Add(layer);

--- a/Tests/Mapsui.Tests.Common/Maps/ProjectionSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/ProjectionSample.cs
@@ -35,7 +35,7 @@ public class ProjectionSample : ISample
         };
         map.Layers.Add(geometryLayer);
         map.Layers.Add(CreateCenterOfAmsterdamLayer());
-        map.Home = n => n.ZoomToPanExtent(MBoxFit.Fit);
+        map.Home = n => n.ZoomToPanBounds(MBoxFit.Fit);
         return map;
     }
 

--- a/Tests/Mapsui.Tests.Common/Maps/TilesSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/TilesSample.cs
@@ -20,7 +20,7 @@ public class TilesSample : ISample
         var map = new Map
         {
             BackColor = Color.FromString("WhiteSmoke"),
-            Home = n => n.ZoomToPanExtent()
+            Home = n => n.ZoomToPanBounds()
         };
 
         map.Layers.Add(layer);


### PR DESCRIPTION
@inforithmics I implemented the 'override property' solution you suggested in your previous MR. I also renamed PanExtent to PanBounds and ZoomExtremes to ZoomBounds, which seems a bit better. Also renamed the ZoomToPanBounds method accourdingly.

