### PR TITLE
Fix: Imagelayer invisible and no warning when constructor with name parameter is used

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
@@ -50,6 +50,9 @@ public class VectorStyleRenderer : ISkiaStyleRenderer, IFeatureSize
                             throw new ArgumentException($"Unknown geometry type: {geometryFeature.Geometry?.GetType()}, Layer: {layer.Name}");
                     }
                     break;
+                default: 
+                    Logger.Log(LogLevel.Warning, $"{nameof(VectorStyleRenderer)} can not render feature of type '{feature.GetType()}', Layer: {layer.Name}");
+                    break;
             }
         }
         catch (Exception ex)

--- a/Mapsui/Layers/ImageLayer.cs
+++ b/Mapsui/Layers/ImageLayer.cs
@@ -20,21 +20,6 @@ namespace Mapsui.Layers;
 
 public class ImageLayer : BaseLayer, IAsyncDataFetcher, ILayerDataSource<IProvider>, IDisposable, ILayer
 {
-    public ImageLayer()
-    {
-        Style = new RasterStyle();
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _startFetchTimer?.Dispose();
-        }
-
-        base.Dispose(disposing);
-    }
-
     private class FeatureSets
     {
         public long TimeRequested { get; set; }
@@ -48,6 +33,18 @@ public class ImageLayer : BaseLayer, IAsyncDataFetcher, ILayerDataSource<IProvid
     private readonly Timer? _startFetchTimer;
     private IProvider? _dataSource;
     private readonly int _numberOfFeaturesReturned;
+
+    public ImageLayer()
+    {
+        Style = new RasterStyle();
+    }
+
+    public ImageLayer(string layerName) : this()
+    {
+        Name = layerName;
+        _startFetchTimer = new Timer(StartFetchTimerElapsed, null, Timeout.Infinite, Timeout.Infinite);
+        _numberOfFeaturesReturned = 1;
+    }
 
     /// <summary>
     /// Delay before fetching a new wms image from the server
@@ -67,13 +64,6 @@ public class ImageLayer : BaseLayer, IAsyncDataFetcher, ILayerDataSource<IProvid
             // the Extent is already created on the creation of the Provider.
             Extent = DataSource?.GetExtent();
         }
-    }
-
-    public ImageLayer(string layerName)
-    {
-        Name = layerName;
-        _startFetchTimer = new Timer(StartFetchTimerElapsed, null, Timeout.Infinite, Timeout.Infinite);
-        _numberOfFeaturesReturned = 1;
     }
 
     private void StartFetchTimerElapsed(object? state)
@@ -197,5 +187,15 @@ public class ImageLayer : BaseLayer, IAsyncDataFetcher, ILayerDataSource<IProvid
         {
             cache.Features = new List<RasterFeature>();
         }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _startFetchTimer?.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 }

--- a/Mapsui/Layers/ImageLayer.cs
+++ b/Mapsui/Layers/ImageLayer.cs
@@ -37,13 +37,13 @@ public class ImageLayer : BaseLayer, IAsyncDataFetcher, ILayerDataSource<IProvid
     public ImageLayer()
     {
         Style = new RasterStyle();
+        _startFetchTimer = new Timer(StartFetchTimerElapsed, null, Timeout.Infinite, Timeout.Infinite);
+        _numberOfFeaturesReturned = 1;
     }
 
     public ImageLayer(string layerName) : this()
     {
         Name = layerName;
-        _startFetchTimer = new Timer(StartFetchTimerElapsed, null, Timeout.Infinite, Timeout.Infinite);
-        _numberOfFeaturesReturned = 1;
     }
 
     /// <summary>


### PR DESCRIPTION
Things done:
- Make parameterized constructor call default constructor, which fixes the actual bug.
- Reorder the methods/fields in ImageLayer somewhat. We pay little attention to the order usually but in this case I think it caused the bug because the constructors were not next to each other.
- Add logging in the VectorStyleRenderer if the feature type is unknown. This might cause logging in existing scenarios which are not bugs, but I still think it is better to log. 