### PR TITLE
MapView: provide read-only access to callouts

### DIFF
--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -700,9 +700,6 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
     private void HandlerTap(object? sender, TappedEventArgs e)
     {
-        // Close all closable Callouts
-        var pins = _pins.ToList();
-
         e.Handled = false;
 
         if (Map != null)

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -238,6 +238,11 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     }
 
     /// <summary>
+    /// Get callouts on map (those that are currently visible).
+    /// </summary>
+    public IReadOnlyList<Callout> GetCallouts() { return _callouts.ToList(); }
+
+    /// <summary>
     /// Single or multiple callouts possible
     /// </summary>
     public bool UniqueCallout

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -60,7 +60,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     private readonly SKPicture _pictZoomOut;
     private readonly SKPicture _pictNorthing;
     private readonly ObservableRangeCollection<Pin> _pins = new ObservableRangeCollection<Pin>();
-    private readonly ObservableRangeCollection<Drawable> _drawable = new ObservableRangeCollection<Drawable>();
+    private readonly ObservableRangeCollection<Drawable> _drawables = new ObservableRangeCollection<Drawable>();
     private readonly ObservableRangeCollection<Callout> _callouts = new ObservableRangeCollection<Callout>();
 
     /// <summary>
@@ -113,7 +113,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         CreateButtons();
 
         _pins.CollectionChanged += HandlerPinsOnCollectionChanged;
-        _drawable.CollectionChanged += HandlerDrawablesOnCollectionChanged;
+        _drawables.CollectionChanged += HandlerDrawablesOnCollectionChanged;
 
         _mapCalloutLayer.ObservableCollection = _callouts;
         _mapCalloutLayer.Style = null;  // We don't want a global style for this layer
@@ -121,7 +121,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         _mapPinLayer.ObservableCollection = _pins;
         _mapPinLayer.Style = null;  // We don't want a global style for this layer
 
-        _mapDrawableLayer.ObservableCollection = _drawable;
+        _mapDrawableLayer.ObservableCollection = _drawables;
         _mapDrawableLayer.Style = null;  // We don't want a global style for this layer
     }
 
@@ -254,7 +254,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     /// <summary>
     /// List of drawables like polyline and polygon
     /// </summary>
-    public IList<Drawable> Drawables => _drawable;
+    public IList<Drawable> Drawables => _drawables;
 
     /// <summary>
     /// Enable rotation with pinch gesture
@@ -642,7 +642,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         // Check for clicked drawables
         else if (e.MapInfo?.Layer == _mapDrawableLayer)
         {
-            var drawables = _drawable.ToList();
+            var drawables = _drawables.ToList();
 
             if (e.MapInfo!.ScreenPosition == null)
                 return;


### PR DESCRIPTION
This PR provides read-only access to the callouts in a MapView.

Unlike for the pins and drawables, we don't want to modify the list of callouts here, but only provide the list of callouts that are currently visible. Normally the callouts are accessed and modified through the corresponding pin, but up to now it was not easily possible to obtain the full list of visible callouts.

Moreover there is some minor cleanup in MapView (second and third commit).