### PR TITLE
Add:  (4.1.2) an iteration Lock so that only one Thread renders at the sa…

### DIFF
--- a/Mapsui/Rendering/VisibleFeatureIterator.cs
+++ b/Mapsui/Rendering/VisibleFeatureIterator.cs
@@ -11,6 +11,7 @@ namespace Mapsui.Rendering;
 
 public static class VisibleFeatureIterator
 {
+    private static object _iterationLock = new();
     public static void IterateLayers(Viewport viewport, IEnumerable<ILayer> layers, long iteration,
         Action<Viewport, ILayer, IStyle, IFeature, float, long> callback)
     {
@@ -20,7 +21,10 @@ public static class VisibleFeatureIterator
             if (layer.MinVisible > viewport.Resolution) continue;
             if (layer.MaxVisible < viewport.Resolution) continue;
 
-            IterateLayer(viewport, layer, iteration, callback);
+            lock (_iterationLock)
+            {
+                IterateLayer(viewport, layer, iteration, callback);    
+            }
         }
     }
 


### PR DESCRIPTION
…me time.

I discovered this during this pull request

https://github.com/Mapsui/Mapsui/pull/2425

That when SkiaObjects are used in more than one threads exceptions occour. This was the simplest fix to the Skia Crashes. I'll still investigating If I can do without a global Render/Iteration Lock But for the 4.1.2 Branch this should be sufficient to Fix Threading issues.