### PR TITLE
Fix widget touch up

### DIFF
--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -236,10 +236,10 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
             TouchAction?.Invoke(sender, e);
             if (e.Handled) return;
 
-            if (e.ActionType == SKTouchAction.Pressed && _touches.IsEmpty)
+            if (e.ActionType == SKTouchAction.Pressed)
             {
                 _widgetPointerDown = false;
-                _pointerDownTicks = DateTime.UtcNow.Ticks;
+                _touches[e.Id] = location;
 
                 if (_touches.Count == 1)
                 {


### PR DESCRIPTION
This was not correctly merged from the touch fix in 4.1. The widget touch up event received null for the starting position.