### PR TITLE
Update LoggingWidget

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaWidgets/LoggingWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/LoggingWidgetRenderer.cs
@@ -65,6 +65,14 @@ public class LoggingWidgetRenderer : ISkiaWidgetRenderer, IDisposable
 
         foreach (var entry in loggingWidget.ListOfLogEntries)
         {
+            if (entry.LogLevel > loggingWidget.LogLevelFilter)
+                continue;
+
+            var top = marginY + (paddingY * line) + loggingWidget.TextSize * (line + 1);
+            
+            if (top >= loggingWidget.Envelope.Height)
+                break;
+
             var paint = entry.LogLevel switch
             {
                 LogLevel.Error => _errorTextPaint,

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -403,8 +403,8 @@ public class Map : INotifyPropertyChanged, IDisposable
             var loggingWidget = new LoggingWidget()
             {
                 Margin = new MRect(10),
-                VerticalAlignment = VerticalAlignment.Top,
-                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
                 BackColor = Color.Transparent,
                 Opacity = 0.0f,
                 LogLevelFilter = LogLevel.Trace,


### PR DESCRIPTION
Change the LoggingWidget after the bid rework of Widgets. Now it is possible to use stretch for vertical and horizontal alignment. Also it is possible to save more log entries, so that the filter or size could be changed, so that old/more log entries are visible.