### PR TITLE
Move LoggingWidget from MapControl to Map

### DIFF
--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -67,8 +67,6 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     private int _updateWidget = 0;
     // keeps track of the widgets count to see if i need to recalculate the touchable widgets.
     private int _updateTouchableWidget;
-    // Default LoggingWidget when the debugger is attached
-    private LoggingWidget _loggingWidget;
 
     private void CommonInitialize()
     {
@@ -317,38 +315,6 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         map.RefreshGraphicsRequest += Map_RefreshGraphicsRequest;
     }
 
-    /// <summary>
-    /// Check, if a debugger is attached and, if yes, add a default LoggingWidget
-    /// </summary>
-    /// <param name="map">Map, to which LoggingWidget should add</param>
-    private void CheckForLoggingWidget(Map map)
-    {
-        // If in debug mode ...
-        if (System.Diagnostics.Debugger.IsAttached)
-        {
-            // Is there already a LoggingWidget ...
-            if (map.Widgets.Where(w => w.GetType() == typeof(LoggingWidget)).Count() > 0)
-                // ... then return;
-                return;
-
-            // Is there already a LoggingWidget we used for an earlier map ...
-            if (_loggingWidget == null)
-                // no, then create one
-                _loggingWidget = new LoggingWidget(map)
-                {
-                    MarginX = 10,
-                    MarginY = 10,
-                    VerticalAlignment = Widgets.VerticalAlignment.Top,
-                    HorizontalAlignment = Widgets.HorizontalAlignment.Left,
-                    BackgroundColor = Color.Transparent,
-                    Opacity = 0.0f,
-                    LogLevelFilter = LogLevel.Trace,
-                };
-
-            map.Widgets.Add(_loggingWidget);
-        }
-    }
-
     private void Map_RefreshGraphicsRequest(object? sender, EventArgs e)
     {
         RefreshGraphics();
@@ -504,7 +470,6 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
         map.Navigator.SetSize(ViewportWidth, ViewportHeight);
         SubscribeToMapEvents(map);
-        CheckForLoggingWidget(map);
         Refresh();
     }
 

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -13,8 +13,10 @@ using System.Linq;
 using Mapsui.Extensions;
 using Mapsui.Fetcher;
 using Mapsui.Layers;
+using Mapsui.Logging;
 using Mapsui.Styles;
 using Mapsui.Widgets;
+using Mapsui.Widgets.LoggingWidget;
 
 namespace Mapsui;
 
@@ -37,6 +39,7 @@ public class Map : INotifyPropertyChanged, IDisposable
     {
         BackColor = Color.White;
         Layers = [];
+        CheckForLoggingWidget();
         Navigator.RefreshDataRequest += Navigator_RefreshDataRequest;
         Navigator.ViewportChanged += Navigator_ViewportChanged;
     }
@@ -382,5 +385,34 @@ public class Map : INotifyPropertyChanged, IDisposable
         }
 
         return areAnimationsRunning;
+    }
+
+    /// <summary>
+    /// Check, if a debugger is attached and, if yes, add a default LoggingWidget
+    /// </summary>
+    /// <param name="map">Map, to which LoggingWidget should add</param>
+    private void CheckForLoggingWidget()
+    {
+        // If in debug mode ...
+        if (System.Diagnostics.Debugger.IsAttached)
+        {
+            // Is there already a LoggingWidget ...
+            if (Widgets.Where(w => w.GetType() == typeof(LoggingWidget)).Count() > 0)
+                // ... then return;
+                return;
+
+            var loggingWidget = new LoggingWidget(this)
+            {
+                MarginX = 10,
+                MarginY = 10,
+                VerticalAlignment = VerticalAlignment.Top,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                BackgroundColor = Color.Transparent,
+                Opacity = 0.0f,
+                LogLevelFilter = LogLevel.Trace,
+            };
+
+            Widgets.Add(loggingWidget);
+        }
     }
 }


### PR DESCRIPTION
Move LoggingWidget from MapControl and add it to Map, so that each map has its own LoggingWidget and not one, that is used for all.

After the first version of adding the LoggingWidget to MapControl, @pauldendulk and @inforithmics both suggest bringing it to Map. This PR should do this.