### PR TITLE
Fix white lines between tiles when map is rotated

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaStyles/RasterStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/RasterStyleRenderer.cs
@@ -65,10 +65,10 @@ public class RasterStyleRenderer : ISkiaStyleRenderer
                 switch (bitmapInfo.Type)
                 {
                     case BitmapType.Bitmap:
-                        BitmapRenderer.Draw(canvas, bitmapInfo.Bitmap!, RoundToPixel(destination), opacity);
+                        BitmapRenderer.Draw(canvas, bitmapInfo.Bitmap!, destination, opacity);
                         break;
                     case BitmapType.Picture:
-                        PictureRenderer.Draw(canvas, bitmapInfo.Picture!, RoundToPixel(destination), opacity);
+                        PictureRenderer.Draw(canvas, bitmapInfo.Picture!, destination, opacity);
                         break;
                 }
 


### PR DESCRIPTION
This PR removed RoundToPixel when rotated.

RoundToPixel was introduced many years ago. The purpose was to draw the pixels of the tile images on corresponding pixels of the target image, so that there would be no quality loss. There are several situations where this will not work out that way:
- If you are in between resolutions of the tile set, which happens when you are pinch zooming, or zooming to a custom extent.
- If density of the target is not 1 (but with multiples of 1 it might still help improve the quality).
- If the map is rotated, it makes no sense at all (except perhaps when rotated a multiple of 90 degrees).

Also the effectiveness of RoundToPixel was tested long ago, not sure how it works out on modern devices.

Since it does not help when rotated it makes sense to remove it for that case. We already have a check on IsRotated to some specific rendering in that case. So, we can could just remove it there and it will not affect the non-rotated case. I could not reproduce it afterwards.

I expected some failed render regression tests but did not see any when running the tests locally.