### PR TITLE
Feature/remove upper bound from the System nugets

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,9 +98,8 @@
     <PackageVersion Include="sqlite-net-pcl" Version="[1.8.116,2.0.0)" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="[2.1.6,3.0.0)" />
     <PackageVersion Include="Svg.Skia" Version="[1.0.0.3,2.0.0)" />
-    <PackageVersion Include="System.Drawing.Common" Version="[7.0.0,8.0.0)" />
-    <PackageVersion Include="System.Linq.Async" Version="[6.0.1,7.0.0)" />
-    <PackageVersion Include="System.Text.Encoding.CodePages" Version="[7.0.0,8.0.0)" />
+    <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="7.0.0" />
     <PackageVersion Include="System.Memory" Version="[4.5.5,5.0.0)" />
     <PackageVersion Include="Topten.RichTextKit" Version="[0.4.166,1.0.0)" />
     <PackageVersion Include="Uno.Core" Version="[4.0.1,5.0.0)" />


### PR DESCRIPTION
This is an attempt to remedy this:  https://github.com/Mapsui/Mapsui/issues/2324. But there are likely to be other limiting packages. 

I only looked at the four System.* packages, because it is pretty save there are no breaking changes there.
- System.Drawing.Common - Removed upper bound
- System.Text.Encoding.CodePages - Removed upper bound
- System.Linq.Async - Remove entirely because was not used
- System.Memory - leave, it is a very specific workaround for some issue on iOS. Can be removed in master.

I don't have a general strategy wrt upper bounds yet. Two things to take into account:
- If we test with one version we don't want to allow just any other version
- If it is unlikely to introduce breaking changes we should allow higher major version.

Let's see where the next problem is.

