### PR TITLE
Target Maui,iOS,Android to .NET 7 because .NET 6 is end of life for M…

### DIFF
--- a/Mapsui.UI.Android/Mapsui.UI.Android.csproj
+++ b/Mapsui.UI.Android/Mapsui.UI.Android.csproj
@@ -4,7 +4,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFramework>net6.0-android31.0</TargetFramework>
+    <TargetFrameworks>net6.0-android31.0;net7.0-android33.0</TargetFrameworks>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>Mapsui.Android</PackageId>

--- a/Mapsui.UI.iOS/Mapsui.UI.iOS.csproj
+++ b/Mapsui.UI.iOS/Mapsui.UI.iOS.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <TargetFramework>net6.0-ios15.4</TargetFramework>
+    <TargetFramework>net6.0-ios15.4;net7.0-ios16.0</TargetFramework>
     <ImplicitUsings>true</ImplicitUsings>
     <PackageId>Mapsui.iOS</PackageId>
     <!--<RuntimeIdentifiers>iossimulator-x64</RuntimeIdentifiers>-->

--- a/Mapsui.iOS.slnf
+++ b/Mapsui.iOS.slnf
@@ -1,0 +1,22 @@
+{
+  "solution": {
+    "path": "Mapsui.sln",
+    "projects": [
+      "Mapsui.ArcGIS\\Mapsui.ArcGIS.csproj",
+      "Mapsui.Extensions\\Mapsui.Extensions.csproj",
+      "Mapsui.Nts\\Mapsui.Nts.csproj",
+      "Mapsui.Rendering.Skia\\Mapsui.Rendering.Skia.csproj",
+      "Mapsui.Tiling\\Mapsui.Tiling.csproj",
+      "Mapsui.UI.Shared\\Mapsui.UI.Shared.shproj",
+      "Mapsui.UI.iOS\\Mapsui.UI.iOS.csproj",
+      "Mapsui\\Mapsui.csproj",
+      "Samples\\Mapsui.Samples.Common\\Mapsui.Samples.Common.csproj",
+      "Samples\\Mapsui.Samples.CustomWidget\\Mapsui.Samples.CustomWidget.csproj",
+      "Samples\\Mapsui.Samples.iOS\\Mapsui.Samples.iOS.csproj",
+      "Tests\\Mapsui.Nts.Tests\\Mapsui.Nts.Tests.csproj",
+      "Tests\\Mapsui.Rendering.Skia.Tests\\Mapsui.Rendering.Skia.Tests.csproj",
+      "Tests\\Mapsui.Tests.Common\\Mapsui.Tests.Common.csproj",
+      "Tests\\Mapsui.Tests\\Mapsui.Tests.csproj"
+    ]
+  }
+}

--- a/Samples/Mapsui.Samples.Droid/Mapsui.Samples.Droid.csproj
+++ b/Samples/Mapsui.Samples.Droid/Mapsui.Samples.Droid.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-android31.0</TargetFramework>
+    <TargetFramework>net7.0-android33.0</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationId>com.companyname.MapsuiSamples</ApplicationId>

--- a/Samples/Mapsui.Samples.Maui.MapView/Mapsui.Samples.Maui.MapView.csproj
+++ b/Samples/Mapsui.Samples.Maui.MapView/Mapsui.Samples.Maui.MapView.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Mapsui.Samples.Maui</RootNamespace>
     <UseMaui>true</UseMaui>

--- a/Samples/Mapsui.Samples.Maui/Mapsui.Samples.Maui.csproj
+++ b/Samples/Mapsui.Samples.Maui/Mapsui.Samples.Maui.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>

--- a/Samples/Mapsui.Samples.iOS/Mapsui.Samples.iOS.csproj
+++ b/Samples/Mapsui.Samples.iOS/Mapsui.Samples.iOS.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net7.0-ios</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>


### PR DESCRIPTION
…aui,Android,iOS Applications (Not Libraries)

The Maui Client End of life is that after a major Release (.NET 6) only 6 Months support is given for this Version.

https://dotnet.microsoft.com/en-us/platform/support/policy/maui