### PR TITLE
MapControl: fix missing TouchEnded events

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -323,11 +323,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
 
                 _flingTracker.RemoveId(e.Id);
 
-                if (_touches.Count == 1)
-                {
-                    e.Handled = OnTouchStart(_touches.Select(t => t.Value.Location).ToList());
-                }
-
                 if (!e.Handled)
                     e.Handled = OnTouchEnd(_touches.Select(t => t.Value.Location).ToList(), releasedTouch.Location);
             }


### PR DESCRIPTION
This is supposed to fix #2017. For discussion see the issue.