### PR TITLE
Update Svg.Skia to 1.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <!--This should be enabled because this reduces the number of nuget packages that get donwloded without 
+    <!--This should be enabled because this reduces the number of nuget packages that get donwloded without
     this the several versions of a nuget package are downloaded causing the builds to be slower-->
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
@@ -92,7 +92,7 @@
     <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="[2.88.3,3.0.0)" />
     <PackageVersion Include="sqlite-net-pcl" Version="[1.8.116,2.0.0)" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="[2.1.2,3.0.0)" />
-    <PackageVersion Include="Svg.Skia" Version="[0.6.0-rc1.1,1.0.0)" />
+    <PackageVersion Include="Svg.Skia" Version="[1.0.0,2.0.0)" />
     <PackageVersion Include="System.Drawing.Common" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="System.Linq.Async" Version="[6.0.1,7.0.0)" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="[7.0.0,8.0.0)" />


### PR DESCRIPTION
... in order to finally have a 'stable' version for this dependency. The changes from 0.6.0-rc1.1 to 1.0.0 are minimal AFAICS, so this update should not cause any issues.