### PR TITLE
Fix: the merge of NET8, Uno needs to add NativeAssets. to NET8 Targets

### DIFF
--- a/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
+++ b/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
@@ -43,7 +43,7 @@
 
   <!--Harfbuzz Sharp references Workaround for this issue-->
   <!--https://github.com/mono/SkiaSharp/issues/1725-->
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0' or '$(TargetFramework)'=='net7.0'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0' or '$(TargetFramework)'=='net7.0' or '$(TargetFramework)'=='net8.0'">
     <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
   </ItemGroup>

--- a/Mapsui.UI.Uno/Mapsui.UI.Uno.csproj
+++ b/Mapsui.UI.Uno/Mapsui.UI.Uno.csproj
@@ -54,7 +54,7 @@
 
   <!--Harfbuzz Sharp references Workaround for this issue-->
   <!--https://github.com/mono/SkiaSharp/issues/1725-->
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0' or '$(TargetFramework)'=='net7.0'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0' or '$(TargetFramework)'=='net7.0' or '$(TargetFramework)'=='net8.0'">
     <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
   </ItemGroup>


### PR DESCRIPTION
When I merged main into this I forgot to add NativeAssets.WebAssembly to .NET 8 Uno Targets