### PR TITLE
Explicitly ignore Avalonia samples to build as nugets

### DIFF
--- a/Samples/Avalonia/Directory.Build.props
+++ b/Samples/Avalonia/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <AvaloniaVersion>11.0.0</AvaloniaVersion>
-	<IsPackable>false</IsPackable>
+	<IsPackable>false</IsPackable> <!--Default to not packable and override in projects that do need to be packed.-->
   </PropertyGroup>
 </Project>

--- a/Samples/Avalonia/Directory.Build.props
+++ b/Samples/Avalonia/Directory.Build.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <AvaloniaVersion>11.0.0</AvaloniaVersion>
+	<IsPackable>false</IsPackable>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The test build showed that nuget packages were generated for the Avalonia samples. This should not happen.

The current configuration for packing is that the Directory.Build.props has it set to false and all projects that need to be packed have IsPackable set to true.

For the Avalonia samples this system apparently failed because it has it's own Directory.Build.props. So, this fix also set IsPackage to false in that file.