### PR TITLE
fix: Widget Touch does not work on Maui/Forms on Touch devices

### DIFF
--- a/Mapsui.UI.Forms/MapControl.cs
+++ b/Mapsui.UI.Forms/MapControl.cs
@@ -306,6 +306,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
             
             if (HandleTouch(e, location))
             {
+                e.Handled = true;
                 return;
             }
 


### PR DESCRIPTION
doing this by Setting the handled to true if touch is handled

Fixes this

https://github.com/Mapsui/Mapsui/issues/2197