### PR TITLE
Call GeometryChanged in Modified to make editing easier

### DIFF
--- a/Mapsui.Nts/GeometryFeature.cs
+++ b/Mapsui.Nts/GeometryFeature.cs
@@ -54,6 +54,10 @@ public class GeometryFeature : BaseFeature, IFeature
     override public void Modified()
     {
         base.Modified();
+
+        // Recalculate Geometry Values (for example in Polygons).
         Geometry?.GeometryChanged();
+        // Recalculate the Envelope
+        Geometry?.GeometryChangedAction();
     }
 }

--- a/Mapsui.Nts/GeometryFeature.cs
+++ b/Mapsui.Nts/GeometryFeature.cs
@@ -50,4 +50,10 @@ public class GeometryFeature : BaseFeature, IFeature
         // Recalculate the Envelope
         Geometry.GeometryChangedAction();
     }
+
+    override public void Modified()
+    {
+        base.Modified();
+        Geometry?.GeometryChanged();
+    }
 }

--- a/Mapsui/Features/BaseFeature.cs
+++ b/Mapsui/Features/BaseFeature.cs
@@ -56,7 +56,7 @@ public abstract class BaseFeature
         set => _dictionary[key] = value;
     }
 
-    public void Modified()
+    virtual public void Modified()
     {
         // is modified needs a new id.
         Id = NextId();


### PR DESCRIPTION
This may help avoid some users frustration. When updating the NTS coordinates you need to call GeometryChanged and GeometryChangedAction. This is something most users will not know about. This will not be necessary anymore if we do this in the Modified() method, which they need to call anyway.