### PR TITLE
Change order of features of each layer in MapInfo

### DIFF
--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -252,7 +252,7 @@ public sealed class MapRenderer : IRenderer, IDisposable
                                 mapList = new List<MapInfoRecord>();
                                 // get information from ILayer Feature Info
                                 var features = await layerFeatureInfo.GetFeatureInfoAsync(viewport, x, y);
-                                foreach (var it in features)
+                                foreach (var it in features.Reverse())
                                 {
                                     foreach (var feature in it.Value)
                                     {

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -543,16 +543,6 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
         if (mapInfo != null)
         {
-            var result = new List<MapInfoRecord>(mapInfo.MapInfoRecords.Count);
-
-            foreach (var layer in mapInfo.MapInfoRecords.Select((mi) => mi.Layer).Distinct())
-            {
-                result.AddRange(mapInfo.MapInfoRecords.Where((mi) => mi.Layer == layer).Reverse());
-            }
-
-            mapInfo.MapInfoRecords.Clear();
-            mapInfo.MapInfoRecords.AddRange(result);
-
             return new MapInfoEventArgs
             {
                 MapInfo = mapInfo,

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -543,6 +543,16 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
         if (mapInfo != null)
         {
+            var result = new List<MapInfoRecord>(mapInfo.MapInfoRecords.Count);
+
+            foreach (var layer in mapInfo.MapInfoRecords.Select((mi) => mi.Layer).Distinct())
+            {
+                result.AddRange(mapInfo.MapInfoRecords.Where((mi) => mi.Layer == layer).Reverse());
+            }
+
+            mapInfo.MapInfoRecords.Clear();
+            mapInfo.MapInfoRecords.AddRange(result);
+
             return new MapInfoEventArgs
             {
                 MapInfo = mapInfo,


### PR DESCRIPTION
The sort order is respected when drawing the map, but not when the map is touched. All features, that are hit in a layer are in sorted order, but should be in reversed order like the layers, which are already reversed. The topmost feature is the last drawn feature, but should be the first hidden feature. See also #2438. 

This PR reverses all features for all layers.
