### PR TITLE
Added missing HarfBuzzSharp.NativeAssets.WebAssembly to mapsui.Blazor dependencies

### DIFF
--- a/Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj
+++ b/Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <PackageReference Include="DotNext.Threading" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This still needs the workaround, but at least the Dependencies are correct now