### PR TITLE
Fix clipping while rotated

### DIFF
--- a/Mapsui.Rendering.Skia/Functions/ClippingFunctions.cs
+++ b/Mapsui.Rendering.Skia/Functions/ClippingFunctions.cs
@@ -21,7 +21,7 @@ public static class ClippingFunctions
     {
         var output = WorldToScreen(viewport, points);
 
-        // Do this for the 4 edges (left, top, right, bottom) of clipping rectangle
+         // Do this for the 4 edges (left, top, right, bottom) of clipping rectangle
         for (var j = 0; j < 4; j++)
         {
             // If there aren't any points to reduce
@@ -89,31 +89,9 @@ public static class ClippingFunctions
         if (points == null)
             return result;
 
-        var screenCenterX = viewport.Width * 0.5;
-        var screenCenterY = viewport.Height * 0.5;
-        var centerX = viewport.CenterX;
-        var centerY = viewport.CenterY;
-        var resolution = 1.0 / viewport.Resolution;
-        var rotation = viewport.Rotation / 180f * Math.PI;
-        var sin = Math.Sin(rotation);
-        var cos = Math.Cos(rotation);
-
         foreach (var point in points)
         {
-            var screenX = (point.X - centerX) * resolution;
-            var screenY = (centerY - point.Y) * resolution;
-
-            if (viewport.IsRotated())
-            {
-                var newX = screenX * cos - screenY * sin;
-                var newY = screenX * sin + screenY * cos;
-                screenX = newX;
-                screenY = newY;
-            }
-
-            screenX += screenCenterX;
-            screenY += screenCenterY;
-
+            var (screenX, screenY) = viewport.WorldToScreenXY(point.X, point.Y);
             result.Add(new SKPoint((float)screenX, (float)screenY));
         }
 

--- a/Mapsui/Extensions/ViewportExtensions.cs
+++ b/Mapsui/Extensions/ViewportExtensions.cs
@@ -12,12 +12,22 @@ public static class ViewportExtensions
     public static bool HasSize(this Viewport viewport) =>
         viewport.Width > 0 && viewport.Height > 0;
 
-    /// <summary> World To Screen Translation of a Rect </summary>
-    /// <param name="viewport">view Port</param>
-    /// <param name="rect">rect</param>
+    /// <summary>Transforms the MRect from world coordinates to screen coordinates. Note, that
+    /// an MRect always represents and unrotated box. If the Viewport is rotated this will result
+    /// in an unrotated box that encompasses the rotated transformation.</summary>
+    /// <param name="viewport">Viewport</param>
+    /// <param name="rect">The MRect to transform</param>
     /// <returns>Transformed rect</returns>
     public static MRect WorldToScreen(this Viewport viewport, MRect rect)
     {
+        if (!viewport.IsRotated()) // Checking on IsRotated for performance reasons
+        {
+            var min = viewport.WorldToScreen(rect.Min);
+            var max = viewport.WorldToScreen(rect.Max);
+            return new MRect(min.X, min.Y, max.X, max.Y);
+        }
+
+        // In case of the rotated viewport the 
         var screenPoints = new List<MPoint>
         {
             viewport.WorldToScreen(rect.BottomLeft),

--- a/Mapsui/Extensions/ViewportExtensions.cs
+++ b/Mapsui/Extensions/ViewportExtensions.cs
@@ -27,7 +27,11 @@ public static class ViewportExtensions
             return new MRect(min.X, min.Y, max.X, max.Y);
         }
 
-        // In case of the rotated viewport the 
+        // In case of the rotated viewport all four coordinates
+        // are transformed and the min and max x/y of these are
+        // taken to form the new box. In this case the result is
+        // not a real transformation because an MRect can not be
+        // rotated.
         var screenPoints = new List<MPoint>
         {
             viewport.WorldToScreen(rect.BottomLeft),

--- a/Mapsui/Extensions/ViewportExtensions.cs
+++ b/Mapsui/Extensions/ViewportExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using Mapsui.Utilities;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Mapsui.Extensions;
 
@@ -16,9 +18,20 @@ public static class ViewportExtensions
     /// <returns>Transformed rect</returns>
     public static MRect WorldToScreen(this Viewport viewport, MRect rect)
     {
-        var min = viewport.WorldToScreen(rect.Min);
-        var max = viewport.WorldToScreen(rect.Max);
-        return new MRect(min.X, min.Y, max.X, max.Y);
+        var screenPoints = new List<MPoint>
+        {
+            viewport.WorldToScreen(rect.BottomLeft),
+            viewport.WorldToScreen(rect.BottomRight),
+            viewport.WorldToScreen(rect.TopRight),
+            viewport.WorldToScreen(rect.TopLeft)
+        };
+
+        var minx = screenPoints.Select(p => p.X).Min();
+        var miny = screenPoints.Select(p => p.Y).Min();
+        var maxx = screenPoints.Select(p => p.X).Max();
+        var maxy = screenPoints.Select(p => p.Y).Max();
+
+        return new MRect(minx, miny, maxx, maxy).Grow(-50);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #1958.

MRect WorldToScreen did not take into account rotation. Since the MRect does not have individual coordinates for the four corners but just has min/max x/y values it can not be rotated. In case of rotation the encompassing rectangle of the rotated rectangle is returned.

With this fix the clipping edges are not visible. So the clip rect is not too small. Yet the clip rect could also be too big. In order to test this I shrunk the clip rect a bit after the transformation and then it showed the clip edges inside the viewport as expected.

![image](https://user-images.githubusercontent.com/963462/232526652-7808b240-1b0c-4e9d-a221-9816fca349f1.png)


Notes:
- Perhaps WorldToScreen(MRect) should not be an extension method, or perhaps it should have a different name. What is does is different to the other WorldToScreen methods.

