### PR TITLE
Remove wrong comment in BoxWidgetRenderer

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaWidgets/BoxWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/BoxWidgetRenderer.cs
@@ -14,9 +14,6 @@ public class BoxWidgetRenderer : ISkiaWidgetRenderer
         boxWidget.UpdateEnvelope(boxWidget.Width, boxWidget.Height, viewport.Width, viewport.Height);
 
         using var backPaint = new SKPaint { Color = boxWidget.BackColor.ToSkia(layerOpacity), IsAntialias = true };
-        // The textRect has an offset which can be confusing. 
-        // This is because DrawText's origin is the baseline of the text, not the bottom.
-        // Read more here: https://developer.xamarin.com/guides/xamarin-forms/advanced/skiasharp/basics/text/
 
         canvas.DrawRoundRect(boxWidget.Envelope?.ToSkia() ?? new SKRect(0, 0, (float)boxWidget.Width, (float)boxWidget.Height), (float)boxWidget.CornerRadius, (float)boxWidget.CornerRadius, backPaint);
     }


### PR DESCRIPTION
The comment isn't correct in this renderer, because there isn't drawn any text.