### PR TITLE
Make _renderer non nullable

### DIFF
--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -1,7 +1,6 @@
 using Mapsui.Extensions;
 using Mapsui.Layers;
 using Mapsui.Logging;
-using Mapsui.Rendering;
 using Mapsui.UI.Utils;
 using Mapsui.Utilities;
 using Microsoft.Maui.ApplicationModel;
@@ -70,7 +69,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
         _initialized = true;
     }
     
-    public IRenderCache RenderCache => _renderer.RenderCache;
     public bool UseDoubleTap { get; set; } = true;
     public bool UseFling { get; set; } = true;
     private double ViewportWidth => Width; // Used in shared code

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -65,6 +65,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     private List<ITouchableWidget>? _touchableWidgets;
     // keeps track of the widgets count to see if i need to recalculate the touchable widgets.
     private int _updateTouchableWidget;
+    private IRenderer _renderer = new MapRenderer();
 
     private void CommonInitialize()
     {
@@ -227,27 +228,11 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     }
 
     public float PixelDensity => (float)GetPixelDensity();
-    
-#pragma warning disable IDISP008
-    private IRenderer? _renderer;
-#pragma warning restore IDISP008
 
     /// <summary>
     /// Renderer that is used from this MapControl
     /// </summary>
-    public IRenderer Renderer
-    {
-        get => _renderer ??= new MapRenderer();
-        set
-        {
-            if (value is null) throw new NullReferenceException(nameof(Renderer));
-            if (_renderer != value)
-            {
-                _renderer = value;
-                OnPropertyChanged();
-            }
-        }
-    }
+    public IRenderer Renderer => _renderer;
 
     /// <summary>
     /// Called whenever the map is clicked. The MapInfoEventArgs contain the features that were hit in
@@ -562,8 +547,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             StopUpdates();
             _invalidateTimer?.Dispose();
             _invalidateTimer = null;
-            _renderer?.Dispose();
-            _renderer = null;
+            _renderer.Dispose();
             _map?.Dispose();
             _map = null;
         }


### PR DESCRIPTION
To fix a warning on the _renderer.RenderCache being nullable, but then it turned out the _renderer.RenderCache property could also be removed.