### PR TITLE
CoordinateExtensions.ToLinearRing: remove exception

### DIFF
--- a/Mapsui.Nts/Extensions/CoordinateExtensions.cs
+++ b/Mapsui.Nts/Extensions/CoordinateExtensions.cs
@@ -32,7 +32,7 @@ public static class CoordinateExtensions
             list.Add(list[0].Copy()); // LineString needs at least two coordinates
         if (list.Count == 2)
             list.Add(list[0].Copy()); // LinearRing needs at least three coordinates
-        if (!list.First().Equals2D(list.Last()))
+        if (list.Count > 2 && !list.First().Equals2D(list.Last()))
             list.Add(list[0].Copy()); // LinearRing needs to be 'closed' (first should equal last)
         return new LinearRing(list.ToArray());
     }

--- a/Mapsui.Nts/Extensions/CoordinateExtensions.cs
+++ b/Mapsui.Nts/Extensions/CoordinateExtensions.cs
@@ -27,9 +27,6 @@ public static class CoordinateExtensions
 
     public static LinearRing ToLinearRing(this IEnumerable<Coordinate> coordinates)
     {
-        if (coordinates.Count() == 0)
-            throw new Exception("coordinates can not be length 0");
-
         var list = coordinates.ToList(); // Not using ToList could be more performant
         if (list.Count == 1)
             list.Add(list[0].Copy()); // LineString needs at least two coordinates


### PR DESCRIPTION
This PR is analogous to #1521 and should fix https://github.com/Mapsui/Mapsui/issues/1520#issuecomment-1564929374.