### PR TITLE
Remove touch event van MAUI MapControl

### DIFF
--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -64,16 +64,9 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
         // Add some events to _mapControl
         Map.Navigator.ViewportChanged += HandlerViewportChanged;
-        Info += HandlerInfo;
-        SingleTap += HandlerTap;
-        DoubleTap += HandlerTap;
-        LongTap += HandlerLongTap;
+        Info += (s, e) => HandlerInfo(e);
         SizeChanged += HandlerSizeChanged;
 
-        TouchMove += (s, e) =>
-        {
-            RunOnUIThread(() => MyLocationFollow = false);
-        };
 
         // Add MapView layers to Map
         AddLayers();
@@ -118,11 +111,6 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     /// Occurs when map clicked
     /// </summary>
     public event EventHandler<MapClickedEventArgs>? MapClicked;
-
-    /// <summary>
-    /// Occurs when map long clicked
-    /// </summary>
-    public event EventHandler<MapLongClickedEventArgs>? MapLongClicked;
 
     #endregion
 
@@ -446,7 +434,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
                 // Add event handlers
                 Map.Navigator.ViewportChanged += HandlerViewportChanged;
-                Info += HandlerInfo;
+                Info += (s, e) => HandlerInfo(e);
             }
         }
     }
@@ -551,7 +539,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         Refresh();
     }
 
-    private void HandlerInfo(object? sender, MapInfoEventArgs e)
+    private void HandlerInfo(MapInfoEventArgs e)
     {
         // Click on pin?
         if (e.MapInfo?.Layer == _mapPinLayer)
@@ -664,18 +652,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         }
     }
 
-    private void HandlerLongTap(object? sender, TappedEventArgs e)
-    {
-        var args = new MapLongClickedEventArgs(Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToNative());
-        MapLongClicked?.Invoke(this, args);
-
-        if (args.Handled)
-        {
-            e.Handled = true;
-        }
-    }
-
-    private void HandlerTap(object? sender, TappedEventArgs e)
+    private void HandlerTap(TappedEventArgs e)
     {
         e.Handled = false;
 
@@ -686,7 +663,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
             var mapInfoEventArgs = new MapInfoEventArgs { MapInfo = mapInfo, Handled = e.Handled, NumTaps = e.NumOfTaps };
 
-            HandlerInfo(sender, mapInfoEventArgs);
+            HandlerInfo(mapInfoEventArgs);
 
             e.Handled = mapInfoEventArgs.Handled;
 
@@ -873,5 +850,23 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         Pins.Clear();
         Drawables.Clear();
         HideCallouts();
+    }
+
+    protected override bool OnSingleTapped(MPoint screenPosition)
+    {
+        HandlerTap(new TappedEventArgs(screenPosition, 1));
+        return base.OnSingleTapped(screenPosition);
+    }
+
+    protected override bool OnDoubleTapped(MPoint screenPosition, int numOfTaps)
+    {
+        HandlerTap(new TappedEventArgs(screenPosition, numOfTaps));
+        return base.OnDoubleTapped(screenPosition, numOfTaps);
+    }
+
+    protected override bool OnTouchMove(List<MPoint> touchPoints)
+    {
+        RunOnUIThread(() => MyLocationFollow = false);
+        return base.OnTouchMove(touchPoints);
     }
 }

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -38,10 +38,8 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     private SKCanvasView? _canvasView;
 
     // See http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/4.0.4_r2.1/android/view/ViewConfiguration.java#ViewConfiguration.0PRESSED_STATE_DURATION for values
-    private const int _shortTap = 125;
     private const int _shortClick = 250;
     private const int _delayTap = 200;
-    private const int _longTap = 500;
 
     /// <summary>
     /// If a finger touches down and up it counts as a tap if the distance between the down and up location is smaller
@@ -232,8 +230,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
 
             var location = GetScreenPosition(e.Location);
 
-            // if user handles action by his own return
-            TouchAction?.Invoke(sender, e);
             if (e.Handled) return;
 
             if (e.ActionType == SKTouchAction.Pressed)
@@ -311,7 +307,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
 
                     // If touch start and end is in the same area and the touch time is shorter
                     // than longTap, than we have a tap.
-                    if (isAround && (_pointerUpTicks - _pointerDownTicks) < (e.DeviceType == SKTouchDeviceType.Mouse ? _shortClick : _longTap) * 10000)
+                    if (isAround)
                     {
                         _waitingForDoubleTap = true;
                         if (UseDoubleTap) { await Task.Delay(_delayTap); }
@@ -333,11 +329,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
                         {
                             _waitingForDoubleTap = false; ;
                         }
-                    }
-                    else if (isAround && (_pointerUpTicks - _pointerDownTicks) >= _longTap * 10000)
-                    {
-                        if (!e.Handled)
-                            e.Handled = OnLongTapped(location);
                     }
                 }
 
@@ -366,8 +357,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
 
                 if (e.InContact && !e.Handled && !_widgetPointerDown)
                     e.Handled = OnTouchMove(_touches.Select(t => t.Value).ToList());
-                else
-                    e.Handled = OnHovered(_touches.Select(t => t.Value).FirstOrDefault());
             }
             else if (e.ActionType == SKTouchAction.Cancelled)
             {
@@ -377,10 +366,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
             else if (e.ActionType == SKTouchAction.Exited && _touches.TryRemove(e.Id, out var exitedTouch))
             {
                 e.Handled = OnTouchExited(_touches.Select(t => t.Value).ToList());
-            }
-            else if (e.ActionType == SKTouchAction.Entered)
-            {
-                e.Handled = OnTouchEntered(_touches.Select(t => t.Value).ToList());
             }
             else if (e.ActionType == SKTouchAction.WheelChanged)
             {
@@ -435,101 +420,20 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     {
         return new MPoint(point.X / PixelDensity, point.Y / PixelDensity);
     }
-
+        
     /// <summary>
-    /// Event handlers
-    /// </summary>
-
-    /// <summary>
-    /// TouchStart is called, when user press a mouse button or touch the display
-    /// </summary>
-    public event EventHandler<TouchedEventArgs>? TouchStarted;
-
-    /// <summary>
-    /// TouchEnd is called, when user release a mouse button or doesn't touch display anymore
-    /// </summary>
-    public event EventHandler<TouchedEventArgs>? TouchEnded;
-
-    /// <summary>
-    /// TouchEntered is called, when user moves an active touch onto the view
-    /// </summary>
-    public event EventHandler<TouchedEventArgs>? TouchEntered;
-
-    /// <summary>
-    /// TouchExited is called, when user moves an active touch off the view
-    /// </summary>
-    public event EventHandler<TouchedEventArgs>? TouchExited;
-
-    /// <summary>
-    /// TouchMove is called, when user move mouse over map (independent from mouse button state) or move finger on display
-    /// </summary>
-    public event EventHandler<TouchedEventArgs>? TouchMove;
-
-    /// <summary>
-    /// TouchAction is called, when user provokes a touch event
-    /// </summary>
-    public event EventHandler<SKTouchEventArgs>? TouchAction;
-
-    /// <summary>
-    /// Hover is called, when user move mouse over map without pressing mouse button
-    /// </summary>
-    public event EventHandler<HoveredEventArgs>? Hovered;
-
-    /// <summary>
-    /// Fling is called, when user release mouse button or lift finger while moving with a certain speed
-    /// </summary>
-    public event EventHandler<SwipedEventArgs>? Fling;
-
-    /// <summary>
-    /// SingleTap is called, when user clicks with a mouse button or tap with a finger on map 
-    /// </summary>
-    public event EventHandler<TappedEventArgs>? SingleTap;
-
-    /// <summary>
-    /// LongTap is called, when user clicks with a mouse button or tap with a finger on map for 500 ms
-    /// </summary>
-    public event EventHandler<TappedEventArgs>? LongTap;
-
-    /// <summary>
-    /// DoubleTap is called, when user clicks with a mouse button or tap with a finger two or more times on map
-    /// </summary>
-    public event EventHandler<TappedEventArgs>? DoubleTap;
-
-    /// <summary>
-    /// Zoom is called, when map should be zoomed
-    /// </summary>
-    public event EventHandler<ZoomedEventArgs>? Zoomed;
-
-    /// <summary>
-    /// Called, when map should zoom in or out
+        /// Called, when map should zoom in or out
     /// </summary>
     /// <param name="currentMousePosition">Center of zoom out event</param>
     private bool OnZoomInOrOut(int mouseWheelDelta, MPoint currentMousePosition)
     {
         var args = new ZoomedEventArgs(currentMousePosition, mouseWheelDelta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
-        Zoomed?.Invoke(this, args);
-
         if (args.Handled)
             return true;
 
         Map.Navigator.MouseWheelZoom(mouseWheelDelta, currentMousePosition);
 
         return true;
-    }
-
-    /// <summary>
-    /// Called, when mouse/finger/pen hovers around
-    /// </summary>
-    /// <param name="screenPosition">Actual position of mouse/finger/pen</param>
-    private bool OnHovered(MPoint? screenPosition)
-    {
-        if (screenPosition == null)
-            return false;
-        var args = new HoveredEventArgs(screenPosition);
-
-        Hovered?.Invoke(this, args);
-
-        return args.Handled;
     }
 
     /// <summary>
@@ -540,11 +444,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     private bool OnFlinged(double velocityX, double velocityY)
     {
         var args = new SwipedEventArgs(velocityX, velocityY);
-
-        Fling?.Invoke(this, args);
-
-        // TODO
-        // Perform standard behavior
 
         if (args.Handled)
             return true;
@@ -565,8 +464,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
             return false;
 
         var args = new TouchedEventArgs(touchPoints);
-
-        TouchStarted?.Invoke(this, args);
 
         if (args.Handled)
             return true;
@@ -595,8 +492,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     {
         var args = new TouchedEventArgs(touchPoints);
 
-        TouchEnded?.Invoke(this, args);
-
         // Last touch released
         if (touchPoints.Count == 0)
         {
@@ -611,26 +506,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     }
 
     /// <summary>
-    /// Called when touch enters map
-    /// </summary>
-    /// <param name="touchPoints">List of all touched points</param>
-    private bool OnTouchEntered(List<MPoint> touchPoints)
-    {
-        // Sanity check
-        if (touchPoints.Count == 0)
-            return false;
-
-        var args = new TouchedEventArgs(touchPoints);
-
-        TouchEntered?.Invoke(this, args);
-
-        if (args.Handled)
-            return true;
-
-        return true;
-    }
-
-    /// <summary>
     /// Called when touch exits map
     /// </summary>
     /// <param name="touchPoints">List of all touched points</param>
@@ -638,8 +513,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     private bool OnTouchExited(List<MPoint> touchPoints)
     {
         var args = new TouchedEventArgs(touchPoints);
-
-        TouchExited?.Invoke(this, args);
 
         // Last touch released
         if (touchPoints.Count == 0)
@@ -658,11 +531,9 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     /// Called, when mouse/finger/pen moves over map
     /// </summary>
     /// <param name="touchPoints">List of all touched points</param>
-    private bool OnTouchMove(List<MPoint> touchPoints)
+    protected virtual bool OnTouchMove(List<MPoint> touchPoints)
     {
         var args = new TouchedEventArgs(touchPoints);
-
-        TouchMove?.Invoke(this, args);
 
         if (args.Handled)
             return true;
@@ -722,11 +593,9 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     /// <param name="screenPosition">First clicked/touched position on screen</param>
     /// <param name="numOfTaps">Number of taps on map (2 is a double click/tap)</param>
     /// <returns>True, if the event is handled</returns>
-    private bool OnDoubleTapped(MPoint screenPosition, int numOfTaps)
+    protected virtual bool OnDoubleTapped(MPoint screenPosition, int numOfTaps)
     {
         var args = new TappedEventArgs(screenPosition, numOfTaps);
-
-        DoubleTap?.Invoke(this, args);
 
         if (args.Handled)
             return true;
@@ -745,11 +614,9 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     /// </summary>
     /// <param name="screenPosition">Clicked/touched position on screen</param>
     /// <returns>True, if the event is handled</returns>
-    private bool OnSingleTapped(MPoint screenPosition)
+    protected virtual bool OnSingleTapped(MPoint screenPosition)
     {
         var args = new TappedEventArgs(screenPosition, 1);
-
-        SingleTap?.Invoke(this, args);
 
         if (args.Handled)
             return true;
@@ -761,20 +628,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
 
         OnInfo(infoToInvoke);
         return infoToInvoke?.Handled ?? false;
-    }
-
-    /// <summary>
-    /// Called, when mouse/finger/pen tapped long on map
-    /// </summary>
-    /// <param name="screenPosition">Clicked/touched position on screen</param>
-    /// <returns>True, if the event is handled</returns>
-    private bool OnLongTapped(MPoint screenPosition)
-    {
-        var args = new TappedEventArgs(screenPosition, 1);
-
-        LongTap?.Invoke(this, args);
-
-        return args.Handled;
     }
 
     private static (MPoint centre, double radius, double angle) GetPinchValues(List<MPoint> locations)

--- a/docfx/documentation/v5.0-upgrade-guide.md
+++ b/docfx/documentation/v5.0-upgrade-guide.md
@@ -1,4 +1,5 @@
 # v5.0 upgrade guide 
 
-## Unsorted list of changes in the order that they were applied.
+## List of changes in the order that they were applied.
 - Removed `RectFeature`. Instead of `new RectFeature(myRect)` use `new GeometryFeature(myRect.ToPolygon())`
+- Removed all events from the MAUI MapControl except for MapInfo. Use gesture recognizers instead.


### PR DESCRIPTION
The touch events could be used by the user to listen to specific events that we detect in our logic of handling the skiasharp touch events.

This is part of the effort make MapControl more similar and to support less and better. We should not block users so it should be possible to react to a touch events and get map info, they may need extra work. Perhaps there should be a GetMapInfo on the Map.

Long press functionality was also removed.