### PR TITLE
Fix: Mapsui.com\Samples 

### DIFF
--- a/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
+++ b/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
@@ -14,7 +14,7 @@
   <!--Release enable all Performance-->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <RunAOTCompilation>true</RunAOTCompilation>
-    <WasmStripILAfterAOT>true</WasmStripILAfterAOT>
+    <!--<WasmStripILAfterAOT>true</WasmStripILAfterAOT>-->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
After the the Aot pull request got https://github.com/Mapsui/Mapsui/pull/2349 in Mapsui.com\Samples stopped working.

Locally it works but not on the Website so as a first step I comment out the ILStripping in the Release Mode of the Blazor Sample.
When it still doesn't work I will disable the AOTCompilation for now.


