### PR TITLE
Limit width of sample button list in MAUI sample

### DIFF
--- a/Samples/Mapsui.Samples.Maui/View/MainPage.cs
+++ b/Samples/Mapsui.Samples.Maui/View/MainPage.cs
@@ -11,6 +11,7 @@ public sealed class MainPage : ContentPage, IDisposable
     readonly CollectionView collectionView;
     readonly Picker categoryPicker;
     readonly MapControl mapControl = new MapControl();
+    const int menuItemWidth = 220;
 
     public MainPage(MainViewModel mainViewModel)
     {
@@ -38,16 +39,18 @@ public sealed class MainPage : ContentPage, IDisposable
             {
                 new ScrollView()
                 {
+                    WidthRequest = menuItemWidth + 40,
                     Content = new VerticalStackLayout()
                     {
+                        WidthRequest = menuItemWidth + 20,
                         Spacing = 20,
                         Children =
                         {
                             categoryPicker,
                             collectionView
-                        }
+                        }                        
                     } 
-                }.Column(0).Padding(20),
+                }.Column(0).Padding(10),
                 mapControl.Column(1)
             }
         };
@@ -57,7 +60,7 @@ public sealed class MainPage : ContentPage, IDisposable
     {
         return new Picker
         {
-            WidthRequest = 220,
+            WidthRequest = menuItemWidth,
             ItemsSource = mainViewModel.Categories
         }
         .Bind(Picker.SelectedItemProperty, nameof(mainViewModel.SelectedCategory))
@@ -83,10 +86,9 @@ public sealed class MainPage : ContentPage, IDisposable
         {
             Padding = 10,
             Margin = new Thickness(2, 2),
+            WidthRequest = menuItemWidth,
             Content = new Label
             {
-                WidthRequest = 200,
-
             }.Bind(Label.TextProperty, nameof(ISample.Name))
         };
     }


### PR DESCRIPTION
This is intended to fix the issue reported here https://github.com/Mapsui/Mapsui/issues/2087#issuecomment-1605939314. I could not test this because I do not run on Mac. I now hard limited the width op the controls. It seems on mac the auto size column takes up so much width because it thinks some of it's children are this wide. By explicitly setting the width I hope to counter that.

I thought about a better solution.
- A flyout menu is supported in MAUI but this only applies to tabbed pages.
- There is a MenuView, but this only works on Windows and Mac.
- What seems a fair option would be to add a toggle button on the top left of the map which could set the width of the sample menu to zero or back to the original size.