### PR TITLE
Fix MRect intersect to return false when touching

### DIFF
--- a/Mapsui/MRect.cs
+++ b/Mapsui/MRect.cs
@@ -120,10 +120,10 @@ public class MRect
     {
         if (rect is null) return false;
 
-        if (rect.Max.X < Min.X) return false;
-        if (rect.Max.Y < Min.Y) return false;
-        if (rect.Min.X > Max.X) return false;
-        if (rect.Min.Y > Max.Y) return false;
+        if (rect.Max.X <= Min.X) return false;
+        if (rect.Max.Y <= Min.Y) return false;
+        if (rect.Min.X >= Max.X) return false;
+        if (rect.Min.Y >= Max.Y) return false;
 
         return true;
     }

--- a/Tests/Mapsui.Tests/MRectTests.cs
+++ b/Tests/Mapsui.Tests/MRectTests.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+
+namespace Mapsui.Tests;
+
+[TestFixture]
+public class MRectTests
+{
+    [TestCase(2, 2, 8, 8, true)]
+    [TestCase(5, 5, 15, 15, true)]
+    [TestCase(-5, -5, 5, 5, true)]
+    [TestCase(5, -5, 15, 5, true)]
+    [TestCase(-5, 5, 5, 15, true)]
+    [TestCase(0, -10, 10, 0, false)]
+    [TestCase(0, 10, 10, 20, false)]
+    [TestCase(-10, 0, 0, 10, false)]
+    [TestCase(10, 0, 20, 10, false)]
+    public void IntersectsTest(
+        double minX, double minY, double maxX, double maxY,
+        bool intersect)
+    {
+        // Arrange
+        var rect1 = new MRect(0, 0, 10, 10);
+        var rect2 = new MRect(minX, minY, maxX, maxY);
+
+        // Act
+        var result = rect1.Intersects(rect2);
+
+        // Assert
+        Assert.AreEqual(intersect, result);
+    }
+}


### PR DESCRIPTION
This came about because of #1643. The fix might not make a big difference. If two rects touch the Intersects now returns false.