### PR TITLE
Fixing the Build Documentation action. (Need to create the website\samples directory first bevore copying data)

### DIFF
--- a/Scripts/BuildSamplesWebsite.ps1
+++ b/Scripts/BuildSamplesWebsite.ps1
@@ -6,10 +6,10 @@ dotnet publish -c Release Samples\Mapsui.Samples.Blazor\Mapsui.Samples.Blazor.cs
 # no jekill so that everything gets deployed
 New-Item -ItemType File -Path "release/wwwroot/.nojekyll" -Force
 # fix 404 errors
-cp release/wwwroot/index.html release/wwwroot/404.html
+cp release/wwwroot/index.html release/wwwroot/404.html -Force
 # create samples directory
 New-Item -Path "website\samples" -ItemType Directory -Force
 # copy it to website/samples
-Copy-Item -Path "release/wwwroot/*" -Destination "website/samples" -Recurse
+Copy-Item -Path "release/wwwroot/*" -Destination "website/samples" -Recurse -Force
 
 

--- a/Scripts/BuildSamplesWebsite.ps1
+++ b/Scripts/BuildSamplesWebsite.ps1
@@ -7,6 +7,8 @@ dotnet publish -c Release Samples\Mapsui.Samples.Blazor\Mapsui.Samples.Blazor.cs
 New-Item -ItemType File -Path "release/wwwroot/.nojekyll"
 # fix 404 errors
 cp release/wwwroot/index.html release/wwwroot/404.html
+# create samples directory
+New-Item -Path "website\samples" -ItemType Directory -Force
 # copy it to website/samples
 Copy-Item -Path "release/wwwroot/*" -Destination "website/samples" -Recurse
 

--- a/Scripts/BuildSamplesWebsite.ps1
+++ b/Scripts/BuildSamplesWebsite.ps1
@@ -4,7 +4,7 @@ dotnet publish -c Release Samples\Mapsui.Samples.Blazor\Mapsui.Samples.Blazor.cs
 # change base url
 (Get-Content -Path "release/wwwroot/index.html") -replace '<base href="/" \/>', '<base href="/samples/" />' | Set-Content -Path "release/wwwroot/index.html"
 # no jekill so that everything gets deployed
-New-Item -ItemType File -Path "release/wwwroot/.nojekyll"
+New-Item -ItemType File -Path "release/wwwroot/.nojekyll" -Force
 # fix 404 errors
 cp release/wwwroot/index.html release/wwwroot/404.html
 # create samples directory


### PR DESCRIPTION
According to this I need to create the Directory first then I can copy the data

https://www.roelvanlisdonk.nl/2020/06/30/2020-06-30-learned-today/#:~:text=Copy-Item%20-Path%20%E2%80%9CC%3AFilesAndFolderToBeCopied%2A%E2%80%9D%20-Destination%20%E2%80%9CC%3AMyNonExistingFolder%E2%80%9D%20-Force%20-Recurse%20Some,destination%20folder%20before%20copying%2C%20this%20error%20was%20resolved.