### PR TITLE
Fix Mapsui.com/Samples V2

### DIFF
--- a/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
+++ b/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
@@ -13,6 +13,8 @@
 
   <!--Release enable all Performance-->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <WasmStripILAfterAOT>false</WasmStripILAfterAOT>
     <!--<RunAOTCompilation>true</RunAOTCompilation>-->
     <!--<WasmStripILAfterAOT>true</WasmStripILAfterAOT>-->
   </PropertyGroup>

--- a/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
+++ b/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
@@ -13,7 +13,7 @@
 
   <!--Release enable all Performance-->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <RunAOTCompilation>true</RunAOTCompilation>
+    <!--<RunAOTCompilation>true</RunAOTCompilation>-->
     <!--<WasmStripILAfterAOT>true</WasmStripILAfterAOT>-->
   </PropertyGroup>
 


### PR DESCRIPTION
Follow up from https://github.com/Mapsui/Mapsui/pull/2349 (AOT Compilation).
remove runaotCompilation for fixing Maspui.com/samples

I think I have fix the Deployment of Mapsui.com/Samples because locally it works so disabling the AOT Compilation for now