### PR TITLE
Add ZOrder to IFeatures

### DIFF
--- a/Mapsui.Nts/GeometryFeature.cs
+++ b/Mapsui.Nts/GeometryFeature.cs
@@ -46,7 +46,7 @@ public class GeometryFeature : BaseFeature, IFeature
     /// <summary>
     /// Order of feature
     /// </summary>
-    public int ZOrder => throw new NotImplementedException();
+    public int ZOrder { get; set; } = 0;
 
     /// <summary>
     /// Implementation of visitor pattern for coordinates

--- a/Mapsui.Nts/GeometryFeature.cs
+++ b/Mapsui.Nts/GeometryFeature.cs
@@ -1,10 +1,13 @@
-using System;
 using Mapsui.Layers;
 using Mapsui.Nts.Extensions;
 using NetTopologySuite.Geometries;
+using System;
 
 namespace Mapsui.Nts;
 
+/// <summary>
+/// Feature representing a NTS geometry on the <cref="Map"/>
+/// </summary>
 public class GeometryFeature : BaseFeature, IFeature
 {
     public GeometryFeature()
@@ -30,10 +33,25 @@ public class GeometryFeature : BaseFeature, IFeature
         Geometry = geometry;
     }
 
+    /// <summary>
+    /// Geometry for this feature
+    /// </summary>
     public Geometry? Geometry { get; set; }
 
+    /// <summary>
+    /// Extent of feature
+    /// </summary>
     public MRect? Extent => Geometry?.EnvelopeInternal.ToMRect();
 
+    /// <summary>
+    /// Order of feature
+    /// </summary>
+    public int ZOrder => throw new NotImplementedException();
+
+    /// <summary>
+    /// Implementation of visitor pattern for coordinates
+    /// </summary>
+    /// <param name="visit"></param>
     public void CoordinateVisitor(Action<double, double, CoordinateSetter> visit)
     {
         if (Geometry is null) return;

--- a/Mapsui/Features/PointFeature.cs
+++ b/Mapsui/Features/PointFeature.cs
@@ -22,6 +22,11 @@ public class PointFeature : BaseFeature, IFeature
         Point = new MPoint(x, y);
     }
 
+    public PointFeature((double x, double y) point)
+    {
+        Point = new MPoint(point.x, point.y);
+    }
+
     /// <summary>
     /// Point of <cref="Map"/>
     /// </summary>

--- a/Mapsui/Features/PointFeature.cs
+++ b/Mapsui/Features/PointFeature.cs
@@ -40,7 +40,7 @@ public class PointFeature : BaseFeature, IFeature
     /// <summary>
     /// Order of feature
     /// </summary>
-    public int ZOrder { get; set; }
+    public int ZOrder { get; set; } = 0;
 
     /// <summary>
     /// Implementation of visitor pattern for coordinates

--- a/Mapsui/Features/PointFeature.cs
+++ b/Mapsui/Features/PointFeature.cs
@@ -2,6 +2,9 @@
 
 namespace Mapsui.Layers;
 
+/// <summary>
+/// Feature representing a point on the <cref="Map"/>
+/// </summary>
 public class PointFeature : BaseFeature, IFeature
 {
     public PointFeature(PointFeature pointFeature) : base(pointFeature)
@@ -19,9 +22,25 @@ public class PointFeature : BaseFeature, IFeature
         Point = new MPoint(x, y);
     }
 
+    /// <summary>
+    /// Point of <cref="Map"/>
+    /// </summary>
     public MPoint Point { get; }
+
+    /// <summary>
+    /// Extent of feature
+    /// </summary>
     public MRect Extent => Point.MRect;
 
+    /// <summary>
+    /// Order of feature
+    /// </summary>
+    public int ZOrder { get; set; }
+
+    /// <summary>
+    /// Implementation of visitor pattern for coordinates
+    /// </summary>
+    /// <param name="visit"></param>
     public void CoordinateVisitor(Action<double, double, CoordinateSetter> visit)
     {
         visit(Point.X, Point.Y, (x, y) =>

--- a/Mapsui/Features/RasterFeature.cs
+++ b/Mapsui/Features/RasterFeature.cs
@@ -1,13 +1,12 @@
-﻿
-using System;
+﻿using System;
 
 namespace Mapsui.Layers;
 
+/// <summary>
+/// Feature representing a bitmap on the <cref="Map"/>
+/// </summary>
 public class RasterFeature : BaseFeature, IFeature
 {
-    public MRaster? Raster { get; }
-    public MRect? Extent => Raster;
-
     public RasterFeature(RasterFeature rasterFeature) : base(rasterFeature)
     {
         Raster = rasterFeature.Raster == null ? null : new MRaster(rasterFeature.Raster);
@@ -18,6 +17,25 @@ public class RasterFeature : BaseFeature, IFeature
         Raster = raster;
     }
 
+    /// <summary>
+    /// Raster containing rect and bitmap of raster
+    /// </summary>
+    public MRaster? Raster { get; }
+
+    /// <summary>
+    /// Extent of feature
+    /// </summary>
+    public MRect? Extent => Raster;
+
+    /// <summary>
+    /// Order of feature which is here always 0, because all rasters are on the same level
+    /// </summary>
+    public int ZOrder => 0;
+
+    /// <summary>
+    /// Implementation of visitor pattern for coordinates
+    /// </summary>
+    /// <param name="visit"></param>
     public void CoordinateVisitor(Action<double, double, CoordinateSetter> visit)
     {
         if (Raster != null)

--- a/Mapsui/IFeature.cs
+++ b/Mapsui/IFeature.cs
@@ -1,19 +1,49 @@
+using Mapsui.Styles;
 using System;
 using System.Collections.Generic;
-using Mapsui.Styles;
 
 namespace Mapsui;
 
 public delegate void CoordinateSetter(double x, double y);
 
+/// <summary>
+/// Interface for a feature which could be displayed on the <cref="Map"/>
+/// </summary>
 public interface IFeature
 {
+    /// <summary>
+    /// Styles used for this feature
+    /// </summary>
     ICollection<IStyle> Styles { get; }
+    /// <summary>
+    /// Added informations to this feature
+    /// </summary>
+    /// <param name="key">Key used to store informations for feature</param>
+    /// <returns></returns>
     object? this[string key] { get; set; }
+    /// <summary>
+    /// Keys used to store informations for feature
+    /// </summary>
     IEnumerable<string> Fields { get; }
+    /// <summary>
+    /// <cref="Extent"/> of feature
+    /// </summary>
     MRect? Extent { get; }
+    /// <summary>
+    /// Implementation of visitor pattern for coordinates
+    /// </summary>
+    /// <param name="visit">Function for visiting each coordinate X or Y value</param>
     void CoordinateVisitor(Action<double, double, CoordinateSetter> visit);
+    /// <summary>
+    /// Unique Id for feature
+    /// </summary>
     long Id => 0;
+    /// <summary>
+    /// Function to call whenever something changes in settings of feature
+    /// </summary>
     void Modified() { } // default implementation
+    /// <summary>
+    /// Function to call if the rendered feature is invalide
+    /// </summary>
     void ClearRenderedGeometry() { } // default implementation
 }

--- a/Mapsui/IFeature.cs
+++ b/Mapsui/IFeature.cs
@@ -26,6 +26,13 @@ public interface IFeature
     /// </summary>
     IEnumerable<string> Fields { get; }
     /// <summary>
+    /// Order of features retrieved from GetFeatures() 
+    /// </summary>
+    /// <remarks>
+    /// Smaller values are retrieved later
+    /// </remarks>
+    int ZOrder { get; }
+    /// <summary>
     /// <cref="Extent"/> of feature
     /// </summary>
     MRect? Extent { get; }

--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -36,7 +36,7 @@ public class MemoryLayer : BaseLayer
                 SymbolStyle.DefaultWidth * 2 * resolution,
                 SymbolStyle.DefaultHeight * 2 * resolution);
 
-        return Features.Where(f => f.Extent?.Intersects(biggerRect) == true);
+        return Features.Where(f => f.Extent?.Intersects(biggerRect) == true).OrderBy(f => f.ZOrder).ThenBy(f => f.Id);
     }
 
     public override MRect? Extent => Features.GetExtent();


### PR DESCRIPTION
This PR is regarding #2389.

Add a ZOrder property for features to order features while retrieving them.

What is the problem? Up to now, MemoryLayer uses a ConcurrentBag to store features. ConcurrentBag is an unordered collection, so that you could not decide, which feature is created before or after another feaure. This is problematic, if you want to have access to the creation of the map. With ZOrder it is possible to say, which feature will be print over which other feature.

Additionally, the list of features returned by `GetFeatures()` is first ordered by the ZOrder and then ordered by the Id of the feature, because this Id is a consecutive number. If the Id of a feature is lower than another, then it is created earlier. Other map libraries use the y position to sort features. See for detailed discussion issue #2389. 