### PR TITLE
Add sorting of features before drawing

### DIFF
--- a/Mapsui/Layers/BaseLayer.cs
+++ b/Mapsui/Layers/BaseLayer.cs
@@ -187,7 +187,7 @@ public abstract class BaseLayer : ILayer
     public abstract IEnumerable<IFeature> GetFeatures(MRect box, double resolution);
 
     /// <inheritdoc/>
-    public virtual Func<IEnumerable<IFeature>, IEnumerable<IFeature>> SortFeatures => (feature) => feature;
+    public virtual Func<IEnumerable<IFeature>, IEnumerable<IFeature>> SortFeatures { get; set; } = (feature) => feature;
 
     public void DataHasChanged()
     {

--- a/Mapsui/Layers/BaseLayer.cs
+++ b/Mapsui/Layers/BaseLayer.cs
@@ -186,6 +186,9 @@ public abstract class BaseLayer : ILayer
     /// <inheritdoc />
     public abstract IEnumerable<IFeature> GetFeatures(MRect box, double resolution);
 
+    /// <inheritdoc/>
+    public virtual Func<IEnumerable<IFeature>, IEnumerable<IFeature>> SortFeatures => (feature) => feature;
+
     public void DataHasChanged()
     {
         DataChanged?.Invoke(this, new DataChangedEventArgs());

--- a/Mapsui/Layers/ILayer.cs
+++ b/Mapsui/Layers/ILayer.cs
@@ -80,7 +80,7 @@ public interface ILayer : IAnimatable, INotifyPropertyChanged, IDisposable
     /// <summary>
     /// Function to sort order of features for drawing
     /// </summary>
-    Func<IEnumerable<IFeature>, IEnumerable<IFeature>>? SortFeatures { get; }
+    Func<IEnumerable<IFeature>, IEnumerable<IFeature>> SortFeatures { get; }
 
     /// <summary>
     /// Attribution for layer

--- a/Mapsui/Layers/ILayer.cs
+++ b/Mapsui/Layers/ILayer.cs
@@ -78,6 +78,11 @@ public interface ILayer : IAnimatable, INotifyPropertyChanged, IDisposable
     IEnumerable<IFeature> GetFeatures(MRect extent, double resolution);
 
     /// <summary>
+    /// Function to sort order of features for drawing
+    /// </summary>
+    Func<IEnumerable<IFeature>, IEnumerable<IFeature>>? SortFeatures { get; }
+
+    /// <summary>
     /// Attribution for layer
     /// </summary>
     HyperlinkWidget Attribution { get; }

--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -39,5 +39,7 @@ public class MemoryLayer : BaseLayer
         return Features.Where(f => f.Extent?.Intersects(biggerRect) == true);
     }
 
+    public override Func<IEnumerable<IFeature>, IEnumerable<IFeature>> SortFeatures => (features) => features.OrderBy(f => f.ZOrder).ThenBy(f => f.Id);
+
     public override MRect? Extent => Features.GetExtent();
 }

--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -1,10 +1,9 @@
+using Mapsui.Extensions;
+using Mapsui.Styles;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using Mapsui.Extensions;
-using Mapsui.Providers;
-using Mapsui.Styles;
 
 namespace Mapsui.Layers;
 
@@ -39,7 +38,7 @@ public class MemoryLayer : BaseLayer
         return Features.Where(f => f.Extent?.Intersects(biggerRect) == true);
     }
 
-    public override Func<IEnumerable<IFeature>, IEnumerable<IFeature>> SortFeatures => (features) => features.OrderBy(f => f.ZOrder).ThenBy(f => f.Id);
+    public override Func<IEnumerable<IFeature>, IEnumerable<IFeature>> SortFeatures { get; set; } = (features) => features.OrderBy(f => f.ZOrder).ThenBy(f => f.Id);
 
     public override MRect? Extent => Features.GetExtent();
 }

--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -36,7 +36,7 @@ public class MemoryLayer : BaseLayer
                 SymbolStyle.DefaultWidth * 2 * resolution,
                 SymbolStyle.DefaultHeight * 2 * resolution);
 
-        return Features.Where(f => f.Extent?.Intersects(biggerRect) == true).OrderBy(f => f.ZOrder).ThenBy(f => f.Id);
+        return Features.Where(f => f.Extent?.Intersects(biggerRect) == true);
     }
 
     public override MRect? Extent => Features.GetExtent();

--- a/Mapsui/Rendering/VisibleFeatureIterator.cs
+++ b/Mapsui/Rendering/VisibleFeatureIterator.cs
@@ -30,7 +30,7 @@ public static class VisibleFeatureIterator
         var extent = viewport.ToExtent();
         if (extent is null) return;
 
-        var features = layer.GetFeatures(extent, viewport.Resolution).ToList();
+        var features = layer.GetFeatures(extent, viewport.Resolution).OrderBy(f => f.ZOrder).ThenBy(f => f.Id).ToList();
 
         // Part 1. Styles on the layer
         var layerStyles = layer.Style.GetStylesToApply(viewport.Resolution);

--- a/Mapsui/Rendering/VisibleFeatureIterator.cs
+++ b/Mapsui/Rendering/VisibleFeatureIterator.cs
@@ -30,7 +30,7 @@ public static class VisibleFeatureIterator
         var extent = viewport.ToExtent();
         if (extent is null) return;
 
-        var features = layer.GetFeatures(extent, viewport.Resolution).OrderBy(f => f.ZOrder).ThenBy(f => f.Id).ToList();
+        var features = layer.SortFeatures(layer.GetFeatures(extent, viewport.Resolution)).ToList();
 
         // Part 1. Styles on the layer
         var layerStyles = layer.Style.GetStylesToApply(viewport.Resolution);


### PR DESCRIPTION
See issue #2421.

This PR introduce a `SortFeature()` function, which is used to sort features before drawing. In the `BaseLayer` implementation, this functions return the given features untouched. In the `MemoryLayer` implementation this function is replaced by a function, that orders the features by ZOrder and Id by default (perhaps this should be reverted and the default function should use). With this, it is possible to use whatever sorting algorithm you like. 
