### PR TITLE
Update svg skia to 1.0.0.7

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -89,7 +89,7 @@
     <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="[2.88.6,3.0.0)" />
     <PackageVersion Include="sqlite-net-pcl" Version="[1.8.116,2.0.0)" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="[2.1.6,3.0.0)" />
-    <PackageVersion Include="Svg.Skia" Version="[1.0.0.3,2.0.0)" />
+    <PackageVersion Include="Svg.Skia" Version="[1.0.0.7,2.0.0)" />
     <PackageVersion Include="System.Linq.Async" Version="[6.0.1,7.0.0)" />
     <PackageVersion Include="System.Memory" Version="[4.5.5,5.0.0)" />
     <PackageVersion Include="Topten.RichTextKit" Version="[0.4.166,1.0.0)" />


### PR DESCRIPTION
Update svg skia to 1.0.0.7 because 1.0.0.6 breaks Mapsui. (There was an incompatible change) And to avoid that someone is using 1.0.0.6 I upgrade the dependency to 1.0.0.7