### PR TITLE
Fix: Callout does not display on pin clicked in Uno.WinUI Wasm

### DIFF
--- a/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
+++ b/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net6.0;net6.0-android;net7.0;net7.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or $([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net6.0-ios;net7.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or $([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net6.0-ios;net6.0-maccatalyst;net7.0-macos;net7.0-ios;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0;net7.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -39,6 +39,13 @@
   <ItemGroup Condition="$(TargetFramework.Contains('windows'))">
     <PackageReference Include="Microsoft.WindowsAppSDK" VersionOverride="[1.3.230502000,2.0.0)"  />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
+  </ItemGroup>
+
+  <!--Harfbuzz Sharp references Workaround for this issue-->
+  <!--https://github.com/mono/SkiaSharp/issues/1725-->
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0' or '$(TargetFramework)'=='net7.0'">
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.Uno/Mapsui.UI.Uno.csproj
+++ b/Mapsui.UI.Uno/Mapsui.UI.Uno.csproj
@@ -7,7 +7,7 @@
 
 	<PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net6.0-android;net7.0;net7.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or $([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net6.0-ios;net7.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or $([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net6.0-ios;net6.0-maccatalyst;net6.0-macos;net7.0-ios;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);uap10.0.19041</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -43,6 +43,13 @@
     	<ProjectReference Include="..\Mapsui.Tiling\Mapsui.Tiling.csproj" />
     	<ProjectReference Include="..\Mapsui\Mapsui.csproj" />
   	</ItemGroup>
+
+  <!--Harfbuzz Sharp references Workaround for this issue-->
+  <!--https://github.com/mono/SkiaSharp/issues/1725-->
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0' or '$(TargetFramework)'=='net7.0'">
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
+  </ItemGroup>
 
 	<ItemGroup>
 		<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Wasm/Mapsui.Samples.Uno.WinUI.Wasm.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Wasm/Mapsui.Samples.Uno.WinUI.Wasm.csproj
@@ -61,7 +61,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.Resizetizer" />
-		<PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="7.0.0" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="7.0.5" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" />
 		<PackageReference Include="Uno.WinUI.WebAssembly" />

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Wasm/Mapsui.Samples.Uno.WinUI.Wasm.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Wasm/Mapsui.Samples.Uno.WinUI.Wasm.csproj
@@ -85,17 +85,7 @@
 		<PackageReference Include="Uno.Extensions.Navigation.WinUI" VersionOverride="2.3.11" />
 		<PackageReference Include="Uno.Extensions.Reactive.WinUI" VersionOverride="2.3.11" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" />
-    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
 	</ItemGroup>
-
-  <!--Harfbuzz Sharp references Workaround for this issue-->
-  <!--https://github.com/mono/SkiaSharp/issues/1725-->
-  <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\2.8.2\*.a" />
-  </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\Mapsui.UI.Uno.WinUI\Mapsui.UI.Uno.WinUI.csproj" />

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
@@ -62,17 +62,7 @@
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
     <PackageReference Include="Uno.Wasm.Bootstrap" VersionOverride="3.3.1" />
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" VersionOverride="3.3.1" />
-    <PackageReference Include="SkiaSharp.Views.Uno" />
-    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
     <PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="6.0.7" />
-  </ItemGroup>
-
-  <!--Harfbuzz Sharp references Workaround for this issue-->
-  <!--https://github.com/mono/SkiaSharp/issues/1725-->
-  <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\2.8.2\*.a" />
   </ItemGroup>
 
   <ItemGroup>    

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" VersionOverride="3.3.1" />
     <PackageReference Include="SkiaSharp.Views.Uno" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="6.0.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="6.0.7" />
   </ItemGroup>
 
   <!--Harfbuzz Sharp references Workaround for this issue-->


### PR DESCRIPTION
Fixes this https://github.com/Mapsui/Mapsui/issues/2234

Things done: 
1. Add all uno targets (added macos and maccatalyst) so that the .Net6.0 and .Net7.0 only target Uno Wasm
2. Added HarfbuzzSharp.NativeAssets.WebAssembly and SkiaSharp.NativeAssets.WebAssembly to the .Net6.0 and .Net7.0 Targets
