### PR TITLE
Use ManipulationTracker in WPF and update it for that purpose

### DIFF
--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -189,7 +189,7 @@ public partial class MapControl : ComponentBase, IMapControl
             _ = UpdateBoundingRectAsync();
 
             var location = e.ToLocation(_clientRect);
-            _tapGestureTracker.Start(location);
+            _tapGestureTracker.SetDownPosition(location);
             _manipulationTracker.Restart([]);
 
             if (OnWidgetPointerPressed(location, GetShiftPressed()))
@@ -203,7 +203,7 @@ public partial class MapControl : ComponentBase, IMapControl
         {
             var isHovering = !IsMouseButtonPressed(e);
             var position = e.ToLocation(_clientRect);
-            _tapGestureTracker.Move(position);
+            _tapGestureTracker.SetLastMovePosition(position);
 
             if (OnWidgetPointerMoved(position, !isHovering, GetShiftPressed()))
                 return;
@@ -284,7 +284,7 @@ public partial class MapControl : ComponentBase, IMapControl
             var locations = e.TargetTouches.ToTouchLocations(_clientRect);
             if (OnWidgetPointerPressed(locations[0], GetShiftPressed()))
                 return;
-            _tapGestureTracker.Start(locations[0]);
+            _tapGestureTracker.SetDownPosition(locations[0]);
             _manipulationTracker.Restart(locations);
         });
     }
@@ -294,7 +294,7 @@ public partial class MapControl : ComponentBase, IMapControl
         Catch.Exceptions(() =>
         {
             var locations = e.TargetTouches.ToTouchLocations(_clientRect);
-            _tapGestureTracker.Move(locations[0]);
+            _tapGestureTracker.SetLastMovePosition(locations[0]);
             if (OnWidgetPointerMoved(locations[0], true, GetShiftPressed()))
                 return;
             _manipulationTracker.Manipulate(locations.ToArray(), Map.Navigator.Pinch);

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -18,12 +18,9 @@ namespace Mapsui.UI.Wpf;
 
 public partial class MapControl : Grid, IMapControl, IDisposable
 {
-    private readonly Rectangle _selectRectangle = CreateSelectRectangle();
-    private MPoint? _pointerDownPosition;
-    private MPoint? _previousMousePosition;
     private readonly FlingTracker _flingTracker = new();
-    private MPoint? _currentMousePosition;
     private readonly TapGestureTracker _tapGestureTracker = new();
+    private readonly ManipulationTracker _manipulationTracker = new();
 
     public MapControl()
     {
@@ -36,7 +33,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         };
 
         Children.Add(SkiaCanvas);
-        Children.Add(_selectRectangle);
 
         SkiaCanvas.PaintSurface += SKElementOnPaintSurface;
         Loaded += MapControlLoaded;
@@ -52,6 +48,8 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         ManipulationInertiaStarting += OnManipulationInertiaStarting;
         ManipulationDelta += OnManipulationDelta;
         ManipulationCompleted += OnManipulationCompleted;
+
+        TouchDown += MapControl_TouchDown;
         TouchUp += MapControlTouchUp;
 
         IsManipulationEnabled = true;
@@ -60,33 +58,33 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         RefreshGraphics();
     }
 
-    private static Rectangle CreateSelectRectangle()
+
+    /// <summary>
+    /// The movement allowed between a touch down and touch up in a touch gestures in device independent pixels.
+    /// </summary>
+    public int MaxTapGestureMovement { get; set; } = 8;
+
+    private static Rectangle CreateSelectRectangle() => new()
     {
-        return new Rectangle
-        {
-            Fill = new SolidColorBrush(Colors.Red),
-            Stroke = new SolidColorBrush(Colors.Black),
-            StrokeThickness = 3,
-            RadiusX = 0.5,
-            RadiusY = 0.5,
-            StrokeDashArray = [3.0],
-            Opacity = 0.3,
-            VerticalAlignment = VerticalAlignment.Top,
-            HorizontalAlignment = HorizontalAlignment.Left,
-            Visibility = Visibility.Collapsed
-        };
-    }
+        Fill = new SolidColorBrush(Colors.Red),
+        Stroke = new SolidColorBrush(Colors.Black),
+        StrokeThickness = 3,
+        RadiusX = 0.5,
+        RadiusY = 0.5,
+        StrokeDashArray = [3.0],
+        Opacity = 0.3,
+        VerticalAlignment = VerticalAlignment.Top,
+        HorizontalAlignment = HorizontalAlignment.Left,
+        Visibility = Visibility.Collapsed
+    };
 
     private SKElement SkiaCanvas { get; } = CreateSkiaRenderElement();
 
-    private static SKElement CreateSkiaRenderElement()
+    private static SKElement CreateSkiaRenderElement() => new()
     {
-        return new SKElement
-        {
-            VerticalAlignment = VerticalAlignment.Stretch,
-            HorizontalAlignment = HorizontalAlignment.Stretch
-        };
-    }
+        VerticalAlignment = VerticalAlignment.Stretch,
+        HorizontalAlignment = HorizontalAlignment.Stretch
+    };
 
     internal void InvalidateCanvas()
     {
@@ -96,15 +94,14 @@ public partial class MapControl : Grid, IMapControl, IDisposable
     private void MapControlLoaded(object sender, RoutedEventArgs e)
     {
         SetViewportSize();
-
         Focusable = true;
     }
 
     private void MapControlMouseWheel(object sender, MouseWheelEventArgs e)
     {
         var mouseWheelDelta = e.Delta;
-        _currentMousePosition = e.GetPosition(this).ToMapsui();
-        Map.Navigator.MouseWheelZoom(mouseWheelDelta, _currentMousePosition);
+        var mousePosition = e.GetPosition(this).ToMapsui();
+        Map.Navigator.MouseWheelZoom(mouseWheelDelta, mousePosition);
     }
 
     private void MapControlSizeChanged(object sender, SizeChangedEventArgs e)
@@ -115,58 +112,38 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
     private void MapControlMouseLeave(object sender, MouseEventArgs e)
     {
-        _previousMousePosition = null;
         ReleaseMouseCapture();
     }
 
     private void RunOnUIThread(Action action)
     {
         if (!Dispatcher.CheckAccess())
-        {
             Dispatcher.BeginInvoke(action);
-        }
         else
-        {
             action();
-        }
     }
 
     private void MapControlMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
-        _pointerDownPosition = e.GetPosition(this).ToMapsui();
-
-        if (OnWidgetPointerPressed(_pointerDownPosition, GetShiftPressed()))
+        var mousePosition = e.GetPosition(this).ToMapsui();
+        _tapGestureTracker.SetDownPosition(mousePosition);
+        _manipulationTracker.Restart([mousePosition]);
+        if (OnWidgetPointerPressed(mousePosition, GetShiftPressed()))
             return;
-
-        _previousMousePosition = _pointerDownPosition;
         _flingTracker.Clear();
         CaptureMouse();
-    }
-
-    private static bool IsInBoxZoomMode()
-    {
-        return Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl);
     }
 
     private void MapControlMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
         var position = e.GetPosition(this).ToMapsui();
 
-        if (_previousMousePosition != null)
+        _tapGestureTracker.IfTap((p) =>
         {
-            if (IsInBoxZoomMode())
-            {
-                var previous = Map.Navigator.Viewport.ScreenToWorld(_previousMousePosition.X, _previousMousePosition.Y);
-                var current = Map.Navigator.Viewport.ScreenToWorld(position.X, position.Y);
-                ZoomToBox(previous, current);
-            }
-            else if (IsTap(position, _pointerDownPosition))
-            {
-                if (OnWidgetTapped(position, e.ClickCount, GetShiftPressed()))
-                    return;
-                OnInfo(CreateMapInfoEventArgs(position, position, e.ClickCount));
-            }
-        }
+            if (OnWidgetTapped(p, 1, GetShiftPressed()))
+                return;
+            OnInfo(CreateMapInfoEventArgs(p, p, 1));
+        }, MaxTapGestureMovement * PixelDensity, position);
 
         RefreshData();
 
@@ -183,27 +160,24 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         }
         _flingTracker.RemoveId(1);
 
-        _previousMousePosition = new MPoint();
         ReleaseMouseCapture();
     }
 
-    private static bool IsTap(MPoint currentPosition, MPoint? previousPosition)
+    private void MapControl_TouchDown(object? sender, TouchEventArgs e)
     {
-        if (previousPosition is null)
-            return false;
-
-        return
-            Math.Abs(currentPosition.X - previousPosition.X) < SystemParameters.MinimumHorizontalDragDistance &&
-            Math.Abs(currentPosition.Y - previousPosition.Y) < SystemParameters.MinimumVerticalDragDistance;
+        var touchDownPosition = e.GetTouchPoint(this).Position.ToMapsui();
+        _tapGestureTracker.SetDownPosition(touchDownPosition);
     }
 
     private void MapControlTouchUp(object? sender, TouchEventArgs e)
     {
-        var touchPosition = e.GetTouchPoint(this).Position.ToMapsui();
-        if (IsTap(touchPosition, _pointerDownPosition))
+        var touchUpPosition = e.GetTouchPoint(this).Position.ToMapsui();
+        _tapGestureTracker.IfTap((p) =>
         {
-            OnInfo(CreateMapInfoEventArgs(touchPosition, touchPosition, 1));
-        }
+            if (OnWidgetTapped(p, 1, GetShiftPressed()))
+                return;
+            OnInfo(CreateMapInfoEventArgs(p, p, 1));
+        }, MaxTapGestureMovement * PixelDensity, touchUpPosition);
     }
 
     public void OpenInBrowser(string url)
@@ -222,70 +196,13 @@ public partial class MapControl : Grid, IMapControl, IDisposable
     private void MapControlMouseMove(object sender, MouseEventArgs e)
     {
         var isHovering = IsHovering(e);
-        if (OnWidgetPointerMoved(e.GetPosition(this).ToMapsui(), !isHovering, GetShiftPressed()))
+        var mousePosition = e.GetPosition(this).ToMapsui();
+        if (OnWidgetPointerMoved(mousePosition, !isHovering, GetShiftPressed()))
             return;
-
-        if (IsInBoxZoomMode() && !isHovering)
-        {
-            DrawRectangle(e.GetPosition(this));
+        if (isHovering)
             return;
-        }
-
-        _currentMousePosition = e.GetPosition(this).ToMapsui();
-
-        if (!isHovering)
-        {
-            if (_previousMousePosition == null)
-            {
-                // Usually MapControlMouseLeftButton down initializes _previousMousePosition but in some
-                // situations it can be null. So far I could only reproduce this in debug mode when putting
-                // a breakpoint and continuing.
-                return;
-            }
-
-            _flingTracker.AddEvent(1, _currentMousePosition, DateTime.Now.Ticks);
-            Map.Navigator.Drag(_currentMousePosition, _previousMousePosition);
-            _previousMousePosition = _currentMousePosition;
-        }
-    }
-
-    public void ZoomToBox(MPoint beginPoint, MPoint endPoint)
-    {
-        var box = new MRect(beginPoint.X, beginPoint.Y, endPoint.X, endPoint.Y);
-        Map.Navigator.ZoomToBox(box, duration: 300); ;
-        ClearBBoxDrawing();
-    }
-
-    private void ClearBBoxDrawing()
-    {
-        RunOnUIThread(() => _selectRectangle.Visibility = Visibility.Collapsed);
-    }
-
-    private void DrawRectangle(Point screenPosition)
-    {
-        if (_previousMousePosition == null) return; // can happen during debug
-
-        var from = _previousMousePosition;
-        var to = screenPosition;
-
-        if (from.X > to.X)
-        {
-            var temp = from;
-            from.X = to.X;
-            to.X = temp.X;
-        }
-
-        if (from.Y > to.Y)
-        {
-            var temp = from;
-            from.Y = to.Y;
-            to.Y = temp.Y;
-        }
-
-        _selectRectangle.Width = to.X - from.X;
-        _selectRectangle.Height = to.Y - from.Y;
-        _selectRectangle.Margin = new Thickness(from.X, from.Y, 0, 0);
-        _selectRectangle.Visibility = Visibility.Visible;
+        _flingTracker.AddEvent(1, mousePosition, DateTime.Now.Ticks);
+        _manipulationTracker.Manipulate([mousePosition], Map.Navigator.Pinch);
     }
 
     private double ViewportWidth => ActualWidth;
@@ -322,20 +239,14 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         return deltaScale;
     }
 
-    private void OnManipulationCompleted(object? sender, ManipulationCompletedEventArgs e)
-    {
-        Refresh();
-    }
+    private void OnManipulationCompleted(object? sender, ManipulationCompletedEventArgs e) => Refresh();
 
     private void SKElementOnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
     {
         if (PixelDensity <= 0)
             return;
-
         var canvas = args.Surface.Canvas;
-
         canvas.Scale(PixelDensity, PixelDensity);
-
         CommonDrawControl(canvas);
     }
 

--- a/Mapsui/Manipulations/TapGestureTracker.cs
+++ b/Mapsui/Manipulations/TapGestureTracker.cs
@@ -9,24 +9,50 @@ public class TapGestureTracker
     private MPoint? _tapStartPosition;
     private MPoint? _tapEndPosition;
 
+    public void IfTap(Action<MPoint> onTap, double maxTapDistance, MPoint tapEndPosition)
+    {
+        if (_tapStartPosition == null) return;
+        if (tapEndPosition == null) return; // Note, this uses the tapEndPosition parameter.
+
+        IfTap(onTap, maxTapDistance, _tapStartPosition, tapEndPosition);
+    }
+
+    /// <summary>
+    /// Use this method in Blazor or other platforms where the mouse up position is unknown. Use this in combination 
+    /// with SetLastMovePosition.
+    /// </summary>
+    /// <param name="onTap"></param>
+    /// <param name="maxTapDistance"></param>
     public void IfTap(Action<MPoint> onTap, double maxTapDistance)
     {
         if (_tapStartPosition == null) return;
-        if (_tapEndPosition == null) return;
+        if (_tapEndPosition == null) return; // Note, this uses the _tapEndPosition field.
 
-        var duration = (DateTime.Now - _tapStartTime).TotalSeconds;
-        var distance = _tapEndPosition.Distance(_tapStartPosition);
-        var isTap = duration < _maxTapDuration && distance < maxTapDistance;
-
-        if (isTap) onTap(_tapEndPosition);
+        IfTap(onTap, maxTapDistance, _tapStartPosition, _tapEndPosition);
     }
 
-    public void Move(MPoint position)
+    private void IfTap(Action<MPoint> onTap, double maxTapDistance, MPoint tapStartPosition, MPoint tapEndPosition)
+    {
+        if (tapStartPosition == null) return;
+        if (tapEndPosition == null) return;
+
+        var duration = (DateTime.Now - _tapStartTime).TotalSeconds;
+        var distance = tapEndPosition.Distance(tapStartPosition);
+        var isTap = duration < _maxTapDuration && distance < maxTapDistance;
+
+        if (isTap) onTap(tapEndPosition);
+    }
+
+    /// <summary>
+    /// Call this method during move if the platform does not provide the mouse up position.
+    /// </summary>
+    /// <param name="position"></param>
+    public void SetLastMovePosition(MPoint position)
     {
         _tapEndPosition = position;
     }
 
-    public void Start(MPoint position)
+    public void SetDownPosition(MPoint position)
     {
         _tapStartTime = DateTime.Now;
         _tapStartPosition = position;


### PR DESCRIPTION
Done:
- Delete te ZoomToBox functionality. We need to replace it with a widget.
- Removed use of Navigator.Drag which need to keep track of the previous positions (there three of these fields, now we only use the trackers.
- Update the ManipulationTracker for use in WPF (Blazor is the exceptional case because it has now touch up location.

