### PR TITLE
Improvement: Simplifying IVectorCache Interface

### DIFF
--- a/Mapsui.Rendering.Skia/Cache/RenderCache.cs
+++ b/Mapsui.Rendering.Skia/Cache/RenderCache.cs
@@ -6,9 +6,9 @@ using SkiaSharp;
 
 namespace Mapsui.Rendering.Skia.Cache;
 
-public sealed class RenderCache : IRenderCache<SKPath, SKPaint>
+public sealed class RenderCache : IRenderCache
 {
-    private IVectorCache<SKPath, SKPaint> _vectorCache;
+    private IVectorCache _vectorCache;
 
     public RenderCache(int capacity = 10000)
     {
@@ -22,19 +22,13 @@ public sealed class RenderCache : IRenderCache<SKPath, SKPaint>
 
     public ISymbolCache SymbolCache { get; set; }
 
-    public IVectorCache<SKPath,SKPaint> VectorCache
+    public IVectorCache VectorCache
     {
         get => _vectorCache;
         set => _vectorCache = value ?? throw new NullReferenceException();
     }
 
     public ITileCache TileCache { get; set; }
-    
-    IVectorCache IRenderCache.VectorCache
-    {
-        get => VectorCache;
-        set => VectorCache = (IVectorCache<SKPath, SKPaint>)value;
-    }
 
     public Size? GetSize(int bitmapId)
     {
@@ -56,20 +50,23 @@ public sealed class RenderCache : IRenderCache<SKPath, SKPaint>
         return LabelCache.GetOrCreateLabel(text, style, opacity, createLabelAsBitmap);
     }
 
-    public CacheTracker<SKPaint> GetOrCreatePaint<TParam>(TParam param, Func<TParam, SKPaint> toPaint)
-        where TParam : notnull
+    public CacheTracker<TPaint> GetOrCreatePaint<TParam, TPaint>(TParam param, Func<TParam, TPaint> toPaint)
+        where TParam : notnull 
+        where TPaint : class
     {
         return VectorCache.GetOrCreatePaint(param, toPaint);
     }
 
-    public CacheTracker<SKPaint> GetOrCreatePaint<TParam>(TParam param, Func<TParam, ISymbolCache, SKPaint> toPaint)
+    public CacheTracker<TPaint> GetOrCreatePaint<TParam, TPaint>(TParam param, Func<TParam, ISymbolCache, TPaint> toPaint)
         where TParam : notnull
+        where TPaint : class
     {
         return VectorCache.GetOrCreatePaint(param, toPaint);
     }
 
-    public CacheTracker<SKPath> GetOrCreatePath<TParam>(TParam param, Func<TParam, SKPath> toSkRect)
+    public CacheTracker<TPath> GetOrCreatePath<TParam, TPath>(TParam param, Func<TParam, TPath> toSkRect)
         where TParam : notnull
+        where TPath : class
     {
         return VectorCache.GetOrCreatePath(param, toSkRect);
     }

--- a/Mapsui.Rendering.Skia/Cache/VectorCache.cs
+++ b/Mapsui.Rendering.Skia/Cache/VectorCache.cs
@@ -4,45 +4,48 @@ using SkiaSharp;
 
 namespace Mapsui.Rendering.Skia.Cache;
 
-public sealed class VectorCache(ISymbolCache symbolCache, int capacity) : IVectorCache<SKPath, SKPaint>
+public sealed class VectorCache(ISymbolCache symbolCache, int capacity) : IVectorCache
 {
-    private readonly LruCache<object, CacheHolder<SKPaint>> _paintCache = new(Math.Min(capacity, 1));
-    private readonly LruCache<object, CacheHolder<SKPath>> _pathParamCache = new(Math.Min(capacity, 1));
+    private readonly LruCache<object, ICacheHolder> _paintCache = new(Math.Min(capacity, 1));
+    private readonly LruCache<object, ICacheHolder> _pathParamCache = new(Math.Min(capacity, 1));
 
-    public CacheTracker<SKPaint> GetOrCreatePaint<TParam>(TParam param, Func<TParam, SKPaint> toPaint)
-        where TParam : notnull
+    public CacheTracker<TPaint> GetOrCreatePaint<TParam, TPaint>(TParam param, Func<TParam, TPaint> toPaint)
+        where TParam : notnull 
+        where TPaint : class
     {
         var holder = _paintCache.GetOrCreateValue(param, f =>
         {
             var paint = toPaint(f);
-            return new CacheHolder<SKPaint>(paint);
+            return new CacheHolder<TPaint>(paint);
         });
 
-        return holder?.Get<SKPaint>() ?? new CacheTracker<SKPaint>(toPaint(param));
+        return holder?.Get<TPaint>() ?? new CacheTracker<TPaint>(toPaint(param));
     }
 
-    public CacheTracker<SKPaint> GetOrCreatePaint<TParam>(TParam param, Func<TParam, ISymbolCache, SKPaint> toPaint)
+    public CacheTracker<TPaint> GetOrCreatePaint<TParam,TPaint>(TParam param, Func<TParam, ISymbolCache, TPaint> toPaint)
         where TParam : notnull
+        where TPaint : class
     {
         var holder = _paintCache.GetOrCreateValue(param, f =>
         {
             var paint = toPaint(f, symbolCache);
-            return new CacheHolder<SKPaint>(paint);
+            return new CacheHolder<TPaint>(paint);
         });
         
-        return holder?.Get<SKPaint>() ?? new CacheTracker<SKPaint>(toPaint(param, symbolCache));
+        return holder?.Get<TPaint>() ?? new CacheTracker<TPaint>(toPaint(param, symbolCache));
     }
 
-    public CacheTracker<SKPath> GetOrCreatePath<TParam>(TParam param, Func<TParam, SKPath> toPath)
+    public CacheTracker<TPath> GetOrCreatePath<TParam, TPath>(TParam param, Func<TParam, TPath> toPath)
         where TParam : notnull
+        where TPath : class
     {
         var holder = _pathParamCache.GetOrCreateValue(param, f =>
         {
             var path = toPath(f);
-            return new CacheHolder<SKPath>(path);
+            return new CacheHolder<TPath>(path);
         });
         
-        return holder?.Get<SKPath>() ?? new CacheTracker<SKPath>(toPath(param));
+        return holder?.Get<TPath>() ?? new CacheTracker<TPath>(toPath(param));
     }
 
     public void Dispose()

--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -26,7 +26,7 @@ namespace Mapsui.Rendering.Skia;
 
 public sealed class MapRenderer : IRenderer, IDisposable
 {
-    private readonly DisposableWrapper<IRenderCache<SKPath, SKPaint>> _renderCache;
+    private readonly DisposableWrapper<IRenderCache> _renderCache;
     private long _currentIteration;
 
     public IRenderCache RenderCache => _renderCache.WrappedObject;
@@ -46,7 +46,7 @@ public sealed class MapRenderer : IRenderer, IDisposable
 
     public MapRenderer(IRenderCache renderer)
     {
-        _renderCache = new DisposableWrapper<IRenderCache<SKPath, SKPaint>>((IRenderCache<SKPath, SKPaint>)renderer, false);
+        _renderCache = new DisposableWrapper<IRenderCache>(renderer, false);
         InitRenderer();
     }
 
@@ -69,7 +69,7 @@ public sealed class MapRenderer : IRenderer, IDisposable
 
     public MapRenderer()
     {
-        _renderCache = new DisposableWrapper<IRenderCache<SKPath, SKPaint>>(new RenderCache(), true);
+        _renderCache = new DisposableWrapper<IRenderCache>(new RenderCache(), true);
         InitRenderer();
     }
 

--- a/Mapsui.Rendering.Skia/SkiaStyles/GeometryCollectionRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/GeometryCollectionRenderer.cs
@@ -17,7 +17,7 @@ public static class GeometryCollectionRenderer
         IFeature feature,
         GeometryCollection collection,
         float opacity,
-        IVectorCache<SKPath, SKPaint> vectorCache)
+        IVectorCache vectorCache)
     {
         SKPath ToPath((GeometryCollection collection, IFeature feature, Viewport viewport, float lineWidth) valueTuple)
         {

--- a/Mapsui.Rendering.Skia/SkiaStyles/LineStringRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/LineStringRenderer.cs
@@ -9,7 +9,7 @@ namespace Mapsui.Rendering.Skia;
 public static class LineStringRenderer
 {
     public static void Draw(SKCanvas canvas, Viewport viewport, VectorStyle? vectorStyle,
-        IFeature feature, LineString lineString, float opacity, IRenderCache<SKPath, SKPaint> renderCache)
+        IFeature feature, LineString lineString, float opacity, IRenderCache renderCache)
     {
         if (vectorStyle == null)
             return;

--- a/Mapsui.Rendering.Skia/SkiaStyles/PolygonRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/PolygonRenderer.cs
@@ -14,7 +14,7 @@ internal static class PolygonRenderer
     private const float _scale = 10.0f;
 
     public static void Draw(SKCanvas canvas, Viewport viewport, VectorStyle vectorStyle, IFeature feature,
-        Polygon polygon, float opacity, IVectorCache<SKPath, SKPaint> vectorCache)
+        Polygon polygon, float opacity, IVectorCache vectorCache)
     {
         SKPath ToPath((long featureId, MRect extent, double rotation, float lineWidth) valueTuple)
         {

--- a/Mapsui.Rendering.Skia/SkiaStyles/SymbolStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/SymbolStyleRenderer.cs
@@ -15,22 +15,21 @@ public class SymbolStyleRenderer : ISkiaStyleRenderer, IFeatureSize
 {
     public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, IStyle style, IRenderCache renderCache, long iteration)
     {
-        var cache = (IRenderCache<SKPath, SKPaint>)renderCache;
         var symbolStyle = (SymbolStyle)style;
         switch (feature)
         {
             case PointFeature pointFeature:
-                DrawXY(canvas, viewport, layer, pointFeature.Point.X, pointFeature.Point.Y, symbolStyle, cache);
+                DrawXY(canvas, viewport, layer, pointFeature.Point.X, pointFeature.Point.Y, symbolStyle, renderCache);
                 break;
             case GeometryFeature geometryFeature:
                 switch (geometryFeature.Geometry)
                 {
                     case GeometryCollection collection:
                         foreach (var point in GetPoints(collection))
-                            DrawXY(canvas, viewport, layer, point.X, point.Y, symbolStyle, cache);
+                            DrawXY(canvas, viewport, layer, point.X, point.Y, symbolStyle, renderCache);
                         break;
                     case Point point:
-                        DrawXY(canvas, viewport, layer, point.X, point.Y, symbolStyle, cache);
+                        DrawXY(canvas, viewport, layer, point.X, point.Y, symbolStyle, renderCache);
                         break;
                 }
                 break;
@@ -54,7 +53,7 @@ public class SymbolStyleRenderer : ISkiaStyleRenderer, IFeatureSize
         }
     }
 
-    public static bool DrawXY(SKCanvas canvas, Viewport viewport, ILayer layer, double x, double y, SymbolStyle symbolStyle, IRenderCache<SKPath,SKPaint> renderCache)
+    public static bool DrawXY(SKCanvas canvas, Viewport viewport, ILayer layer, double x, double y, SymbolStyle symbolStyle, IRenderCache renderCache)
     {
         if (symbolStyle.SymbolType == SymbolType.Image)
         {
@@ -142,7 +141,7 @@ public class SymbolStyleRenderer : ISkiaStyleRenderer, IFeatureSize
         return true;
     }
 
-    private static bool DrawSymbol(SKCanvas canvas, Viewport viewport, ILayer layer, double x, double y, SymbolStyle symbolStyle, IVectorCache<SKPath, SKPaint> vectorCache)
+    private static bool DrawSymbol(SKCanvas canvas, Viewport viewport, ILayer layer, double x, double y, SymbolStyle symbolStyle, IVectorCache vectorCache)
     {
         var opacity = (float)(layer.Opacity * symbolStyle.Opacity);
 

--- a/Mapsui.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
@@ -15,29 +15,28 @@ public class VectorStyleRenderer : ISkiaStyleRenderer, IFeatureSize
     {
         try
         {
-            var cache = (IRenderCache<SKPath, SKPaint>)renderCache;
             var vectorStyle = (VectorStyle)style;
             var opacity = (float)(layer.Opacity * style.Opacity);
 
             switch (feature)
             {
                 case PointFeature pointFeature:
-                    SymbolStyleRenderer.DrawXY(canvas, viewport, layer, pointFeature.Point.X, pointFeature.Point.Y, CreateSymbolStyle(vectorStyle), cache);
+                    SymbolStyleRenderer.DrawXY(canvas, viewport, layer, pointFeature.Point.X, pointFeature.Point.Y, CreateSymbolStyle(vectorStyle), renderCache);
                     break;
                 case GeometryFeature geometryFeature:
                     switch (geometryFeature.Geometry)
                     {
                         case GeometryCollection collection:
-                            GeometryCollectionRenderer.Draw(canvas, viewport, vectorStyle, feature, collection, opacity, cache);
+                            GeometryCollectionRenderer.Draw(canvas, viewport, vectorStyle, feature, collection, opacity, renderCache);
                             break;
                         case Point point:
-                            SymbolStyleRenderer.DrawXY(canvas, viewport, layer, point.X, point.Y, CreateSymbolStyle(vectorStyle), cache);
+                            SymbolStyleRenderer.DrawXY(canvas, viewport, layer, point.X, point.Y, CreateSymbolStyle(vectorStyle), renderCache);
                             break;
                         case Polygon polygon:
-                            PolygonRenderer.Draw(canvas, viewport, vectorStyle, feature, polygon, opacity, cache);
+                            PolygonRenderer.Draw(canvas, viewport, vectorStyle, feature, polygon, opacity, renderCache);
                             break;
                         case LineString lineString:
-                            LineStringRenderer.Draw(canvas, viewport, vectorStyle, feature, lineString, opacity, cache);
+                            LineStringRenderer.Draw(canvas, viewport, vectorStyle, feature, lineString, opacity, renderCache);
                             break;
                         case null:
                             throw new ArgumentException($"Geometry is null, Layer: {layer.Name}");

--- a/Mapsui/Rendering/IRenderCache.cs
+++ b/Mapsui/Rendering/IRenderCache.cs
@@ -12,8 +12,3 @@ public interface IRenderCache : ILabelCache, ISymbolCache, IVectorCache, ITileCa
     ITileCache TileCache { get; set; }
     IVectorCache VectorCache { get; set; }
 }
-
-public interface IRenderCache<TPath, TPaint> : IRenderCache, IVectorCache<TPath, TPaint>
-{
-    new IVectorCache<TPath, TPaint> VectorCache { get; set; }
-}

--- a/Mapsui/Rendering/IVectorCache.cs
+++ b/Mapsui/Rendering/IVectorCache.cs
@@ -6,18 +6,17 @@ namespace Mapsui.Rendering;
 
 public interface IVectorCache : IDisposable
 {
-}
-
-public interface IVectorCache<TPath, TPaint> : IVectorCache
-{
     [return: NotNullIfNotNull(nameof(param))]
-    CacheTracker<TPaint> GetOrCreatePaint<TParam>(TParam param, Func<TParam, TPaint> toPaint)
-        where TParam : notnull;
+    CacheTracker<TPaint> GetOrCreatePaint<TParam, TPaint>(TParam param, Func<TParam, TPaint> toPaint)
+        where TParam : notnull
+        where TPaint : class;
 
     [return: NotNullIfNotNull(nameof(param))]
-    CacheTracker<TPaint> GetOrCreatePaint<TParam>(TParam param, Func<TParam, ISymbolCache, TPaint> toPaint)
-        where TParam : notnull;
+    CacheTracker<TPaint> GetOrCreatePaint<TParam, TPaint>(TParam param, Func<TParam, ISymbolCache, TPaint> toPaint)
+        where TParam : notnull
+        where TPaint : class;
 
-    CacheTracker<TPath> GetOrCreatePath<TParam>(TParam param, Func<TParam, TPath> toPath)
-        where TParam : notnull;
+    CacheTracker<TPath> GetOrCreatePath<TParam, TPath>(TParam param, Func<TParam, TPath> toPath)
+        where TParam : notnull
+        where TPath : class;
 }

--- a/Mapsui/Rendering/NonCachingVectorCache.cs
+++ b/Mapsui/Rendering/NonCachingVectorCache.cs
@@ -4,22 +4,25 @@ namespace Mapsui.Rendering;
 
 public sealed class NonCachingVectorCache(ISymbolCache symbolCache) : IVectorCache
 {
-    public CacheTracker<T> GetOrCreatePaint<T, TParam>(TParam param, Func<TParam, T> toPaint)
-        where TParam: notnull
+    public CacheTracker<TPaint> GetOrCreatePaint<TParam, TPaint>(TParam param, Func<TParam, TPaint> toPaint)
+        where TParam: notnull 
+        where TPaint : class
     {
-        return new CacheTracker<T>(toPaint(param));
+        return new CacheTracker<TPaint>(toPaint(param));
     }
 
-    public CacheTracker<T> GetOrCreatePaint<T, TParam>(TParam param, Func<TParam, ISymbolCache, T> toPaint)
+    public CacheTracker<TPaint> GetOrCreatePaint<TParam, TPaint>(TParam param, Func<TParam, ISymbolCache, TPaint> toPaint)
         where TParam: notnull
+        where TPaint : class
     {
-        return new CacheTracker<T>(toPaint(param, symbolCache));
+        return new CacheTracker<TPaint>(toPaint(param, symbolCache));
     }
 
-    public CacheTracker<T> GetOrCreatePath<T, TParam>(TParam param, Func<TParam, T> toSkRect)
+    public CacheTracker<TPath> GetOrCreatePath<TParam, TPath>(TParam param, Func<TParam, TPath> toSkRect)
         where TParam: notnull
+        where TPath : class
     {
-        return new CacheTracker<T>(toSkRect(param));
+        return new CacheTracker<TPath>(toSkRect(param));
     }
 
     public void Dispose()


### PR DESCRIPTION
I removed the SkPath and SkPaint Type constraints from IVectorCache, because they are not really needed and it simplify things. (Less casts when using VectorCache)
