### PR TITLE
Remove INotifyPropertyChanged from widgets

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaWidgets/WidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/WidgetRenderer.cs
@@ -41,6 +41,9 @@ public static class WidgetRenderer
             }
 
             ((ISkiaWidgetRenderer)renderer).Draw(canvas, viewport, widget, layerOpacity);
+
+            // Widget is redrawn
+            widget.NeedsRedraw = false;
         }
     }
 }

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -847,7 +847,6 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             Enabled = true,
         };
         result.Touched += (s, e) => action(s, e);
-        result.PropertyChanged += (s, e) => RefreshGraphics();
 
         return result;
     }

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -121,7 +121,11 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
                 _refresh = true;
 
             // seems that this could be null sometimes
-            if (Map?.Navigator?.UpdateAnimations() ?? false)
+            if (!_refresh && (Map?.Navigator?.UpdateAnimations() ?? false))
+                _refresh = true;
+
+            // Check if widgets need refresh
+            if (!_refresh && Map.Widgets.Any(w => w.NeedsRedraw))
                 _refresh = true;
 
             if (!_refresh)

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -125,7 +125,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
                 _refresh = true;
 
             // Check if widgets need refresh
-            if (!_refresh && Map.Widgets.Any(w => w.NeedsRedraw))
+            if (!_refresh && (Map?.Widgets?.Any(w => w.NeedsRedraw) ?? false))
                 _refresh = true;
 
             if (!_refresh)

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -121,7 +121,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
                 _refresh = true;
 
             // seems that this could be null sometimes
-            if (!_refresh && (Map?.Navigator?.UpdateAnimations() ?? false))
+            if (Map?.Navigator?.UpdateAnimations() ?? false)
                 _refresh = true;
 
             // Check if widgets need refresh

--- a/Mapsui/Widgets/BoxWidgets/BoxWidget.cs
+++ b/Mapsui/Widgets/BoxWidgets/BoxWidget.cs
@@ -20,7 +20,7 @@ public class BoxWidget : Widget
             if (_cornerRadius == value)
                 return;
             _cornerRadius = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -37,7 +37,7 @@ public class BoxWidget : Widget
             if (_backColor == value)
                 return;
             _backColor = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -54,7 +54,7 @@ public class BoxWidget : Widget
             if (_opacity == value)
                 return;
             _opacity = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 }

--- a/Mapsui/Widgets/BoxWidgets/TextBoxWidget.cs
+++ b/Mapsui/Widgets/BoxWidgets/TextBoxWidget.cs
@@ -20,7 +20,7 @@ public class TextBoxWidget : BoxWidget
             if (_padding == value)
                 return;
             _padding = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -37,7 +37,7 @@ public class TextBoxWidget : BoxWidget
             if (_text == value)
                 return;
             _text = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -54,7 +54,7 @@ public class TextBoxWidget : BoxWidget
             if (_textSize == value)
                 return;
             _textSize = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -71,7 +71,7 @@ public class TextBoxWidget : BoxWidget
             if (_textColor == value)
                 return;
             _textColor = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 }

--- a/Mapsui/Widgets/ButtonWidgets/HyperlinkWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/HyperlinkWidget.cs
@@ -18,7 +18,7 @@ public class HyperlinkWidget : TextButtonWidget
             if (_url == value)
                 return;
             _url = value ?? string.Empty;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 }

--- a/Mapsui/Widgets/ButtonWidgets/IconButtonWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/IconButtonWidget.cs
@@ -39,7 +39,7 @@ public class IconButtonWidget : BoxWidget, ITouchableWidget
             if (_paddingX == value)
                 return;
             _paddingX = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -56,7 +56,7 @@ public class IconButtonWidget : BoxWidget, ITouchableWidget
             if (_paddingY == value)
                 return;
             _paddingY = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -75,7 +75,7 @@ public class IconButtonWidget : BoxWidget, ITouchableWidget
 
             _svgImage = value;
             Picture = null;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -91,7 +91,7 @@ public class IconButtonWidget : BoxWidget, ITouchableWidget
         {
             if (Equals(value, _picture)) return;
             _picture = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -108,7 +108,7 @@ public class IconButtonWidget : BoxWidget, ITouchableWidget
             if (_rotation == value)
                 return;
             _rotation = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 

--- a/Mapsui/Widgets/ButtonWidgets/ZoomInOutWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/ZoomInOutWidget.cs
@@ -35,7 +35,7 @@ public class ZoomInOutWidget : TouchableWidget
             if (_size == value)
                 return;
             _size = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -52,7 +52,7 @@ public class ZoomInOutWidget : TouchableWidget
             if (_orientation == value)
                 return;
             _orientation = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -69,7 +69,7 @@ public class ZoomInOutWidget : TouchableWidget
             if (_strokeColor == value)
                 return;
             _strokeColor = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -86,7 +86,7 @@ public class ZoomInOutWidget : TouchableWidget
             if (_textColor == value)
                 return;
             _textColor = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -103,7 +103,7 @@ public class ZoomInOutWidget : TouchableWidget
             if (_backColor == value)
                 return;
             _backColor = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -120,7 +120,7 @@ public class ZoomInOutWidget : TouchableWidget
             if (_opacity == value)
                 return;
             _opacity = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 

--- a/Mapsui/Widgets/IWidget.cs
+++ b/Mapsui/Widgets/IWidget.cs
@@ -41,4 +41,9 @@ public interface IWidget
     /// Is Widget visible on screen
     /// </summary>
     bool Enabled { get; set; }
+
+    /// <summary>
+    /// Flag for redrawing widget in the next drawing cycle
+    /// </summary>
+    bool NeedsRedraw { get; }
 }

--- a/Mapsui/Widgets/IWidget.cs
+++ b/Mapsui/Widgets/IWidget.cs
@@ -45,5 +45,5 @@ public interface IWidget
     /// <summary>
     /// Flag for redrawing widget in the next drawing cycle
     /// </summary>
-    bool NeedsRedraw { get; }
+    bool NeedsRedraw { get; set; }
 }

--- a/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
@@ -54,7 +54,7 @@ public class LoggingWidget : TextBoxWidget
             _listOfLogEntries.TryDequeue(out var outObj);
         }
 
-        OnPropertyChanged(nameof(Text));
+        Invalidate(nameof(Text));
     }
 
     public void Clear()
@@ -64,7 +64,7 @@ public class LoggingWidget : TextBoxWidget
             _listOfLogEntries.TryDequeue(out var outObj);
         }
 
-        OnPropertyChanged(nameof(Text));
+        Invalidate(nameof(Text));
     }
 
     private ConcurrentQueue<LogEntry> _listOfLogEntries;
@@ -85,7 +85,7 @@ public class LoggingWidget : TextBoxWidget
             if (_logLevelFilter == value)
                 return;
             _logLevelFilter = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -99,7 +99,7 @@ public class LoggingWidget : TextBoxWidget
             if (_maxNumberOfLogEntriesToKeep == value)
                 return;
             _maxNumberOfLogEntriesToKeep = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -116,7 +116,7 @@ public class LoggingWidget : TextBoxWidget
             if (_errorTextColor == value)
                 return;
             _errorTextColor = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -133,7 +133,7 @@ public class LoggingWidget : TextBoxWidget
             if (_warningTextColor == value)
                 return;
             _warningTextColor = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -150,11 +150,11 @@ public class LoggingWidget : TextBoxWidget
             if (_informationTextColor == value)
                 return;
             _informationTextColor = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
-    public override void OnPropertyChanged([CallerMemberName] string name = "")
+    public override void Invalidate([CallerMemberName] string name = "")
     {
         if (name == nameof(Enabled))
         {
@@ -164,6 +164,6 @@ public class LoggingWidget : TextBoxWidget
                 Logger.LogDelegate -= Log;
         }
 
-        base.OnPropertyChanged(name);
+        base.Invalidate(name);
     }
 }

--- a/Mapsui/Widgets/ScaleBar/ScaleBarWidget.cs
+++ b/Mapsui/Widgets/ScaleBar/ScaleBarWidget.cs
@@ -81,7 +81,7 @@ public class ScaleBarWidget : Widget
                 return;
 
             _maxWidth = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -98,7 +98,7 @@ public class ScaleBarWidget : Widget
             if (_textColor == value)
                 return;
             _textColor = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -115,7 +115,7 @@ public class ScaleBarWidget : Widget
             if (_haloColor == value)
                 return;
             _haloColor = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -150,7 +150,7 @@ public class ScaleBarWidget : Widget
                 return;
 
             _textAlignment = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -173,7 +173,7 @@ public class ScaleBarWidget : Widget
                 return;
 
             _font = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -197,7 +197,7 @@ public class ScaleBarWidget : Widget
             }
 
             _unitConverter = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -217,7 +217,7 @@ public class ScaleBarWidget : Widget
             }
 
             _secondaryUnitConverter = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -237,7 +237,7 @@ public class ScaleBarWidget : Widget
             }
 
             _scaleBarMode = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 

--- a/Mapsui/Widgets/TouchableWidget.cs
+++ b/Mapsui/Widgets/TouchableWidget.cs
@@ -38,7 +38,7 @@ public abstract class TouchableWidget : Widget, ITouchableWidget
             if (_touchableArea == value)
                 return;
             _touchableArea = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 

--- a/Mapsui/Widgets/Widget.cs
+++ b/Mapsui/Widgets/Widget.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 
 namespace Mapsui.Widgets;
 
-public abstract class Widget : IWidget, INotifyPropertyChanged
+public abstract class Widget : IWidget
 {
     private HorizontalAlignment _horizontalAlignment = HorizontalAlignment.Right;
 
@@ -19,7 +19,7 @@ public abstract class Widget : IWidget, INotifyPropertyChanged
             if (_horizontalAlignment == value)
                 return;
             _horizontalAlignment = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -36,7 +36,7 @@ public abstract class Widget : IWidget, INotifyPropertyChanged
             if (_verticalAlignment == value)
                 return;
             _verticalAlignment = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -53,7 +53,7 @@ public abstract class Widget : IWidget, INotifyPropertyChanged
             if (_margin == value)
                 return;
             _margin = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -70,7 +70,7 @@ public abstract class Widget : IWidget, INotifyPropertyChanged
             if (_position.Equals(value))
                 return;
             _position = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -87,7 +87,7 @@ public abstract class Widget : IWidget, INotifyPropertyChanged
             if (_width == value)
                 return;
             _width = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -104,7 +104,7 @@ public abstract class Widget : IWidget, INotifyPropertyChanged
             if (_height == value)
                 return;
             _height = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -121,7 +121,7 @@ public abstract class Widget : IWidget, INotifyPropertyChanged
             if (_envelope == value)
                 return;
             _envelope = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -138,7 +138,7 @@ public abstract class Widget : IWidget, INotifyPropertyChanged
             if (_enabled == value)
                 return;
             _enabled = value;
-            OnPropertyChanged();
+            Invalidate();
         }
     }
 
@@ -146,11 +146,6 @@ public abstract class Widget : IWidget, INotifyPropertyChanged
     /// Flag for redrawing widget in the next drawing cycle
     /// </summary>
     public bool NeedsRedraw { get; set; } = false;
-
-    /// <summary>
-    /// Event handler which is called, when a property changes
-    /// </summary>
-    public event PropertyChangedEventHandler? PropertyChanged;
 
     public void UpdateEnvelope(double maxWidth, double maxHeight, double screenWidth, double screenHeight)
     {
@@ -162,9 +157,9 @@ public abstract class Widget : IWidget, INotifyPropertyChanged
         Envelope = new MRect(minX, minY, maxX, maxY);
     }
 
-    public virtual void OnPropertyChanged([CallerMemberName] string name = "")
+    public virtual void Invalidate([CallerMemberName] string name = "")
     {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        NeedsRedraw = true;
     }
 
     private double CalculatePositionX(double left, double right, double width) => HorizontalAlignment switch

--- a/Mapsui/Widgets/Widget.cs
+++ b/Mapsui/Widgets/Widget.cs
@@ -143,6 +143,11 @@ public abstract class Widget : IWidget, INotifyPropertyChanged
     }
 
     /// <summary>
+    /// Flag for redrawing widget in the next drawing cycle
+    /// </summary>
+    public bool NeedsRedraw { get; set; } = false;
+
+    /// <summary>
     /// Event handler which is called, when a property changes
     /// </summary>
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Samples/Mapsui.Samples.CustomWidget/CustomWidget.cs
+++ b/Samples/Mapsui.Samples.CustomWidget/CustomWidget.cs
@@ -20,4 +20,5 @@ public class CustomWidget : IWidget
     public double Width { get; set; }
     public double Height { get; set; }
     public bool Enabled { get; set; } = true;
+    public bool NeedsRedraw { get; set; }
 }


### PR DESCRIPTION
As promised, when the new widget handling is merged, the INotifyPropertyChanged interface could be easily removed. This is done with this PR.

Widgets are now redrawn when their flag NeedsRedraw is set to true. After a redraw, this flag is set to false by the renderer. For easy use, this flag is set in the `Invalidate()` function.