### PR TITLE
Make FlingTracker more similar to the other trackers and move it to the same folder

### DIFF
--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -1,7 +1,6 @@
 using Mapsui.Extensions;
 using Mapsui.Logging;
 using Mapsui.Manipulations;
-using Mapsui.UI.Utils;
 using Mapsui.Utilities;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -232,7 +232,8 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
                 // Delete e.Id from _touches, because finger is released
                 _touches.Remove(e.Id, out var releasedTouch);
 
-                FlingIfNeeded(e);
+                if (UseFling)
+                    _flingTracker.IfFling(e.Id, (vX, vY) => Map.Navigator.Fling(vX, vY, 1000));
                 _flingTracker.RemoveId(e.Id);
 
                 if (IsTap(releasedTouch, _downLocation))
@@ -268,26 +269,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
                 OnZoomInOrOut(e.WheelDelta, location);
             }
         });
-    }
-
-    private void FlingIfNeeded(SKTouchEventArgs e)
-    {
-        if (!_touches.IsEmpty)
-            return;
-
-        if (!UseFling)
-            return;
-
-        double velocityX;
-        double velocityY;
-
-        (velocityX, velocityY) = _flingTracker.CalcVelocity(e.Id, DateTime.Now.Ticks);
-
-        if (Math.Abs(velocityX) <= 200 && Math.Abs(velocityY) <= 200)
-            return;
-
-        // This was the last finger on screen, so this is a fling
-        Map.Navigator.Fling(velocityX, velocityY, 1000);
     }
 
     private bool IsTap(MPoint? releasePosition, MPoint? pressedPosition)

--- a/Mapsui.UI.Shared/Mapsui.UI.Shared.projitems
+++ b/Mapsui.UI.Shared/Mapsui.UI.Shared.projitems
@@ -10,6 +10,5 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)MapControl.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Utils\FlingTracker.cs" />
   </ItemGroup>
 </Project>

--- a/Mapsui.UI.Shared/Utils/FlingTracker.cs
+++ b/Mapsui.UI.Shared/Utils/FlingTracker.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable IDE0005
+using System;
 using System.Collections.Generic;
 
 namespace Mapsui.UI.Utils;
@@ -79,5 +80,15 @@ public class FlingTracker
         var totalTime = finalTime - firstTime;
 
         return (distanceX / totalTime, distanceY / totalTime);
+    }
+
+    public void IfFling(long eventId, Action<double, double> onFling)
+    {
+        var (velocityX, velocityY) = CalcVelocity(eventId, DateTime.Now.Ticks);
+
+        if (Math.Abs(velocityX) <= 200 && Math.Abs(velocityY) <= 200)
+            return;
+
+        onFling(velocityX, velocityY);
     }
 }

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -147,17 +147,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
         RefreshData();
 
-        double velocityX;
-        double velocityY;
-
-        (velocityX, velocityY) = _flingTracker.CalcVelocity(1, DateTime.Now.Ticks);
-
-        if (Math.Abs(velocityX) > 200 || Math.Abs(velocityY) > 200)
-        {
-            // This was the last finger on screen, so this is a fling
-            Map.Navigator.Fling(velocityX, velocityY, 1000);
-            e.Handled = true;
-        }
+        _flingTracker.IfFling(1, (vX, vY) => Map.Navigator.Fling(vX, vY, 1000));
         _flingTracker.RemoveId(1);
 
         ReleaseMouseCapture();

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -1,6 +1,5 @@
 using Mapsui.Extensions;
 using Mapsui.Manipulations;
-using Mapsui.UI.Utils;
 using Mapsui.UI.Wpf.Extensions;
 using Mapsui.Utilities;
 using SkiaSharp.Views.Desktop;

--- a/Mapsui/Manipulations/FlingTracker.cs
+++ b/Mapsui/Manipulations/FlingTracker.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Mapsui.UI.Utils;
+namespace Mapsui.Manipulations;
 
 public class FlingTracker
 {
@@ -30,7 +30,7 @@ public class FlingTracker
         // Check, if we at the end of array
         if (value.Count > 2)
         {
-            while (value.Count > _maxSize || value.Peek().time < (ticks - _maxTicks))
+            while (value.Count > _maxSize || value.Peek().time < ticks - _maxTicks)
                 value.Dequeue();
         }
     }


### PR DESCRIPTION
Making the FlingTracker similar to the other trackers is another logic step that follows from the previous steps. It is now clear that the trackers are the way to go forward. We should remove all other state tracking fields in the MapControls.

Next:
- A closer look at the trackers, make them even more similar, improve naming, perhaps improve the structure.
- Remove Drag from Eto and use ManipulationTracker there too.
- There is a lot of similar code in all the events now (like what to do an a tap event). More could be moves to the shared MapControl (like an OnTapped) event. 
- Remove remaining state holding fields left in the MapControls (like _isMouseDown, _mouseDownPosition, _previousMouseDownPosition) 
- Add a new ZoomToBoxWidget.
- Use TapGestureTracker in Eto.
- Use TapGestureTracker in MAUI.
- Go over all similarties and differences and make the MapControls even more similar
