### PR TITLE
Update BruTile to 5.0.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="BenchmarkDotNet" Version="[0.13.6,1.0.0)" />
     <PackageVersion Include="BitMiracle.LibTiff.NET" Version="[2.4.649,3.0.0)" />
     <PackageVersion Include="BrotliSharpLib" Version="[0.3.3,1.0.0)" />
-    <PackageVersion Include="BruTile" Version="[5.0.5,6.0)" />
-    <PackageVersion Include="BruTile.MbTiles" Version="[5.0.5,6.0)" />
+    <PackageVersion Include="BruTile" Version="[5.0.6,6.0)" />
+    <PackageVersion Include="BruTile.MbTiles" Version="[5.0.6,6.0)" />
     <PackageVersion Include="coverlet.collector" Version="[3.0.2,4.0.0)" />
     <PackageVersion Include="DotSpatial.Projections" Version="[4.0.656,5.0.0)" />
     <PackageVersion Include="CommandLineParser" Version="[2.9.1,3.0.0)" />


### PR DESCRIPTION
BruTile 5.0.5 had an unintended breaking change and has been unlisted.