### PR TITLE
Remove RenderedGeometry and IDisposable from IFeature

### DIFF
--- a/Mapsui.Nts/GeometryFeature.cs
+++ b/Mapsui.Nts/GeometryFeature.cs
@@ -1,12 +1,11 @@
 using System;
-using System.Diagnostics;
 using Mapsui.Layers;
 using Mapsui.Nts.Extensions;
 using NetTopologySuite.Geometries;
 
 namespace Mapsui.Nts;
 
-public class GeometryFeature : BaseFeature, IFeature, IDisposable
+public class GeometryFeature : BaseFeature, IFeature
 {
     private bool _disposed;
 
@@ -36,13 +35,6 @@ public class GeometryFeature : BaseFeature, IFeature, IDisposable
     public Geometry? Geometry { get; set; }
 
     public MRect? Extent => Geometry?.EnvelopeInternal.ToMRect();
-
-    public override void Dispose()
-    {
-        if (_disposed) return;
-        base.Dispose();
-        _disposed = true;
-    }
 
     public void CoordinateVisitor(Action<double, double, CoordinateSetter> visit)
     {

--- a/Mapsui.Nts/Providers/Shapefile/ShapeFile.cs
+++ b/Mapsui.Nts/Providers/Shapefile/ShapeFile.cs
@@ -452,8 +452,7 @@ public class ShapeFile : IProvider, IDisposable, IProviderExtended
     {
         if (FilterDelegate != null) //Apply filtering
         {
-            using var fdr = GetFeature(oid);
-            return fdr?.Geometry;
+            return GetFeature(oid)?.Geometry;
         }
 
         return ReadGeometry(oid);

--- a/Mapsui.UI.MapView/Objects/Callout.cs
+++ b/Mapsui.UI.MapView/Objects/Callout.cs
@@ -15,7 +15,7 @@ using Point = Microsoft.Maui.Graphics.Point;
 
 namespace Mapsui.UI.Maui;
 
-public class Callout : IFeatureProvider, IDisposable, INotifyPropertyChanged
+public class Callout : IFeatureProvider, INotifyPropertyChanged
 {
     private readonly Pin _pin;
 
@@ -600,11 +600,6 @@ public class Callout : IFeatureProvider, IDisposable, INotifyPropertyChanged
     {
         UpdateContent();
         UpdateCalloutStyle();
-    }
-
-    public virtual void Dispose()
-    {
-        Feature.Dispose();
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
@@ -16,7 +16,7 @@ namespace Mapsui.UI.Objects;
 /// A layer to display a symbol for own location
 /// </summary>
 /// <remarks>
-/// There are two different symbols for own loaction: one is used when there isn't a change in position (still),
+/// There are two different symbols for own location: one is used when there isn't a change in position (still),
 /// and one is used, if the position changes (moving).
 /// </remarks>
 public class MyLocationLayer : BaseLayer
@@ -483,16 +483,6 @@ public class MyLocationLayer : BaseLayer
                 _mapView.Refresh();
             }
         }
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _feature.Dispose();
-        }
-
-        base.Dispose(disposing);
     }
 
     private bool InternalUpdateMyLocation(Position newLocation)

--- a/Mapsui.UI.MapView/Objects/Pin.cs
+++ b/Mapsui.UI.MapView/Objects/Pin.cs
@@ -14,7 +14,7 @@ using Color = Microsoft.Maui.Graphics.Color;
 
 namespace Mapsui.UI.Maui;
 
-public class Pin : IFeatureProvider, IDisposable, INotifyPropertyChanged
+public class Pin : IFeatureProvider, INotifyPropertyChanged
 {
     // Cache for used bitmaps
     private static readonly Dictionary<string, int> _bitmapIds = new Dictionary<string, int>();
@@ -57,7 +57,6 @@ public class Pin : IFeatureProvider, IDisposable, INotifyPropertyChanged
                     _mapView?.RemoveCallout(_callout);
                 }
 
-                Feature?.Dispose();
                 Feature = null;
                 _mapView = value;
 
@@ -601,12 +600,6 @@ public class Pin : IFeatureProvider, IDisposable, INotifyPropertyChanged
                 });
             }
         }
-    }
-
-    public virtual void Dispose()
-    {
-        _callout?.Dispose();
-        Feature?.Dispose();
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Mapsui/Features/BaseFeature.cs
+++ b/Mapsui/Features/BaseFeature.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using Mapsui.Styles;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
-using Mapsui.Styles;
 
 namespace Mapsui.Layers;
 
-public abstract class BaseFeature : IDisposable
+public abstract class BaseFeature
 {
     // last used feature id
     private static long _currentFeatureId;
@@ -48,7 +46,6 @@ public abstract class BaseFeature : IDisposable
     }
 
     private readonly Dictionary<string, object?> _dictionary = new();
-    private IDictionary<IStyle, object>? _renderedGeometry;
 
     public ICollection<IStyle> Styles { get; set; } = new Collection<IStyle>();
     public IEnumerable<string> Fields => _dictionary.Keys;
@@ -59,37 +56,9 @@ public abstract class BaseFeature : IDisposable
         set => _dictionary[key] = value;
     }
 
-    public IDictionary<IStyle, object> RenderedGeometry
-    {
-        get => _renderedGeometry ??= new ConcurrentDictionary<IStyle, object>();
-        set => _renderedGeometry = value;
-    }
-
     public void Modified()
     {
         // is modified needs a new id.
         Id = NextId();
-        ClearRenderedGeometry();
-    }
-
-    public virtual void Dispose()
-    {
-        ClearRenderedGeometry();
-    }
-
-    public void ClearRenderedGeometry()
-    {
-        if (_renderedGeometry != null)
-        {
-            var values = _renderedGeometry.Values.ToArray();
-            _renderedGeometry = null;
-            foreach (var value in values)
-            {
-                if (value is IDisposable disposable)
-                {
-                    disposable.Dispose();
-                }
-            }
-        }
     }
 }

--- a/Mapsui/IFeature.cs
+++ b/Mapsui/IFeature.cs
@@ -6,13 +6,12 @@ namespace Mapsui;
 
 public delegate void CoordinateSetter(double x, double y);
 
-public interface IFeature : IDisposable
+public interface IFeature
 {
     ICollection<IStyle> Styles { get; }
     object? this[string key] { get; set; }
     IEnumerable<string> Fields { get; }
     MRect? Extent { get; }
-    public IDictionary<IStyle, object> RenderedGeometry { get; }
     void CoordinateVisitor(Action<double, double, CoordinateSetter> visit);
     long Id => 0;
     void Modified() { } // default implementation

--- a/Mapsui/Layers/MyLocationLayer.cs
+++ b/Mapsui/Layers/MyLocationLayer.cs
@@ -490,16 +490,6 @@ public class MyLocationLayer : BaseLayer, IDisposable
         return _features;
     }
 
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _feature.Dispose();
-        }
-
-        base.Dispose(disposing);
-    }
-
     private bool InternalUpdateMyLocation(MPoint newLocation)
     {
         var modified = false;

--- a/Tests/Mapsui.Rendering.Skia.Tests/LabelStyleFeatureSizeTests.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/LabelStyleFeatureSizeTests.cs
@@ -25,7 +25,7 @@ public class LabelStyleFeatureSizeTests
             LabelColumn = "test",
         };
 
-        using var feature = new PointFeature(new MPoint(0, 0));
+        var feature = new PointFeature(new MPoint(0, 0));
         feature["test"] = "Mapsui";
 
         using var skPaint = new SKPaint();
@@ -44,7 +44,7 @@ public class LabelStyleFeatureSizeTests
 
         labelStyle.Font.Size *= 2;
 
-        using var feature = new PointFeature(new MPoint(0, 0));
+        var feature = new PointFeature(new MPoint(0, 0));
         feature["test"] = "Mapsui";
 
         using var skPaint = new SKPaint();
@@ -70,7 +70,7 @@ public class LabelStyleFeatureSizeTests
             Offset = new Offset(2, 0),
         };
 
-        using var feature = new PointFeature(new MPoint(0, 0));
+        var feature = new PointFeature(new MPoint(0, 0));
         feature["test"] = "Mapsui";
 
         using var skPaint = new SKPaint();
@@ -88,7 +88,7 @@ public class LabelStyleFeatureSizeTests
             Offset = new Offset(0, 2),
         };
 
-        using var feature = new PointFeature(new MPoint(0, 0));
+        var feature = new PointFeature(new MPoint(0, 0));
         feature["test"] = "Mapsui";
 
         using var skPaint = new SKPaint();
@@ -106,7 +106,7 @@ public class LabelStyleFeatureSizeTests
             Offset = new Offset(2, 2),
         };
 
-        using var feature = new PointFeature(new MPoint(0, 0));
+        var feature = new PointFeature(new MPoint(0, 0));
         feature["test"] = "Mapsui";
 
         using var skPaint = new SKPaint();

--- a/Tests/Mapsui.Tests/Projections/ProjectionTests.cs
+++ b/Tests/Mapsui.Tests/Projections/ProjectionTests.cs
@@ -49,7 +49,7 @@ public class ProjectionTests
         // arrange
         var multiPolygon = (MultiPolygon)_wktReader.Read("MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))");
         var projectedMultiPolygon = multiPolygon.Copy();
-        using var feature = new GeometryFeature(projectedMultiPolygon);
+        var feature = new GeometryFeature(projectedMultiPolygon);
         var projection = new Projection();
 
         // act
@@ -72,7 +72,7 @@ public class ProjectionTests
         // arrange
         var multiPolygon = (MultiPolygon)_wktReader.Read("MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))");
         var projectedMultiPolygon = multiPolygon.Copy();
-        using var feature = new GeometryFeature(projectedMultiPolygon);
+        var feature = new GeometryFeature(projectedMultiPolygon);
         var projection = new DotSpatialProjection();
 
         // act


### PR DESCRIPTION
The RenderedGeometry was used before to cache rendered features. Those are SkiaSharp classes that need to be disposed. Now the RenderedGeometry is replaced with the IRenderCache. This allows for RenderedGeometry to be removed and more importantly also IDisposable. 

The IFeature is at the basis of most of our classes so this also propagated to other classes as well, good to have this removed.