### PR TITLE
[4.1] Fix MouseOut continues dragging

### DIFF
--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -1,4 +1,3 @@
-using DotNext.Threading.Tasks;
 using Mapsui.Extensions;
 using Mapsui.Logging;
 using Mapsui.Rendering.Skia;

--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -1,3 +1,4 @@
+using DotNext.Threading.Tasks;
 using Mapsui.Extensions;
 using Mapsui.Logging;
 using Mapsui.Rendering.Skia;
@@ -404,4 +405,11 @@ public partial class MapControl : ComponentBase, IMapControl
         _previousTouchState = TouchState.FromLocations(e.TargetTouches.ToLocations(_clientRect));
         RefreshData();
     }
+
+    protected void OnMouseOut(MouseEventArgs e)
+    {
+        _previousMousePosition = null;
+        _pointerDownPosition = null;
+    }
+
 }

--- a/Mapsui.UI.Blazor/MapControlComponent.razor
+++ b/Mapsui.UI.Blazor/MapControlComponent.razor
@@ -5,7 +5,7 @@
      @onmousewheel=@OnMouseWheel @onmousemove=@OnMouseMove 
      @onkeydown=@OnKeyDown @onkeyup=@OnKeyUp @ondblclick="OnDblClick"
      @ontouchstart=@OnTouchStart @ontouchmove=@OnTouchMove @ontouchend=@OnTouchEnd
-     @onwheel="OnMouseWheel"
+     @onwheel="OnMouseWheel" @onmouseout=@OnMouseOut 
      name="@_elementId" id="@_elementId">
 @if (MapControl.UseGPU)
 {


### PR DESCRIPTION
When, while dragging, the mouse goes out of the MapControl area, you lift the mouse button, and hover back over the MapControl again, the map will still be panning. This is because the MouseUp is not detected when the mouse is outside the map. Now we reset the previous position on the MouseOut event.

This type of gesture happens quite a lot when you dragging a long distance.

A better solution would be to use pointer capture, so that you could keep on dragging outside the map, a mouseUp would still be detected when you are out of the map. We have this in other platforms and I like it as a user. 