### PR TITLE
Add (4.1.2) .Net 8 Target to Maui

### DIFF
--- a/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
+++ b/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <!--Windows does not work because of this https://github.com/dotnet/maui/issues/6529-->
 	  <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks)</TargetFrameworks>
     <UseMaui>true</UseMaui>


### PR DESCRIPTION
To indicate that Mapsui.Maui is compatible with .NET 8
Discovered that Mapsui.Maui does not target .NET 8 while investigating 
https://github.com/Mapsui/Mapsui/issues/2364
I couldn't reproduce it with the next .NET 8 Maui Version (8.0.2x Visual Studio 2022 Preview) so this could be fixed.