### PR TITLE
Fix build by removing net6.0-android build target and bumping Microsoft.Windows.Compatibility to 7.0.5

### DIFF
--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:  
       - master   
+      - develop/4.1
       
 permissions:
   contents: write

--- a/Mapsui.UI.Android/Mapsui.UI.Android.csproj
+++ b/Mapsui.UI.Android/Mapsui.UI.Android.csproj
@@ -4,7 +4,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworks>net6.0-android31.0;net7.0-android33.0</TargetFrameworks>
+    <TargetFrameworks>net7.0-android33.0</TargetFrameworks>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>Mapsui.Android</PackageId>

--- a/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
+++ b/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
@@ -6,7 +6,7 @@
 	-->
 
   <PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0;net6.0-android;net7.0;net7.0-android</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;net7.0;net7.0-android</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or $([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net6.0-ios;net7.0-ios</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0;net7.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/Mapsui.UI.Uno/Mapsui.UI.Uno.csproj
+++ b/Mapsui.UI.Uno/Mapsui.UI.Uno.csproj
@@ -6,7 +6,7 @@
 	-->
 
 	<PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net6.0-android;net7.0;net7.0-android</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net7.0-android</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or $([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net6.0-ios;net7.0-ios</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);uap10.0.19041</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/Mapsui.sln
+++ b/Mapsui.sln
@@ -315,6 +315,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapsui.Samples.Avalonia.Des
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapsui.Samples.Avalonia.iOS", "Samples\Avalonia\Mapsui.Samples.Avalonia.iOS\Mapsui.Samples.Avalonia.iOS.csproj", "{A8808FA9-B3FC-4C13-8C22-22DC2C9A1EA7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHubActions", "GitHubActions", "{FE8C331E-F70C-4BC0-8566-A1FF0A8422A7}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\dotnet-docs.yml = .github\workflows\dotnet-docs.yml
+		.github\workflows\dotnet-release-nugets.yml = .github\workflows\dotnet-release-nugets.yml
+		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Ad-Hoc|AnyCPU = Ad-Hoc|AnyCPU

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Wasm/Mapsui.Samples.Uno.WinUI.Wasm.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Wasm/Mapsui.Samples.Uno.WinUI.Wasm.csproj
@@ -61,7 +61,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.Resizetizer" />
-		<PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="7.0.5" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="6.0.7" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" />
 		<PackageReference Include="Uno.WinUI.WebAssembly" />

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Wasm/Mapsui.Samples.Uno.WinUI.Wasm.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Wasm/Mapsui.Samples.Uno.WinUI.Wasm.csproj
@@ -61,7 +61,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.Resizetizer" />
-		<PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="7.0.0" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="8.0.0" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" />
 		<PackageReference Include="Uno.WinUI.WebAssembly" />

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Wasm/Mapsui.Samples.Uno.WinUI.Wasm.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.Wasm/Mapsui.Samples.Uno.WinUI.Wasm.csproj
@@ -61,7 +61,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.Resizetizer" />
-		<PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="8.0.0" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="7.0.5" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" />
 		<PackageReference Include="Uno.WinUI.WebAssembly" />

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" VersionOverride="3.3.1" />
     <PackageReference Include="SkiaSharp.Views.Uno" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="6.0.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="8.0.0" />
   </ItemGroup>
 
   <!--Harfbuzz Sharp references Workaround for this issue-->

--- a/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
+++ b/Samples/Mapsui.Samples.Uno/Mapsui.Samples.Uno.Wasm/Mapsui.Samples.Uno.Wasm.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" VersionOverride="3.3.1" />
     <PackageReference Include="SkiaSharp.Views.Uno" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="8.0.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" VersionOverride="7.0.5" />
   </ItemGroup>
 
   <!--Harfbuzz Sharp references Workaround for this issue-->


### PR DESCRIPTION
The GitHub build agents have started to fail this week because our builds contain components with vulnerabilities.

The next release will be a patch but we had to remove the net6.0-android build target. So, for those who used this it would not be a patch release 😬