### PR TITLE
Use RotationLock in KeepWithinExtentSample

### DIFF
--- a/Mapsui/Limiting/ViewportLimiterKeepWithinExtent.cs
+++ b/Mapsui/Limiting/ViewportLimiterKeepWithinExtent.cs
@@ -13,6 +13,10 @@ public class ViewportLimiterKeepWithinExtent : IViewportLimiter
 {
     public Viewport Limit(Viewport viewport, MRect? panBounds, MMinMax? zoomBounds)
     {
+        if (viewport.IsRotated())
+        {
+            Logger.Log(LogLevel.Warning, "ViewportLimiterKeepWithinExtent does not support rotation.");
+        }
         return LimitExtent(LimitResolution(viewport, zoomBounds), panBounds, zoomBounds);
     }
 
@@ -64,6 +68,7 @@ public class ViewportLimiterKeepWithinExtent : IViewportLimiter
 
     private static double CalculateResolutionAtWhichMapFillsViewport(double screenWidth, double screenHeight, MRect panBounds)
     {
+        // This method does not take rotation into account. This is possible and could be implemented at some point.
         return Math.Min(panBounds.Width / screenWidth, panBounds.Height / screenHeight);
     }
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Navigation/KeepWithinExtentSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Navigation/KeepWithinExtentSample.cs
@@ -18,6 +18,7 @@ public class KeepWithinExtentSample : ISample
         var panBounds = GetLimitsOfMadagaskar();
         map.Layers.Add(KeepCenterInMapSample.CreatePanBoundsLayer(panBounds));
         map.Navigator.Limiter = new ViewportLimiterKeepWithinExtent();
+        map.Navigator.RotationLock = true;
         map.Navigator.OverridePanBounds = panBounds;
         map.Home = n => n.ZoomToBox(panBounds);
         return Task.FromResult(map);


### PR DESCRIPTION
ViewportLimiterKeepWithinExtent does not take into account rotation when calculation to top zoom level. It just needs to be implemented. This 'fix' disables rotation and logs a warning if it is used in combination when zooming.