### PR TITLE
Remove touch events from touchable widget

### DIFF
--- a/Mapsui/Widgets/TouchableWidget.cs
+++ b/Mapsui/Widgets/TouchableWidget.cs
@@ -8,21 +8,6 @@ namespace Mapsui.Widgets;
 public abstract class TouchableWidget : Widget, ITouchableWidget
 {
     /// <summary>
-    /// Event which is called if widget is touched
-    /// </summary>
-    public event EventHandler<WidgetTouchedEventArgs>? Touched;
-
-    /// <summary>
-    /// Event which is called if touching around in the widget
-    /// </summary>
-    public event EventHandler<WidgetTouchedEventArgs>? Touching;
-
-    /// <summary>
-    /// Event which is called if moving inside of widget
-    /// </summary>
-    public event EventHandler<WidgetTouchedEventArgs>? Moving;
-
-    /// <summary>
     /// Type of area to use for touch events
     /// </summary>
     private TouchableAreaType _touchableArea = TouchableAreaType.Widget;
@@ -51,8 +36,6 @@ public abstract class TouchableWidget : Widget, ITouchableWidget
     /// <returns>True, if the Widget had handled the touch event</returns>
     public virtual bool HandleWidgetTouched(Navigator navigator, MPoint position, WidgetTouchedEventArgs args)
     {
-        Touched?.Invoke(this, args);
-
         return args.Handled;
     }
 
@@ -65,8 +48,6 @@ public abstract class TouchableWidget : Widget, ITouchableWidget
     /// <returns>True, if the Widget had handled the touch event</returns>
     public virtual bool HandleWidgetTouching(Navigator navigator, MPoint position, WidgetTouchedEventArgs args)
     {
-        Touching?.Invoke(this, args);
-
         return args.Handled;
     }
 
@@ -79,8 +60,6 @@ public abstract class TouchableWidget : Widget, ITouchableWidget
     /// <returns>True, if the Widget had handled the touch event</returns>
     public virtual bool HandleWidgetMoving(Navigator navigator, MPoint position, WidgetTouchedEventArgs args)
     {
-        Moving?.Invoke(this, args);
-
         return args.Handled;
     }
 


### PR DESCRIPTION
I don't know the use case, there are no tests and no samples. We can add them again if we understand why. There are still issues with the touch handling so lets not build more on top of it.

The alternative is that users use the gestures of the platform and from those handler get feature info themselves. If something is Mapsui is blocking that solution (because something in Mapsui's handling messes it up) than we need to investigate that problem en fix it.