### PR TITLE
Upgrade Microsoft.Net.Compilers.Toolset to 4.6.0

### DIFF
--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -18,7 +18,14 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        fetch-depth: 0      
+        fetch-depth: 0 
+    # .Net 7 update     
+    - name: Setup .NET 7 SDK
+      uses: actions/setup-dotnet@v3
+      with:
+         dotnet-version: |
+           7.0.x
+         include-prerelease: false
     - name: Run DocFx
       # Use a .cmd so this script can be run locally for testing
       run: docfx\build-site.cmd      

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -23,6 +23,14 @@ jobs:
 
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
+
+    # .Net 7 update     
+    - name: Setup .NET 7 SDK
+      uses: actions/setup-dotnet@v3
+      with:
+         dotnet-version: |
+           7.0.x
+         include-prerelease: false
       
     - name: Setup msbuild
       uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,6 +27,13 @@ jobs:
       uses: NuGet/setup-nuget@v1.1.1      
       with:
         nuget-version: latest    
+    # .Net 7 update     
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v3
+      with:
+         dotnet-version: |
+           7.0.x
+         include-prerelease: false
     - name: install android wasm-tools wasm-tools-net6
       run: dotnet workload install android wasm-tools wasm-tools-net6    
     - name: Restore dependencies Mapsui.Linux
@@ -87,6 +94,13 @@ jobs:
       uses: NuGet/setup-nuget@v1.1.1      
       with:
         nuget-version: latest
+    # .Net 7 update     
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v3
+      with:
+         dotnet-version: |
+           7.0.x
+         include-prerelease: false
     - name: Setup Xcode version 14.2
       uses: maxim-lobanov/setup-xcode@v1.5.1
       with:
@@ -145,6 +159,13 @@ jobs:
       with:
          dotnet-version: |
            6.0.x
+         include-prerelease: false
+    # .Net 7 update     
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v3
+      with:
+         dotnet-version: |
+           7.0.x
          include-prerelease: false
     - name: install maui macos android ios maccatalyst wasm-tools wasm-tools-net6
       run: dotnet workload install maui macos android ios maccatalyst wasm-tools wasm-tools-net6
@@ -256,13 +277,13 @@ jobs:
         key: ${{ runner.os }}-nuget13-${{ hashFiles('Directory.Packages.props') }}
         restore-keys: |
             ${{ runner.os }}-nuget13-
-    # .Net 7 already installed on Github Actions      
-    #- name: Setup .NET Core SDK
-    #  uses: actions/setup-dotnet@v3
-    #  with:
-    #     dotnet-version: |
-    #       7.0.100
-    #     include-prerelease: false
+    # .Net 7 update     
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v3
+      with:
+         dotnet-version: |
+           7.0.x
+         include-prerelease: false
     - name: Setup NuGet.exe for use with actions
       uses: NuGet/setup-nuget@v1.1.1
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         nuget-version: latest    
     # .Net 7 update     
-    - name: Setup .NET Core SDK
+    - name: Setup .NET 7 SDK
       uses: actions/setup-dotnet@v3
       with:
          dotnet-version: |
@@ -95,7 +95,7 @@ jobs:
       with:
         nuget-version: latest
     # .Net 7 update     
-    - name: Setup .NET Core SDK
+    - name: Setup .NET 7 SDK
       uses: actions/setup-dotnet@v3
       with:
          dotnet-version: |
@@ -154,14 +154,14 @@ jobs:
       uses: maxim-lobanov/setup-xcode@v1.5.1
       with:
         xcode-version: '14.3' 
-    - name: Setup .NET Core 6 SDK
+    - name: Setup .NET 6 SDK
       uses: actions/setup-dotnet@v3
       with:
          dotnet-version: |
            6.0.x
          include-prerelease: false
     # .Net 7 update     
-    - name: Setup .NET Core SDK
+    - name: Setup .NET 7 SDK
       uses: actions/setup-dotnet@v3
       with:
          dotnet-version: |
@@ -278,7 +278,7 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-nuget13-
     # .Net 7 update     
-    - name: Setup .NET Core SDK
+    - name: Setup .NET 7 SDK
       uses: actions/setup-dotnet@v3
       with:
          dotnet-version: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,8 @@
     <PackageTags>map maps mapping geo gis osm</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <IsPackable>false</IsPackable> <!--Default to not packable and override in projects that do need to be packed.-->
+    <!--Disable Run Api Compat Task causes Build failure on github actions with visual studio 2022 17.5 and .net Compilers Toolset 4.6-->
+    <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>
 
 	<!--Package Icon Include -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,7 +54,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="[16.11.0,17.0.0)" />
-    <PackageVersion Include="Microsoft.DotNet.ApiCompat.Task" Version="[7.0.302,8.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="[1.0.4,2.0.0.0)" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="[4.6.0,5.0.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Eto.SkiaDraw" Version="[0.2.0,0.3.0)" />
     <PackageVersion Include="HarfBuzzSharp" Version="[2.8.2.3,3.0.0.0)" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="[2.8.2.3,3.0.0.0)" />
-    <PackageVersion Include="IDisposableAnalyzers" Version="[4.0.2,5.0.0)" />
+    <PackageVersion Include="IDisposableAnalyzers" Version="[4.0.6,5.0.0)" />
     <PackageVersion Include="Mapsui.Android" Version="4.0.0-beta.8" />
     <PackageVersion Include="Mapsui.ArcGIS" Version="4.0.0-beta.8" />
     <PackageVersion Include="Mapsui.Avalonia" Version="4.0.0-beta.8" />
@@ -60,10 +60,10 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[16.9.4,17.0.0)" />   
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="[6.2.14,7.0.0)" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="[2.6.2,3.0.0)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="[17.2.32,18.0.0)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="[17.6.40,18.0.0)" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="[0.1.588-beta,1.0.0)" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="[2.0.0,3.0.0)" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="[1.2.230217.4,2.0.0)" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="[1.3.230502000,2.0.0)" />
     <PackageVersion Include="NeoSmart.AsyncLock" Version="[3.2.1,4.0.0)" />
     <PackageVersion Include="NetTopologySuite" Version="[2.5.0,3.0.0)" />
     <PackageVersion Include="NetTopologySuite.IO.GeoJSON4STJ" Version="[3.0.0,4.0.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,7 +56,7 @@
     <PackageVersion Include="Microsoft.CodeCoverage" Version="[16.11.0,17.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="[1.0.4,2.0.0.0)" />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="[4.5.0,5.0.0)" />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="[4.6.0,5.0.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[16.9.4,17.0.0)" />   
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="[6.2.14,7.0.0)" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="[2.6.2,3.0.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,7 +54,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="[16.11.0,17.0.0)" />
-    <PackageVersion Include="Microsoft.DotNet.ApiCompat.Task" Version="[7.0.302,8.0.0)" />
+    <PackageVersion Include="Microsoft.DotNet.ApiCompat.Task" Version="[8.0.100-preview.4.23260.11,9.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="[1.0.4,2.0.0.0)" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="[4.6.0,5.0.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,6 +54,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="[16.11.0,17.0.0)" />
+    <PackageVersion Include="Microsoft.DotNet.ApiCompat.Task" Version="[7.0.302,8.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="[1.0.4,2.0.0.0)" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="[4.6.0,5.0.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,7 +54,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="[16.11.0,17.0.0)" />
-    <PackageVersion Include="Microsoft.DotNet.ApiCompat.Task" Version="[8.0.100-preview.4.23260.11,9.0.0)" />
+    <PackageVersion Include="Microsoft.DotNet.ApiCompat.Task" Version="[7.0.302,8.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="[1.0.4,2.0.0.0)" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="[4.6.0,5.0.0)" />

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -26,6 +26,7 @@
 	  <PackageReference Include="Microsoft.WindowsAppSDK" GeneratePathProperty="true" />
 	  <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
+    <PackageReference Include="Microsoft.DotNet.ApiCompat.Task" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -13,6 +13,7 @@
 		<IsPackable>true</IsPackable>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <!--Disable Run Api Compat Task causes Build failure on github actions with visual studio 2022 17.5 and .net Compilers Toolset 4.6-->
     <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>	
 

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -26,10 +26,7 @@
 	  <PackageReference Include="Microsoft.WindowsAppSDK" GeneratePathProperty="true" />
 	  <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
-    <PackageReference Include="Microsoft.DotNet.ApiCompat.Task" >
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.DotNet.ApiCompat.Task" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -13,7 +13,7 @@
 		<IsPackable>true</IsPackable>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
-    <EnableApiCompat>false</EnableApiCompat>
+    <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>	
 
 	<!-- Workaround for https://github.com/microsoft/WindowsAppSDK/issues/1217 -->

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -26,7 +26,6 @@
 	  <PackageReference Include="Microsoft.WindowsAppSDK" GeneratePathProperty="true" />
 	  <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
-    <PackageReference Include="Microsoft.DotNet.ApiCompat.Task" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -16,15 +16,9 @@
     <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>	
 
-	<!-- Workaround for https://github.com/microsoft/WindowsAppSDK/issues/1217 -->
-	<Target Name="FixBinPlaceBootstrapDll" BeforeTargets="BinPlaceBootstrapDll">
-		<PropertyGroup>
-			<_WindowsAppSDKFoundationPlatform>x86</_WindowsAppSDKFoundationPlatform>
-		</PropertyGroup>
-	</Target>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.WindowsAppSDK" GeneratePathProperty="true" />
+	  <PackageReference Include="Microsoft.WindowsAppSDK" />
 	  <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
   </ItemGroup>
@@ -35,13 +29,6 @@
     <ProjectReference Include="..\Mapsui\Mapsui.csproj" />
   </ItemGroup>
 
-	<!-- Required - WinUI can't deploy in a multi-targeting environment -->
-	<Target Name="FixReferenceCopyLocalPaths" BeforeTargets="ResolvePackageAssets">
-	  <ItemGroup>
-		<ReferenceCopyLocalPaths Remove="$(PkgMicrosoft_WindowsAppSDK)\build\..\runtimes\lib\native\AnyCPU\Microsoft.WindowsAppRuntime.Bootstrap.dll" />
-		<ReferenceCopyLocalPaths Remove="$(PkgMicrosoft_WindowsAppSDK)\build\..\runtimes\lib\native\\Microsoft.WindowsAppRuntime.Bootstrap.dll" />
-	  </ItemGroup>
-	</Target>
 
   <Import Project="..\Mapsui.UI.Shared\Mapsui.UI.Shared.projitems" Label="Shared" />
 

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -13,6 +13,7 @@
 		<IsPackable>true</IsPackable>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <EnableApiCompat>false</EnableApiCompat>
   </PropertyGroup>	
 
 	<!-- Workaround for https://github.com/microsoft/WindowsAppSDK/issues/1217 -->

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -26,7 +26,10 @@
 	  <PackageReference Include="Microsoft.WindowsAppSDK" GeneratePathProperty="true" />
 	  <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
-    <PackageReference Include="Microsoft.DotNet.ApiCompat.Task" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.DotNet.ApiCompat.Task" >
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -13,8 +13,6 @@
 		<IsPackable>true</IsPackable>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
-    <!--Disable Run Api Compat Task causes Build failure on github actions with visual studio 2022 17.5 and .net Compilers Toolset 4.6-->
-    <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>	
 
   <ItemGroup>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -16,7 +16,6 @@
     <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>	
 
-
   <ItemGroup>
 	  <PackageReference Include="Microsoft.WindowsAppSDK" />
 	  <PackageReference Include="Microsoft.Graphics.Win2D" />
@@ -28,7 +27,6 @@
     <ProjectReference Include="..\Mapsui.Tiling\Mapsui.Tiling.csproj" />
     <ProjectReference Include="..\Mapsui\Mapsui.csproj" />
   </ItemGroup>
-
 
   <Import Project="..\Mapsui.UI.Shared\Mapsui.UI.Shared.projitems" Label="Shared" />
 

--- a/Mapsui/Providers/Wms/Client.cs
+++ b/Mapsui/Providers/Wms/Client.cs
@@ -265,7 +265,12 @@ public class Client
                 throw new Exception($"Unexpected response code: {response.StatusCode}");
             }
 
-            result = (await response.Content.ReadAsStreamAsync()).ToBytes();
+#if NETSTANDARD2_0
+            using var readAsStreamAsync = await response.Content.ReadAsStreamAsync();
+#else
+            await using var readAsStreamAsync = await response.Content.ReadAsStreamAsync();
+#endif
+            result = readAsStreamAsync.ToBytes();
             _persistentCache?.Add(url, result);
         }
 

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/MainWindow.xaml
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/MainWindow.xaml
@@ -12,7 +12,7 @@
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Background="Gray">
             <winui:MapControl x:Name="MapControl" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" />
-            <Border BorderBrush="White" Opacity="0.65" Background="White" BorderThickness="6" MinWidth="140"
+            <Border BorderBrush="White" Opacity="0.65" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" BorderThickness="6" MinWidth="140"
                     MinHeight="30" HorizontalAlignment="Left">
                 <RelativePanel VerticalAlignment="Stretch" >
                     <ComboBox Name="CategoryComboBox" Margin="0,0, 0, 10">

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "version": "7.0.100",
+    "version": "7.0.302",
     "rollForward": "latestMajor"
   },
   "tools": {
-	"allowPrerelease": false,
-    "dotnet": "7.0.100",
+    "allowPrerelease": false,
+    "dotnet": "7.0.302",
     "rollForward": "latestMajor"
   }  
 }


### PR DESCRIPTION
After upgrading my Visual Studio yesterday to the latest I got this error:
```console
Severity	Code	Description	Project	File	Line	Suppression State
Error	CS9057	The analyzer assembly 'C:\Program Files\dotnet\sdk\7.0.302\Sdks\Microsoft.NET.Sdk\codestyle\cs\Microsoft.CodeAnalysis.CodeStyle.dll' references version '4.6.0.0' of the compiler, which is newer than the currently running version '4.5.0.0'.	Mapsui (netstandard2.0)		
```
The upgrade fixed it.
