### PR TITLE
Building Xamarin.Forms stuff on MacOS

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -202,8 +202,8 @@ jobs:
     #- name: Mapsui.Samples.Uno.Wasm
     #  run: dotnet build --no-restore --configuration Debug Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
     # Samples Uno WinUI
-    - name: Mapsui.Samples.Uno.WinUI.Mobile
-      run: dotnet build --no-restore --configuration Debug Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Mobile/Mapsui.Samples.Uno.WinUI.Mobile.csproj
+    #- name: Mapsui.Samples.Uno.WinUI.Mobile
+    #  run: dotnet build --no-restore --configuration Debug Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Mobile/Mapsui.Samples.Uno.WinUI.Mobile.csproj
     #- name: Mapsui.Samples.Uno.WinUI.Skia.Gtk
     #  run: dotnet build --no-restore --configuration Debug Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Skia.Gtk/Mapsui.Samples.Uno.WinUI.Skia.Gtk.csproj
     #- name: Mapsui.Samples.Uno.WinUI.Skia.Linux.FrameBuffer

--- a/Mapsui.Mac.slnf
+++ b/Mapsui.Mac.slnf
@@ -30,8 +30,6 @@
       "Samples\\Mapsui.Samples.MapView\\Mapsui.Samples.MapView.shproj",
       "Samples\\Mapsui.Samples.Maui.MapView\\Mapsui.Samples.Maui.MapView.csproj",
       "Samples\\Mapsui.Samples.Maui\\Mapsui.Samples.Maui.csproj",
-      "Samples\\Mapsui.Samples.Uno.WinUI\\Mapsui.Samples.Uno.WinUI.Mobile\\Mapsui.Samples.Uno.WinUI.Mobile.csproj",
-      "Samples\\Mapsui.Samples.Uno.WinUI\\Mapsui.Samples.Uno.WinUI\\Mapsui.Samples.Uno.WinUI.csproj",
       "Samples\\Mapsui.Samples.Uno\\Mapsui.Samples.Uno.Mobile\\Mapsui.Samples.Uno.Mobile.csproj",
       "Samples\\Mapsui.Samples.Uno\\Mapsui.Samples.Uno.Shared\\Mapsui.Samples.Uno.Shared.shproj",
       "Samples\\Mapsui.Samples.iOS\\Mapsui.Samples.iOS.csproj",

--- a/Mapsui.UI.Forms/Mapsui.UI.Forms.csproj
+++ b/Mapsui.UI.Forms/Mapsui.UI.Forms.csproj
@@ -8,6 +8,7 @@
 		<Authors>Dirk Weltz</Authors>
 		<PackageTags>$(PackageTags) xamarin.forms xamarin ios android windows uwp macos cross-platform</PackageTags>
 		<IsPackable>true</IsPackable>
+		<BuildWithMSBuildOnMono>true</BuildWithMSBuildOnMono>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Android/Mapsui.Samples.Forms.Android.csproj
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Android/Mapsui.Samples.Forms.Android.csproj
@@ -16,7 +16,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidUseAapt2>true</AndroidUseAapt2>

--- a/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Android/Properties/AndroidManifest.xml
+++ b/Samples/Mapsui.Samples.Forms/Mapsui.Samples.Forms.Android/Properties/AndroidManifest.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.mapsui.samples.forms">
-    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
-    <application android:label="Mapsui.Samples.Forms.Android" android:theme="@style/MainTheme"></application>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
+	<application android:label="Mapsui.Samples.Forms.Android" android:theme="@style/MainTheme"></application>
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 </manifest>


### PR DESCRIPTION
Building all the Xamarin.Forms stuff in Mapsui was not possible for quite a while with VS for Mac (basically since MAUI arrived). With VS for Mac version 17.6, which was released this week, MS has finally fixed this, see:
* https://learn.microsoft.com/en-us/visualstudio/releases/2022/mac-release-notes
* https://developercommunity.visualstudio.com/t/Build-and-Restore-Errors-when-a-solution/10278382

There is a config parameter that determines that a specific project should be built via msbuild/Mono (instead of dotnet). When adding this parameter (which can be done automatically by VS), Mapsui.UI.Forms builds well again on Mac (as well as Mapsui.Samples.Forms).

I also had to remove some Uno.WinUI stuff from the Mac solution, to make package restoration work again.

In addition, I committed some automatic changes by VS that appear every time I open the Mac solution (and should not hurt).