### PR TITLE
Made Avalonia MapControl's Map property DirectProperty

### DIFF
--- a/Mapsui.UI.Avalonia/MapControl.cs
+++ b/Mapsui.UI.Avalonia/MapControl.cs
@@ -46,6 +46,9 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
 
     private bool _shiftPressed;
 
+    public static readonly DirectProperty<MapControl, Map> MapProperty =
+    AvaloniaProperty.RegisterDirect<MapControl, Map>(nameof(Map), o => o.Map, (o, v) => o.Map = v);
+
     public MapControl()
     {
         ClipToBounds = true;

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -436,32 +436,6 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         set => SetValue(MapProperty, value);
     }
 
-#elif __AVALONIA__
-
-    public static readonly StyledProperty<Map> MapProperty =
-        AvaloniaProperty.Register<MapControl, Map>(nameof(Map));
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP004:Don't ignore created IDisposable")]
-    static MapControl()
-    {
-        MapProperty.Changed.AddClassHandler<MapControl>((o, e) =>
-        {
-            if (e.NewValue != null)
-                o.AfterSetMap((Map)e.NewValue);
-        });
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP004:Don't ignore created IDisposable")]
-    public Map Map
-    {
-        get => GetValue(MapProperty);
-        set
-        {
-            BeforeSetMap();
-            SetValue(MapProperty, value);
-        }
-    }
-
 #else
 
     private Map _map = new();

--- a/Samples/Avalonia/Mapsui.Samples.Avalonia/Views/MainView.axaml
+++ b/Samples/Avalonia/Mapsui.Samples.Avalonia/Views/MainView.axaml
@@ -24,7 +24,7 @@
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <avalonia:MapControl Map="{Binding BoundMap}" Grid.Column="1" x:Name="MapControl" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" />
+            <avalonia:MapControl Grid.Column="1" x:Name="MapControl" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" />
             <Border Grid.Row ="0" Grid.Column="0" BorderBrush="White" Opacity="0.65" BorderThickness="6" MinWidth="140"
                     MinHeight="30" HorizontalAlignment="Left">
                 <RelativePanel VerticalAlignment="Stretch" >


### PR DESCRIPTION
Made Avalonia MapControl's Map property direct, because it doesn't need styling and thus we can remove necessity to access it in UI thread only.

Using StyledProperty, as it was made in previous PR requires access to Map property through UI thread and it was not really good idea.
DirectProperty, on the other hand, allows us to use existing Map property without any modifications.
(More details can be found [here](https://docs.avaloniaui.net/docs/guides/custom-controls/how-to-create-advanced-custom-controls))

Removed databinding from sample, because it needs a little bit more advanced DI to use (currently we assign DataContext after construction, but constructor needs ViewModel's Map property to initialize)

