### PR TITLE
Cleanup MapInfo

### DIFF
--- a/Mapsui.Nts/Editing/EditManager.cs
+++ b/Mapsui.Nts/Editing/EditManager.cs
@@ -71,11 +71,11 @@ public class EditManager
         return false;
     }
 
-    public void HoveringVertex(MapInfo? mapInfo)
+    public void HoveringVertex(MapInfo mapInfo)
     {
         if (_addInfo.Vertex != null)
         {
-            _addInfo.Vertex.SetXY(mapInfo?.WorldPosition);
+            _addInfo.Vertex.SetXY(mapInfo.WorldPosition);
             _addInfo.Feature?.Modified();
             Layer?.DataHasChanged();
         }
@@ -262,14 +262,14 @@ public class EditManager
         }
     }
 
-    public bool TryDeleteCoordinate(MapInfo? mapInfo, double screenDistance)
+    public bool TryDeleteCoordinate(MapInfo mapInfo, double screenDistance)
     {
-        if (mapInfo?.Feature is GeometryFeature geometryFeature)
+        if (mapInfo.Feature is GeometryFeature geometryFeature)
         {
-            var vertexTouched = FindVertexTouched(mapInfo, geometryFeature.Geometry?.MainCoordinates() ?? new List<Coordinate>(), screenDistance);
+            var vertexTouched = FindVertexTouched(mapInfo, geometryFeature.Geometry?.MainCoordinates() ?? [], screenDistance);
             if (vertexTouched != null)
             {
-                var vertices = geometryFeature.Geometry?.MainCoordinates() ?? new List<Coordinate>();
+                var vertices = geometryFeature.Geometry?.MainCoordinates() ?? [];
                 var index = vertices.IndexOf(vertexTouched);
                 if (index >= 0)
                 {
@@ -283,10 +283,8 @@ public class EditManager
         return false;
     }
 
-    public bool TryInsertCoordinate(MapInfo? mapInfo)
+    public bool TryInsertCoordinate(MapInfo mapInfo)
     {
-        if (mapInfo?.WorldPosition is null) return false;
-
         if (mapInfo.Feature is GeometryFeature geometryFeature)
         {
             if (geometryFeature.Geometry is null) return false;

--- a/Mapsui.Nts/Editing/EditManipulation.cs
+++ b/Mapsui.Nts/Editing/EditManipulation.cs
@@ -12,11 +12,11 @@ public static class EditManipulation
         // Take into account VertexRadius in feature select, because the objective
         // is to select the vertex.
         var mapInfo = mapControl.GetMapInfo(screenPosition, editManager.VertexRadius);
-        if (editManager.EditMode == EditMode.Modify && mapInfo?.Feature != null)
+        if (editManager.EditMode == EditMode.Modify && mapInfo.Feature != null)
             return editManager.StartDragging(mapInfo, editManager.VertexRadius);
-        if (editManager.EditMode == EditMode.Rotate && mapInfo?.Feature != null)
+        if (editManager.EditMode == EditMode.Rotate && mapInfo.Feature != null)
             return editManager.StartRotating(mapInfo);
-        if (editManager.EditMode == EditMode.Scale && mapInfo?.Feature != null)
+        if (editManager.EditMode == EditMode.Scale && mapInfo.Feature != null)
             return editManager.StartScaling(mapInfo);
         return false;
     }
@@ -88,11 +88,11 @@ public static class EditManipulation
 
         if (editManager.SelectMode)
         {
-            var infoArgs = mapControl.GetMapInfo(screenPosition);
-            if (infoArgs?.Feature != null)
+            var mapInfo = mapControl.GetMapInfo(screenPosition);
+            if (mapInfo.Feature != null)
             {
-                var currentValue = (bool?)infoArgs.Feature["Selected"] == true;
-                infoArgs.Feature["Selected"] = !currentValue; // invert current value
+                var currentValue = (bool?)mapInfo.Feature["Selected"] == true;
+                mapInfo.Feature["Selected"] = !currentValue; // invert current value
             }
         }
 

--- a/Mapsui.Nts/Layers/VertexOnlyLayer.cs
+++ b/Mapsui.Nts/Layers/VertexOnlyLayer.cs
@@ -18,7 +18,7 @@ public class VertexOnlyLayer : BaseLayer
     {
         Source = source;
         Source.DataChanged += (_, args) => OnDataChanged(args);
-        Style = new SymbolStyle { SymbolScale = 0.7 };
+        Style = new SymbolStyle { SymbolScale = 0.5 };
     }
 
     public FeatureKeyCreator<(long, int)> FeatureKeyCreator

--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -203,10 +203,10 @@ public sealed class MapRenderer : IRenderer, IDisposable
         WidgetRenderer.Render(canvas, viewport, widgets, WidgetRenders, layerOpacity);
     }
 
-    public MapInfo? GetMapInfo(double x, double y, Viewport viewport, IEnumerable<ILayer> layers, int margin = 0)
+    public MapInfo GetMapInfo(double x, double y, Viewport viewport, IEnumerable<ILayer> layers, int margin = 0)
     {
-        // todo: use margin to increase the pixel area
-        // todo: We will need to select on style instead of layer
+        // Todo: Use margin to increase the pixel area
+        // Todo: Select on style instead of layer
 
         var mapInfoLayers = layers
             .Select(l => l is ISourceLayer sl and not ILayerFeatureInfo ? sl.SourceLayer : l)
@@ -235,7 +235,11 @@ public sealed class MapRenderer : IRenderer, IDisposable
 
             using (var surface = SKSurface.Create(imageInfo))
             {
-                if (surface == null) return null;
+                if (surface == null)
+                {
+                    Logger.Log(LogLevel.Error, "SKSurface is null while getting MapInfo.  This is not expected.");
+                    return result;
+                }
 
                 surface.Canvas.ClipRect(new SKRect((float)(x - 1), (float)(y - 1), (float)(x + 1), (float)(y + 1)));
                 surface.Canvas.Clear(SKColors.Transparent);
@@ -254,7 +258,7 @@ public sealed class MapRenderer : IRenderer, IDisposable
                             try
                             {
                                 // creating new list to avoid multithreading problems
-                                mapList = new List<MapInfoRecord>();
+                                mapList = [];
                                 // get information from ILayer Feature Info
                                 var features = await layerFeatureInfo.GetFeatureInfoAsync(viewport, x, y);
                                 foreach (var it in features)
@@ -277,7 +281,7 @@ public sealed class MapRenderer : IRenderer, IDisposable
                     else
                     {
                         // get information from ILayer
-                        VisibleFeatureIterator.IterateLayers(viewport, new[] { infoLayer }, 0,
+                        VisibleFeatureIterator.IterateLayers(viewport, [infoLayer], 0,
                             (v, layer, style, feature, opacity, iteration) =>
                             {
                                 try

--- a/Mapsui.UI.MapView/EventArgs/CalloutClickedEventArgs.cs
+++ b/Mapsui.UI.MapView/EventArgs/CalloutClickedEventArgs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Mapsui.Manipulations;
 using Microsoft.Maui.Graphics;
 
 namespace Mapsui.UI.Maui;
@@ -23,7 +24,7 @@ public sealed class CalloutClickedEventArgs : EventArgs
     /// <summary>
     /// Number of taps
     /// </summary>
-    public int NumOfTaps { get; }
+    public TapType TapType { get; }
 
     /// <summary>
     /// Flag, if this event was handled
@@ -31,11 +32,11 @@ public sealed class CalloutClickedEventArgs : EventArgs
     /// <value><c>true</c> if handled; otherwise, <c>false</c>.</value>
     public bool Handled { get; set; } = false;
 
-    internal CalloutClickedEventArgs(Callout? callout, Position point, Point screenPoint, int numOfTaps)
+    internal CalloutClickedEventArgs(Callout? callout, Position point, Point screenPoint, TapType tapType)
     {
         Callout = callout;
         Point = point;
         ScreenPoint = screenPoint;
-        NumOfTaps = numOfTaps;
+        TapType = tapType;
     }
 }

--- a/Mapsui.UI.MapView/EventArgs/DrawableClickedEventArgs.cs
+++ b/Mapsui.UI.MapView/EventArgs/DrawableClickedEventArgs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Mapsui.Manipulations;
 using Microsoft.Maui.Graphics;
 
 namespace Mapsui.UI.Maui;
@@ -18,7 +19,7 @@ public sealed class DrawableClickedEventArgs : EventArgs
     /// <summary>
     /// Number of taps
     /// </summary>
-    public int NumOfTaps { get; }
+    public TapType TapType { get; }
 
     /// <summary>
     /// Flag, if this event was handled
@@ -26,10 +27,10 @@ public sealed class DrawableClickedEventArgs : EventArgs
     /// <value><c>true</c> if handled; otherwise, <c>false</c>.</value>
     public bool Handled { get; set; } = false;
 
-    internal DrawableClickedEventArgs(Position point, Point screenPoint, int numOfTaps)
+    internal DrawableClickedEventArgs(Position point, Point screenPoint, TapType tapType)
     {
         Point = point;
         ScreenPoint = screenPoint;
-        NumOfTaps = numOfTaps;
+        TapType = tapType;
     }
 }

--- a/Mapsui.UI.MapView/EventArgs/MapClickedEventArgs.cs
+++ b/Mapsui.UI.MapView/EventArgs/MapClickedEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Mapsui.Manipulations;
+using System;
 
 namespace Mapsui.UI.Maui;
 
@@ -12,7 +13,7 @@ public sealed class MapClickedEventArgs : EventArgs
     /// <summary>
     /// Number of taps
     /// </summary>
-    public int NumOfTaps { get; }
+    public TapType TapType { get; }
 
     /// <summary>
     /// Flag, if this event was handled
@@ -20,9 +21,9 @@ public sealed class MapClickedEventArgs : EventArgs
     /// <value><c>true</c> if handled; otherwise, <c>false</c>.</value>
     public bool Handled { get; set; } = false;
 
-    public MapClickedEventArgs(Position point, int numOfTaps)
+    public MapClickedEventArgs(Position point, TapType tapType)
     {
         Point = point;
-        NumOfTaps = numOfTaps;
+        TapType = tapType;
     }
 }

--- a/Mapsui.UI.MapView/EventArgs/PinClickedEventArgs.cs
+++ b/Mapsui.UI.MapView/EventArgs/PinClickedEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Mapsui.Manipulations;
+using System;
 
 namespace Mapsui.UI.Maui;
 
@@ -17,7 +18,7 @@ public sealed class PinClickedEventArgs : EventArgs
     /// <summary>
     /// Number of taps
     /// </summary>
-    public int NumOfTaps { get; }
+    public TapType TapType { get; }
 
     /// <summary>
     /// Flag, if this event was handled
@@ -25,10 +26,10 @@ public sealed class PinClickedEventArgs : EventArgs
     /// <value><c>true</c> if handled; otherwise, <c>false</c>.</value>
     public bool Handled { get; set; } = false;
 
-    internal PinClickedEventArgs(Pin pin, Position point, int numOfTaps)
+    internal PinClickedEventArgs(Pin pin, Position point, TapType tapType)
     {
         Pin = pin;
         Point = point;
-        NumOfTaps = numOfTaps;
+        TapType = tapType;
     }
 }

--- a/Mapsui.UI.MapView/EventArgs/TappedEventArgs.cs
+++ b/Mapsui.UI.MapView/EventArgs/TappedEventArgs.cs
@@ -6,12 +6,12 @@ namespace Mapsui.UI;
 public class TappedEventArgs : EventArgs
 {
     public ScreenPosition ScreenPosition { get; }
-    public int NumOfTaps { get; }
+    public TapType TapType { get; }
     public bool Handled { get; set; } = false;
 
-    public TappedEventArgs(ScreenPosition screenPosition, int numOfTaps)
+    public TappedEventArgs(ScreenPosition screenPosition, TapType tapType)
     {
         ScreenPosition = screenPosition;
-        NumOfTaps = numOfTaps;
+        TapType = tapType;
     }
 }

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -663,7 +663,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             // Check if we hit a drawable/pin/callout etc
             var mapInfo = GetMapInfo(e.ScreenPosition);
 
-            var mapInfoEventArgs = new MapInfoEventArgs { MapInfo = mapInfo, Handled = e.Handled, TapType = e.NumOfTaps };
+            var mapInfoEventArgs = new MapInfoEventArgs { MapInfo = mapInfo, Handled = e.Handled, TapType = e.TapType };
 
             HandlerInfo(mapInfoEventArgs);
 
@@ -672,7 +672,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             if (!e.Handled)
             {
                 // if nothing else was hit, then we hit the map
-                var args = new MapClickedEventArgs(Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToNative(), e.NumOfTaps);
+                var args = new MapClickedEventArgs(Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToNative(), e.TapType);
                 MapClicked?.Invoke(this, args);
 
                 if (args.Handled)
@@ -846,7 +846,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
     protected override void OnSingleTapped(ScreenPosition screenPosition)
     {
-        HandlerTap(new TappedEventArgs(screenPosition, 1));
+        HandlerTap(new TappedEventArgs(screenPosition, TapType.Single));
         base.OnSingleTapped(screenPosition);
     }
 }

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -593,9 +593,6 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
                 }
             }
 
-            if (e.MapInfo!.ScreenPosition == null)
-                return;
-
             var calloutArgs = new CalloutClickedEventArgs(clickedCallout,
                 Map.Navigator.Viewport.ScreenToWorld(e.MapInfo!.ScreenPosition).ToNative(),
                 new Point(e.MapInfo.ScreenPosition.X, e.MapInfo.ScreenPosition.Y), e.TapType);
@@ -610,9 +607,6 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         else if (e.MapInfo?.Layer == _mapDrawableLayer)
         {
             var drawables = _drawables.ToList();
-
-            if (e.MapInfo!.ScreenPosition == null)
-                return;
 
             foreach (var rec in e.MapInfo.MapInfoRecords)
             {
@@ -639,9 +633,6 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         // Check for clicked myLocation
         else if (e.MapInfo?.Layer == MyLocationLayer)
         {
-            if (e.MapInfo!.ScreenPosition == null)
-                return;
-
             var args = new DrawableClickedEventArgs(
                 Map.Navigator.Viewport.ScreenToWorld(e.MapInfo!.ScreenPosition).ToNative(),
                 new Point(e.MapInfo.ScreenPosition.X, e.MapInfo.ScreenPosition.Y), e.TapType);

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -663,7 +663,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             // Check if we hit a drawable/pin/callout etc
             var mapInfo = GetMapInfo(e.ScreenPosition);
 
-            var mapInfoEventArgs = new MapInfoEventArgs { MapInfo = mapInfo, Handled = e.Handled, TapType = e.TapType };
+            var mapInfoEventArgs = new MapInfoEventArgs(mapInfo, e.TapType, e.Handled);
 
             HandlerInfo(mapInfoEventArgs);
 
@@ -844,9 +844,8 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         HideCallouts();
     }
 
-    protected override void OnSingleTapped(ScreenPosition screenPosition)
+    private void OnTapped(ScreenPosition screenPosition)
     {
-        HandlerTap(new TappedEventArgs(screenPosition, TapType.Single));
-        base.OnSingleTapped(screenPosition);
+        // Todo: Implement to test simple scenarios.
     }
 }

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -567,7 +567,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
                 if (e.MapInfo?.ScreenPosition is null)
                     return;
 
-                var pinArgs = new PinClickedEventArgs(clickedPin, Map.Navigator.Viewport.ScreenToWorld(e.MapInfo!.ScreenPosition).ToNative(), e.NumTaps);
+                var pinArgs = new PinClickedEventArgs(clickedPin, Map.Navigator.Viewport.ScreenToWorld(e.MapInfo!.ScreenPosition).ToNative(), e.TapType);
 
                 PinClicked?.Invoke(this, pinArgs);
 
@@ -598,7 +598,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
             var calloutArgs = new CalloutClickedEventArgs(clickedCallout,
                 Map.Navigator.Viewport.ScreenToWorld(e.MapInfo!.ScreenPosition).ToNative(),
-                new Point(e.MapInfo.ScreenPosition.X, e.MapInfo.ScreenPosition.Y), e.NumTaps);
+                new Point(e.MapInfo.ScreenPosition.X, e.MapInfo.ScreenPosition.Y), e.TapType);
 
             clickedCallout?.HandleCalloutClicked(this, calloutArgs);
 
@@ -624,7 +624,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
                     {
                         var drawableArgs = new DrawableClickedEventArgs(
                             Map.Navigator.Viewport.ScreenToWorld(e.MapInfo!.ScreenPosition).ToNative(),
-                            new Point(e.MapInfo.ScreenPosition.X, e.MapInfo.ScreenPosition.Y), e.NumTaps);
+                            new Point(e.MapInfo.ScreenPosition.X, e.MapInfo.ScreenPosition.Y), e.TapType);
 
                         drawable?.HandleClicked(drawableArgs);
 
@@ -644,7 +644,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
             var args = new DrawableClickedEventArgs(
                 Map.Navigator.Viewport.ScreenToWorld(e.MapInfo!.ScreenPosition).ToNative(),
-                new Point(e.MapInfo.ScreenPosition.X, e.MapInfo.ScreenPosition.Y), e.NumTaps);
+                new Point(e.MapInfo.ScreenPosition.X, e.MapInfo.ScreenPosition.Y), e.TapType);
 
             MyLocationLayer?.HandleClicked(args);
 
@@ -663,7 +663,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             // Check if we hit a drawable/pin/callout etc
             var mapInfo = GetMapInfo(e.ScreenPosition);
 
-            var mapInfoEventArgs = new MapInfoEventArgs { MapInfo = mapInfo, Handled = e.Handled, NumTaps = e.NumOfTaps };
+            var mapInfoEventArgs = new MapInfoEventArgs { MapInfo = mapInfo, Handled = e.Handled, TapType = e.NumOfTaps };
 
             HandlerInfo(mapInfoEventArgs);
 

--- a/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
@@ -314,6 +314,7 @@ public class MyLocationLayer : BaseLayer
     /// </summary>
     /// <param name="newDirection">New direction</param>
     /// <param name="newViewportRotation">New viewport rotation</param>
+    /// <param name="animated">true if animated</param>
     public void UpdateMyDirection(double newDirection, double newViewportRotation, bool animated = false)
     {
         var newRotation = (int)(newDirection - newViewportRotation);

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -288,7 +288,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     /// <returns>True, if the event is handled</returns>
     protected virtual void OnSingleTapped(ScreenPosition screenPosition)
     {
-        OnInfo(CreateMapInfoEventArgs(screenPosition, screenPosition, 1));
+        OnInfo(CreateMapInfoEventArgs(screenPosition, screenPosition, TapType.Single));
     }
 
     /// <summary>

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -272,26 +272,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
         => Map.Navigator.MouseWheelZoom(mouseWheelDelta, currentMousePosition);
 
     /// <summary>
-    /// Called, when mouse/finger/pen tapped on map 2 or more times
-    /// </summary>
-    /// <param name="screenPosition">First clicked/touched position on screen</param>
-    protected virtual void OnDoubleTapped(ScreenPosition screenPosition)
-    {
-        // Zoom in on double tap
-        OnZoomInOrOut(1, screenPosition); // mouseWheelDelta > 0 to zoom in
-    }
-
-    /// <summary>
-    /// Called, when mouse/finger/pen tapped on map one time
-    /// </summary>
-    /// <param name="screenPosition">Clicked/touched position on screen</param>
-    /// <returns>True, if the event is handled</returns>
-    protected virtual void OnSingleTapped(ScreenPosition screenPosition)
-    {
-        OnInfo(CreateMapInfoEventArgs(screenPosition, screenPosition, TapType.Single));
-    }
-
-    /// <summary>
     /// Public functions
     /// </summary>
 

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -533,7 +533,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             return new MapInfoEventArgs
             {
                 MapInfo = mapInfo,
-                NumTaps = numTaps,
+                TapType = numTaps,
                 Handled = false
             };
         }

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -493,12 +493,9 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     }
 
     /// <inheritdoc />
-    public MapInfo GetMapInfo(ScreenPosition? screenPosition, int margin = 0)
+    public MapInfo GetMapInfo(ScreenPosition screenPosition, int margin = 0)
     {
-        if (screenPosition is null)
-            return null;
-
-        return Renderer.GetMapInfo(screenPosition.Value.X, screenPosition.Value.Y, Map.Navigator.Viewport, Map?.Layers ?? [], margin);
+        return Renderer.GetMapInfo(screenPosition.X, screenPosition.Y, Map.Navigator.Viewport, Map?.Layers ?? [], margin);
     }
 
     /// <inheritdoc />
@@ -550,7 +547,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(position, Map))
         {
             Logger.Log(LogLevel.Information, $"Widget.PointerPressed: {widget.GetType().Name}");
-            if (widget.OnPointerPressed(Map.Navigator, new WidgetEventArgs(position, 0, true, shiftPressed)))
+            if (widget.OnPointerPressed(Map.Navigator, new WidgetEventArgs(position, 0, true, shiftPressed, () => GetMapInfo(position))))
                 return true;
         }
         return false;
@@ -559,7 +556,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     private bool OnWidgetPointerMoved(ScreenPosition position, bool leftButton, bool shiftPressed)
     {
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(position, Map))
-            if (widget.OnPointerMoved(Map.Navigator, new WidgetEventArgs(position, 0, leftButton, shiftPressed)))
+            if (widget.OnPointerMoved(Map.Navigator, new WidgetEventArgs(position, 0, leftButton, shiftPressed, () => GetMapInfo(position))))
                 return true;
         return false;
     }
@@ -569,7 +566,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(position, Map))
         {
             Logger.Log(LogLevel.Information, $"Widget.Released: {widget.GetType().Name}");
-            if (widget.OnPointerReleased(Map.Navigator, new WidgetEventArgs(position, 0, true, shiftPressed)))
+            if (widget.OnPointerReleased(Map.Navigator, new WidgetEventArgs(position, 0, true, shiftPressed, () => GetMapInfo(position))))
                 return true;
         }
         return false;
@@ -581,7 +578,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         foreach (var widget in touchedWidgets)
         {
             Logger.Log(LogLevel.Information, $"Widget.Tapped: {widget.GetType().Name} TapCount: {tapType} KeyState: {shiftPressed}");
-            var e = new WidgetEventArgs(position, tapType, true, shiftPressed);
+            var e = new WidgetEventArgs(position, tapType, true, shiftPressed, () => GetMapInfo(position));
             if (widget.OnTapped(Map.Navigator, e))
                 return true;
         }

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -515,12 +515,12 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     /// </summary>
     /// <param name="screenPosition">Screen position to check for widgets and features</param>
     /// <param name="startScreenPosition">Screen position of Viewport/MapControl</param>
-    /// <param name="numTaps">Number of clicks/taps</param>
+    /// <param name="tapType">single or double tap</param>
     /// <returns>True, if something done </returns>
     private MapInfoEventArgs? CreateMapInfoEventArgs(
         ScreenPosition? screenPosition,
         ScreenPosition? startScreenPosition, // Todo: Figure why this is needed and if it can be removed
-        int numTaps)
+        TapType tapType)
     {
         if (screenPosition is null || startScreenPosition is null)
             return null;
@@ -533,7 +533,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             return new MapInfoEventArgs
             {
                 MapInfo = mapInfo,
-                TapType = numTaps,
+                TapType = tapType,
                 Handled = false
             };
         }
@@ -652,7 +652,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     {
         if (OnWidgetTapped(position, tapType, GetShiftPressed()))
             return true;
-        OnInfo(CreateMapInfoEventArgs(position, position, 1));
+        OnInfo(CreateMapInfoEventArgs(position, position, TapType.Single));
         return false;
     }
 }

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -488,7 +488,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     protected void OnMapInfo(MapInfoEventArgs mapInfoEventArgs)
     {
-        Map?.OnInfo(mapInfoEventArgs); // Also propagate to Map
+        Map?.OnMapInfo(mapInfoEventArgs); // Also propagate to Map
         Info?.Invoke(this, mapInfoEventArgs);
     }
 

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -486,21 +486,19 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         Map.RefreshData(changeType);
     }
 
-    private void OnInfo(MapInfoEventArgs? mapInfoEventArgs)
+    protected void OnMapInfo(MapInfoEventArgs mapInfoEventArgs)
     {
-        if (mapInfoEventArgs is null) return;
-
         Map?.OnInfo(mapInfoEventArgs); // Also propagate to Map
         Info?.Invoke(this, mapInfoEventArgs);
     }
 
     /// <inheritdoc />
-    public MapInfo? GetMapInfo(ScreenPosition? screenPosition, int margin = 0)
+    public MapInfo GetMapInfo(ScreenPosition? screenPosition, int margin = 0)
     {
         if (screenPosition is null)
             return null;
 
-        return Renderer?.GetMapInfo(screenPosition.Value.X, screenPosition.Value.Y, Map.Navigator.Viewport, Map?.Layers ?? [], margin);
+        return Renderer.GetMapInfo(screenPosition.Value.X, screenPosition.Value.Y, Map.Navigator.Viewport, Map?.Layers ?? [], margin);
     }
 
     /// <inheritdoc />
@@ -514,32 +512,13 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     /// Check if a widget or feature at a given screen position is clicked/tapped
     /// </summary>
     /// <param name="screenPosition">Screen position to check for widgets and features</param>
-    /// <param name="startScreenPosition">Screen position of Viewport/MapControl</param>
     /// <param name="tapType">single or double tap</param>
     /// <returns>True, if something done </returns>
-    private MapInfoEventArgs? CreateMapInfoEventArgs(
-        ScreenPosition? screenPosition,
-        ScreenPosition? startScreenPosition, // Todo: Figure why this is needed and if it can be removed
-        TapType tapType)
+    private MapInfoEventArgs CreateMapInfoEventArgs(ScreenPosition screenPosition, TapType tapType)
     {
-        if (screenPosition is null || startScreenPosition is null)
-            return null;
+        var mapInfo = Renderer.GetMapInfo(screenPosition.X, screenPosition.Y, Map.Navigator.Viewport, Map?.Layers ?? []);
 
-        // Check which features in the map were tapped.
-        var mapInfo = Renderer?.GetMapInfo(screenPosition.Value.X, screenPosition.Value.Y, Map.Navigator.Viewport, Map?.Layers ?? []);
-
-        if (mapInfo != null)
-        {
-            return new MapInfoEventArgs
-            {
-                MapInfo = mapInfo,
-                TapType = tapType,
-                Handled = false
-            };
-        }
-
-
-        return null;
+        return new MapInfoEventArgs(mapInfo, tapType, false);
     }
 
     private void SetViewportSize()
@@ -652,7 +631,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     {
         if (OnWidgetTapped(position, tapType, GetShiftPressed()))
             return true;
-        OnInfo(CreateMapInfoEventArgs(position, position, TapType.Single));
+        OnMapInfo(CreateMapInfoEventArgs(position, TapType.Single));
         return false;
     }
 }

--- a/Mapsui/Layers/MyLocationLayer.cs
+++ b/Mapsui/Layers/MyLocationLayer.cs
@@ -309,6 +309,7 @@ public class MyLocationLayer : BaseLayer, IDisposable
     /// </summary>
     /// <param name="newDirection">New direction</param>
     /// <param name="newViewportRotation">New viewport rotation</param>
+    /// <param name="animated">true if animated</param>
     public void UpdateMyDirection(double newDirection, double newViewportRotation, bool animated = false)
     {
         var newRotation = (int)(newDirection - newViewportRotation);

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -354,11 +354,9 @@ public class Map : INotifyPropertyChanged, IDisposable
     /// This method is to invoke the Info event from the Map. This method is called
     /// by the MapControl/MapView and should usually not be called from user code.
     /// </summary>
-    public void OnInfo(MapInfoEventArgs? mapInfoEventArgs)
+    public void OnMapInfo(MapInfoEventArgs e)
     {
-        if (mapInfoEventArgs == null) return;
-
-        Info?.Invoke(this, mapInfoEventArgs);
+        Info?.Invoke(this, e);
     }
 
     public void Dispose()

--- a/Mapsui/MapInfoEventArgs.cs
+++ b/Mapsui/MapInfoEventArgs.cs
@@ -4,12 +4,13 @@ namespace Mapsui;
 
 public class MapInfoEventArgs : EventArgs
 {
-    public MapInfo? MapInfo { get; set; }
+    public MapInfo? MapInfo { get; init; }
 
     /// <summary>
     /// Number of times the user tapped the location
     /// </summary>
-    public int NumTaps { get; set; }
+    public int TapType { get; init; }
+
     /// <summary>
     /// If the interaction was handled by the event subscriber
     /// </summary>

--- a/Mapsui/MapInfoEventArgs.cs
+++ b/Mapsui/MapInfoEventArgs.cs
@@ -3,17 +3,17 @@ using System;
 
 namespace Mapsui;
 
-public class MapInfoEventArgs : EventArgs
+public class MapInfoEventArgs(MapInfo mapInfo, TapType tapType, bool handled) : EventArgs
 {
-    public MapInfo? MapInfo { get; init; }
+    public MapInfo MapInfo { get; } = mapInfo;
 
     /// <summary>
     /// Number of times the user tapped the location
     /// </summary>
-    public TapType TapType { get; init; }
+    public TapType TapType { get; } = tapType;
 
     /// <summary>
     /// If the interaction was handled by the event subscriber
     /// </summary>
-    public bool Handled { get; set; }
+    public bool Handled { get; set; } = handled;
 }

--- a/Mapsui/MapInfoEventArgs.cs
+++ b/Mapsui/MapInfoEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Mapsui.Manipulations;
+using System;
 
 namespace Mapsui;
 
@@ -9,7 +10,7 @@ public class MapInfoEventArgs : EventArgs
     /// <summary>
     /// Number of times the user tapped the location
     /// </summary>
-    public int TapType { get; init; }
+    public TapType TapType { get; init; }
 
     /// <summary>
     /// If the interaction was handled by the event subscriber

--- a/Mapsui/Rendering/IRenderInfo.cs
+++ b/Mapsui/Rendering/IRenderInfo.cs
@@ -5,5 +5,5 @@ namespace Mapsui.Rendering;
 
 public interface IRenderInfo
 {
-    MapInfo? GetMapInfo(double screenX, double screenY, Viewport viewport, IEnumerable<ILayer> layers, int margin = 0);
+    MapInfo GetMapInfo(double screenX, double screenY, Viewport viewport, IEnumerable<ILayer> layers, int margin = 0);
 }

--- a/Mapsui/UI/IMapControl.cs
+++ b/Mapsui/UI/IMapControl.cs
@@ -49,7 +49,7 @@ public interface IMapControl : IDisposable
     /// </summary>
     /// <param name="screenPosition">Screen position to check for widgets and features</param>
     /// <param name="margin">An optional extra margin around the feature to enlarge the hit area.</param>
-    MapInfo? GetMapInfo(ScreenPosition? screenPosition, int margin = 0);
+    MapInfo GetMapInfo(ScreenPosition screenPosition, int margin = 0);
 
     /// <summary>
     /// Create a snapshot form map as PNG image

--- a/Mapsui/Widgets/WidgetEventArgs.cs
+++ b/Mapsui/Widgets/WidgetEventArgs.cs
@@ -6,7 +6,7 @@ namespace Mapsui.Widgets;
 /// <summary>
 /// Arguments for a touched event of a widget
 /// </summary>
-public class WidgetEventArgs(ScreenPosition position, TapType tapType = TapType.Single, bool leftButton = true, bool shiftPressed = false) : EventArgs
+public class WidgetEventArgs(ScreenPosition position, TapType tapType, bool leftButton, bool shiftPressed, Func<MapInfo> getMapInfo) : EventArgs
 {
     /// <summary>
     /// Screen Position of touch in device independent units (or DIP or DP)
@@ -27,4 +27,9 @@ public class WidgetEventArgs(ScreenPosition position, TapType tapType = TapType.
     /// Shift key pressed while touching
     /// </summary>
     public bool ShiftPressed { get; } = shiftPressed;
+
+    /// <summary>
+    /// Function to get the MapInfo for the WidgetEventArgs.Position.
+    /// </summary>
+    public Func<MapInfo> GetMapInfo { get; } = getMapInfo;
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
@@ -85,142 +85,118 @@ public class LabelsSample : ISample
         }]
     };
 
-    private static PointFeature CreateFeatureWithTailTruncation()
+    private static PointFeature CreateFeatureWithTailTruncation() => new(new MPoint(8000000, 2000000))
     {
-        return new(new MPoint(8000000, 2000000))
+        Styles = [new LabelStyle
         {
-            Styles = [new LabelStyle
-            {
-                Text = "Long line break mode test",
-                Font = new Font { FontFamily = "Courier New", Bold = true, Italic = true, },
-                BackColor = new Brush(Color.Transparent),
-                ForeColor = Color.White,
-                Halo = new Pen(Color.Black, 2),
-                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
-                MaxWidth = 10,
-                WordWrap = LabelStyle.LineBreakMode.TailTruncation
-            }]
-        };
-    }
+            Text = "Long line break mode test",
+            Font = new Font { FontFamily = "Courier New", Bold = true, Italic = true, },
+            BackColor = new Brush(Color.Transparent),
+            ForeColor = Color.White,
+            Halo = new Pen(Color.Black, 2),
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
+            MaxWidth = 10,
+            WordWrap = LabelStyle.LineBreakMode.TailTruncation
+        }]
+    };
 
-    private static PointFeature CreateFeatureWithHeadTruncation()
+    private static PointFeature CreateFeatureWithHeadTruncation() => new(new MPoint(-8000000, 2000000))
     {
-        return new(new MPoint(-8000000, 2000000))
+        Styles = [new LabelStyle
         {
-            Styles = [new LabelStyle
-            {
-                Text = "Long line break mode test",
-                Font = new Font { Size = 16, Bold = true, Italic = false, },
-                BackColor = new Brush(Color.Transparent),
-                ForeColor = Color.White,
-                Halo = new Pen(Color.Black, 2),
-                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
-                MaxWidth = 10,
-                WordWrap = LabelStyle.LineBreakMode.HeadTruncation
-            }]
-        };
-    }
+            Text = "Long line break mode test",
+            Font = new Font { Size = 16, Bold = true, Italic = false, },
+            BackColor = new Brush(Color.Transparent),
+            ForeColor = Color.White,
+            Halo = new Pen(Color.Black, 2),
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
+            MaxWidth = 10,
+            WordWrap = LabelStyle.LineBreakMode.HeadTruncation
+        }]
+    };
 
-    private static PointFeature CreateFeatureWithMiddleTruncation()
+    private static PointFeature CreateFeatureWithMiddleTruncation() => new(new MPoint(0, 2000000))
     {
-        return new(new MPoint(0, 2000000))
+        Styles = [new LabelStyle
         {
-            Styles = [new LabelStyle
-            {
-                Text = "Long line break mode test",
-                Font = new Font { Size = 30 },
-                BackColor = new Brush(Color.Transparent),
-                ForeColor = Color.White,
-                Halo = new Pen(Color.Black, 2),
-                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-                MaxWidth = 10,
-                WordWrap = LabelStyle.LineBreakMode.MiddleTruncation
-            }]
-        };
-    }
+            Text = "Long line break mode test",
+            Font = new Font { Size = 30 },
+            BackColor = new Brush(Color.Transparent),
+            ForeColor = Color.White,
+            Halo = new Pen(Color.Black, 2),
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+            MaxWidth = 10,
+            WordWrap = LabelStyle.LineBreakMode.MiddleTruncation
+        }]
+    };
 
-    private static PointFeature CreateFeatureWithWordWrapLeft()
+    private static PointFeature CreateFeatureWithWordWrapLeft() => new(new MPoint(-8000000, 6000000))
     {
-        return new(new MPoint(-8000000, 6000000))
+        Styles = [new LabelStyle
         {
-            Styles = [new LabelStyle
-            {
-                Text = "Long line break mode test",
-                BackColor = new Brush(Color.Gray),
-                ForeColor = Color.White,
-                Halo = new Pen(Color.Black, 2),
-                MaxWidth = 10,
-                WordWrap = LabelStyle.LineBreakMode.WordWrap,
-                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
-                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
-            }]
-        };
-    }
+            Text = "Long line break mode test",
+            BackColor = new Brush(Color.Gray),
+            ForeColor = Color.White,
+            Halo = new Pen(Color.Black, 2),
+            MaxWidth = 10,
+            WordWrap = LabelStyle.LineBreakMode.WordWrap,
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
+            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
+        }]
+    };
 
-    private static PointFeature CreateFeatureWithWordWrapCenter()
+    private static PointFeature CreateFeatureWithWordWrapCenter() => new(new MPoint(0, 6000000))
     {
-        return new(new MPoint(0, 6000000))
+        Styles = [new LabelStyle
         {
-            Styles = [new LabelStyle
-            {
-                Text = "Long line break mode test",
-                BackColor = new Brush(Color.Transparent),
-                ForeColor = Color.White,
-                Halo = new Pen(Color.Black, 2),
-                MaxWidth = 10,
-                LineHeight = 1.2,
-                WordWrap = LabelStyle.LineBreakMode.WordWrap,
-                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
-            }]
-        };
-    }
+            Text = "Long line break mode test",
+            BackColor = new Brush(Color.Transparent),
+            ForeColor = Color.White,
+            Halo = new Pen(Color.Black, 2),
+            MaxWidth = 10,
+            LineHeight = 1.2,
+            WordWrap = LabelStyle.LineBreakMode.WordWrap,
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+        }]
+    };
 
-    private static PointFeature CreateFeatureWithWordWrapRight()
+    private static PointFeature CreateFeatureWithWordWrapRight() => new(new MPoint(8000000, 6000000))
     {
-        return new(new MPoint(8000000, 6000000))
+        Styles = [new LabelStyle
         {
-            Styles = [new LabelStyle
-            {
-                Text = "Long line break mode test",
-                BackColor = new Brush(Color.Gray),
-                ForeColor = Color.White,
-                MaxWidth = 12,
-                WordWrap = LabelStyle.LineBreakMode.WordWrap,
-                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
-                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom,
-            }]
-        };
-    }
+            Text = "Long line break mode test",
+            BackColor = new Brush(Color.Gray),
+            ForeColor = Color.White,
+            MaxWidth = 12,
+            WordWrap = LabelStyle.LineBreakMode.WordWrap,
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
+            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom,
+        }]
+    };
 
-    private static PointFeature CreateFeatureWithCharacterWrap()
+    private static PointFeature CreateFeatureWithCharacterWrap() => new(new MPoint(0, 10000000))
     {
-        return new(new MPoint(0, 10000000))
+        Styles = [new LabelStyle
         {
-            Styles = [new LabelStyle
-            {
-                Text = "Long line break mode test",
-                BackColor = null,
-                ForeColor = Color.Black,
-                MaxWidth = 6,
-                WordWrap = LabelStyle.LineBreakMode.CharacterWrap,
-                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
-            }]
-        };
-    }
+            Text = "Long line break mode test",
+            BackColor = null,
+            ForeColor = Color.Black,
+            MaxWidth = 6,
+            WordWrap = LabelStyle.LineBreakMode.CharacterWrap,
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+        }]
+    };
 
-    private static PointFeature CreateFeatureWithHalo()
+    private static PointFeature CreateFeatureWithHalo() => new(new MPoint(0, -12000000))
     {
-        return new(new MPoint(0, -12000000))
+        Styles = [new LabelStyle
         {
-            Styles = [new LabelStyle
-            {
-                Text = "Halo Halo Halo",
-                BackColor = new Brush(Color.Transparent),
-                ForeColor = Color.White,
-                Halo = new Pen(Color.Black, 2)
-            }]
-        };
-    }
+            Text = "Halo Halo Halo",
+            BackColor = new Brush(Color.Transparent),
+            ForeColor = Color.White,
+            Halo = new Pen(Color.Black, 2)
+        }]
+    };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
@@ -43,21 +43,21 @@ public class LabelsSample : ISample
         return new MemoryLayer { Name = "Points with labels", Features = features };
     }
 
-    private static IFeature CreateFeatureWithDefaultStyle()
+    private static PointFeature CreateFeatureWithDefaultStyle()
     {
         var featureWithDefaultStyle = new PointFeature(new MPoint(0, 0));
         featureWithDefaultStyle.Styles.Add(new LabelStyle { Text = "Default Label" });
         return featureWithDefaultStyle;
     }
 
-    private static IFeature CreateFeatureWithColors()
+    private static PointFeature CreateFeatureWithColors()
     {
         var featureWithColors = new PointFeature(new MPoint(0, -7000000));
         featureWithColors.Styles.Add(CreateColoredLabelStyle());
         return featureWithColors;
     }
 
-    private static IFeature CreateFeatureWithBottomAlignedStyle()
+    private static PointFeature CreateFeatureWithBottomAlignedStyle()
     {
         var featureWithBottomAlignedStyle = new PointFeature(new MPoint(0, -5000000));
         featureWithBottomAlignedStyle.Styles.Add(new LabelStyle
@@ -69,7 +69,7 @@ public class LabelsSample : ISample
         return featureWithBottomAlignedStyle;
     }
 
-    private static IFeature CreateFeatureWithRightAlignedStyle()
+    private static PointFeature CreateFeatureWithRightAlignedStyle()
     {
         var featureWithRightAlignedStyle = new PointFeature(new MPoint(0, -2000000));
         featureWithRightAlignedStyle.Styles.Add(new LabelStyle
@@ -81,7 +81,7 @@ public class LabelsSample : ISample
         return featureWithRightAlignedStyle;
     }
 
-    private static IFeature CreatePolygonWithLabel()
+    private static GeometryFeature CreatePolygonWithLabel()
     {
         var polygon = new GeometryFeature
         {
@@ -97,7 +97,7 @@ public class LabelsSample : ISample
         return polygon;
     }
 
-    private static IStyle CreateColoredLabelStyle()
+    private static LabelStyle CreateColoredLabelStyle()
     {
         return new LabelStyle
         {
@@ -107,134 +107,150 @@ public class LabelsSample : ISample
         };
     }
 
-    private static IFeature CreateFeatureWithTailTruncation()
+    private static PointFeature CreateFeatureWithTailTruncation()
     {
         var featureWithColors = new PointFeature(new MPoint(8000000, 2000000));
-        featureWithColors.Styles.Add(new LabelStyle
-        {
-            Text = "Long line break mode test",
-            Font = new Font { FontFamily = "Courier New", Bold = true, Italic = true, },
-            BackColor = new Brush(Color.Transparent),
-            ForeColor = Color.White,
-            Halo = new Pen(Color.Black, 2),
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
-            MaxWidth = 10,
-            WordWrap = LabelStyle.LineBreakMode.TailTruncation
-        });
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak1());
         return featureWithColors;
     }
 
-    private static IFeature CreateFeatureWithHeadTruncation()
+    private static LabelStyle CreateLabelStyleWithLineBreak1()
+    {
+        return CreateLabelStyleWithLineBreak3();
+    }
+
+    private static LabelStyle CreateLabelStyleWithLineBreak3() => new()
+    {
+        Text = "Long line break mode test",
+        Font = new Font { FontFamily = "Courier New", Bold = true, Italic = true, },
+        BackColor = new Brush(Color.Transparent),
+        ForeColor = Color.White,
+        Halo = new Pen(Color.Black, 2),
+        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
+        MaxWidth = 10,
+        WordWrap = LabelStyle.LineBreakMode.TailTruncation
+    };
+
+    private static PointFeature CreateFeatureWithHeadTruncation()
     {
         var featureWithColors = new PointFeature(new MPoint(-8000000, 2000000));
-        featureWithColors.Styles.Add(new LabelStyle
-        {
-            Text = "Long line break mode test",
-            Font = new Font { Size = 16, Bold = true, Italic = false, },
-            BackColor = new Brush(Color.Transparent),
-            ForeColor = Color.White,
-            Halo = new Pen(Color.Black, 2),
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
-            MaxWidth = 10,
-            WordWrap = LabelStyle.LineBreakMode.HeadTruncation
-        });
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak());
         return featureWithColors;
     }
 
-    private static IFeature CreateFeatureWithMiddleTruncation()
+    private static LabelStyle CreateLabelStyleWithLineBreak() => new()
+    {
+        Text = "Long line break mode test",
+        Font = new Font { Size = 16, Bold = true, Italic = false, },
+        BackColor = new Brush(Color.Transparent),
+        ForeColor = Color.White,
+        Halo = new Pen(Color.Black, 2),
+        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
+        MaxWidth = 10,
+        WordWrap = LabelStyle.LineBreakMode.HeadTruncation
+    };
+
+    private static PointFeature CreateFeatureWithMiddleTruncation()
     {
         var featureWithColors = new PointFeature(new MPoint(0, 2000000));
-        featureWithColors.Styles.Add(new LabelStyle
-        {
-            Text = "Long line break mode test",
-            Font = new Font { Size = 30 },
-            BackColor = new Brush(Color.Transparent),
-            ForeColor = Color.White,
-            Halo = new Pen(Color.Black, 2),
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-            MaxWidth = 10,
-            WordWrap = LabelStyle.LineBreakMode.MiddleTruncation
-        });
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak2());
         return featureWithColors;
     }
 
-    private static IFeature CreateFeatureWithWordWrapLeft()
+    private static LabelStyle CreateLabelStyleWithLineBreak2() => new()
+    {
+        Text = "Long line break mode test",
+        Font = new Font { Size = 30 },
+        BackColor = new Brush(Color.Transparent),
+        ForeColor = Color.White,
+        Halo = new Pen(Color.Black, 2),
+        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+        MaxWidth = 10,
+        WordWrap = LabelStyle.LineBreakMode.MiddleTruncation
+    };
+
+    private static PointFeature CreateFeatureWithWordWrapLeft()
     {
         var featureWithColors = new PointFeature(new MPoint(-8000000, 6000000));
-        featureWithColors.Styles.Add(new LabelStyle
-        {
-            Text = "Long line break mode test",
-            BackColor = new Brush(Color.Gray),
-            ForeColor = Color.White,
-            Halo = new Pen(Color.Black, 2),
-            MaxWidth = 10,
-            WordWrap = LabelStyle.LineBreakMode.WordWrap,
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
-            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
-        });
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak4());
         return featureWithColors;
     }
 
-    private static IFeature CreateFeatureWithWordWrapCenter()
+    private static LabelStyle CreateLabelStyleWithLineBreak4() => new()
+    {
+        Text = "Long line break mode test",
+        BackColor = new Brush(Color.Gray),
+        ForeColor = Color.White,
+        Halo = new Pen(Color.Black, 2),
+        MaxWidth = 10,
+        WordWrap = LabelStyle.LineBreakMode.WordWrap,
+        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
+        VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
+    };
+
+    private static PointFeature CreateFeatureWithWordWrapCenter()
     {
         var featureWithColors = new PointFeature(new MPoint(0, 6000000));
-        featureWithColors.Styles.Add(new LabelStyle
-        {
-            Text = "Long line break mode test",
-            BackColor = new Brush(Color.Transparent),
-            ForeColor = Color.White,
-            Halo = new Pen(Color.Black, 2),
-            MaxWidth = 10,
-            LineHeight = 1.2,
-            WordWrap = LabelStyle.LineBreakMode.WordWrap,
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
-        });
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak5());
         return featureWithColors;
     }
 
-    private static IFeature CreateFeatureWithWordWrapRight()
+    private static LabelStyle CreateLabelStyleWithLineBreak5() => new()
+    {
+        Text = "Long line break mode test",
+        BackColor = new Brush(Color.Transparent),
+        ForeColor = Color.White,
+        Halo = new Pen(Color.Black, 2),
+        MaxWidth = 10,
+        LineHeight = 1.2,
+        WordWrap = LabelStyle.LineBreakMode.WordWrap,
+        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+        VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+    };
+
+    private static PointFeature CreateFeatureWithWordWrapRight()
     {
         var featureWithColors = new PointFeature(new MPoint(8000000, 6000000));
-        featureWithColors.Styles.Add(new LabelStyle
-        {
-            Text = "Long line break mode test",
-            BackColor = new Brush(Color.Gray),
-            ForeColor = Color.White,
-            MaxWidth = 12,
-            WordWrap = LabelStyle.LineBreakMode.WordWrap,
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
-            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom,
-        });
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak6());
         return featureWithColors;
     }
 
-    private static IFeature CreateFeatureWithCharacterWrap()
+    private static LabelStyle CreateLabelStyleWithLineBreak6() => new()
+    {
+        Text = "Long line break mode test",
+        BackColor = new Brush(Color.Gray),
+        ForeColor = Color.White,
+        MaxWidth = 12,
+        WordWrap = LabelStyle.LineBreakMode.WordWrap,
+        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
+        VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom,
+    };
+
+    private static PointFeature CreateFeatureWithCharacterWrap()
     {
         var featureWithColors = new PointFeature(new MPoint(0, 10000000));
-        featureWithColors.Styles.Add(new LabelStyle
-        {
-            Text = "Long line break mode test",
-            BackColor = null,
-            ForeColor = Color.Black,
-            MaxWidth = 6,
-            WordWrap = LabelStyle.LineBreakMode.CharacterWrap,
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
-        });
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak7());
         return featureWithColors;
     }
 
-    private static IFeature CreateFeatureWithHalo()
+    private static LabelStyle CreateLabelStyleWithLineBreak7() => new()
     {
-        var featureWithColors = new PointFeature(new MPoint(0, -12000000));
-        featureWithColors.Styles.Add(new LabelStyle
-        {
-            Text = "Halo Halo Halo",
-            BackColor = new Brush(Color.Transparent),
-            ForeColor = Color.White,
-            Halo = new Pen(Color.Black, 2)
-        });
-        return featureWithColors;
-    }
+        Text = "Long line break mode test",
+        BackColor = null,
+        ForeColor = Color.Black,
+        MaxWidth = 6,
+        WordWrap = LabelStyle.LineBreakMode.CharacterWrap,
+        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+        VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+    };
+
+    private static PointFeature CreateFeatureWithHalo() => new(new MPoint(0, -12000000)) { Styles = [CreateHaloStyle()] };
+
+    private static LabelStyle CreateHaloStyle() => new()
+    {
+        Text = "Halo Halo Halo",
+        BackColor = new Brush(Color.Transparent),
+        ForeColor = Color.White,
+        Halo = new Pen(Color.Black, 2)
+    };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
@@ -114,29 +114,57 @@ public class LabelsSample : ISample
         return featureWithColors;
     }
 
-    private static LabelStyle CreateLabelStyleWithLineBreak1()
-    {
-        return CreateLabelStyleWithLineBreak3();
-    }
-
-    private static LabelStyle CreateLabelStyleWithLineBreak3() => new()
-    {
-        Text = "Long line break mode test",
-        Font = new Font { FontFamily = "Courier New", Bold = true, Italic = true, },
-        BackColor = new Brush(Color.Transparent),
-        ForeColor = Color.White,
-        Halo = new Pen(Color.Black, 2),
-        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
-        MaxWidth = 10,
-        WordWrap = LabelStyle.LineBreakMode.TailTruncation
-    };
-
     private static PointFeature CreateFeatureWithHeadTruncation()
     {
         var featureWithColors = new PointFeature(new MPoint(-8000000, 2000000));
         featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak());
         return featureWithColors;
     }
+
+    private static PointFeature CreateFeatureWithMiddleTruncation()
+    {
+        var featureWithColors = new PointFeature(new MPoint(0, 2000000));
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak2());
+        return featureWithColors;
+    }
+
+    private static PointFeature CreateFeatureWithWordWrapLeft()
+    {
+        var featureWithColors = new PointFeature(new MPoint(-8000000, 6000000));
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak4());
+        return featureWithColors;
+    }
+
+    private static PointFeature CreateFeatureWithWordWrapCenter()
+    {
+        var featureWithColors = new PointFeature(new MPoint(0, 6000000));
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak5());
+        return featureWithColors;
+    }
+
+    private static PointFeature CreateFeatureWithWordWrapRight()
+    {
+        var featureWithColors = new PointFeature(new MPoint(8000000, 6000000));
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak6());
+        return featureWithColors;
+    }
+
+    private static PointFeature CreateFeatureWithCharacterWrap()
+    {
+        var featureWithColors = new PointFeature(new MPoint(0, 10000000));
+        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak7());
+        return featureWithColors;
+    }
+
+    private static PointFeature CreateFeatureWithHalo() => new(new MPoint(0, -12000000)) { Styles = [CreateHaloStyle()] };
+
+    private static LabelStyle CreateHaloStyle() => new()
+    {
+        Text = "Halo Halo Halo",
+        BackColor = new Brush(Color.Transparent),
+        ForeColor = Color.White,
+        Halo = new Pen(Color.Black, 2)
+    };
 
     private static LabelStyle CreateLabelStyleWithLineBreak() => new()
     {
@@ -150,12 +178,18 @@ public class LabelsSample : ISample
         WordWrap = LabelStyle.LineBreakMode.HeadTruncation
     };
 
-    private static PointFeature CreateFeatureWithMiddleTruncation()
+    private static LabelStyle CreateLabelStyleWithLineBreak1() => new()
     {
-        var featureWithColors = new PointFeature(new MPoint(0, 2000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak2());
-        return featureWithColors;
-    }
+        Text = "Long line break mode test",
+        Font = new Font { FontFamily = "Courier New", Bold = true, Italic = true, },
+        BackColor = new Brush(Color.Transparent),
+        ForeColor = Color.White,
+        Halo = new Pen(Color.Black, 2),
+        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
+        MaxWidth = 10,
+        WordWrap = LabelStyle.LineBreakMode.TailTruncation
+    };
+
 
     private static LabelStyle CreateLabelStyleWithLineBreak2() => new()
     {
@@ -169,13 +203,6 @@ public class LabelsSample : ISample
         WordWrap = LabelStyle.LineBreakMode.MiddleTruncation
     };
 
-    private static PointFeature CreateFeatureWithWordWrapLeft()
-    {
-        var featureWithColors = new PointFeature(new MPoint(-8000000, 6000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak4());
-        return featureWithColors;
-    }
-
     private static LabelStyle CreateLabelStyleWithLineBreak4() => new()
     {
         Text = "Long line break mode test",
@@ -188,12 +215,6 @@ public class LabelsSample : ISample
         VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
     };
 
-    private static PointFeature CreateFeatureWithWordWrapCenter()
-    {
-        var featureWithColors = new PointFeature(new MPoint(0, 6000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak5());
-        return featureWithColors;
-    }
 
     private static LabelStyle CreateLabelStyleWithLineBreak5() => new()
     {
@@ -208,13 +229,6 @@ public class LabelsSample : ISample
         VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
     };
 
-    private static PointFeature CreateFeatureWithWordWrapRight()
-    {
-        var featureWithColors = new PointFeature(new MPoint(8000000, 6000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak6());
-        return featureWithColors;
-    }
-
     private static LabelStyle CreateLabelStyleWithLineBreak6() => new()
     {
         Text = "Long line break mode test",
@@ -226,13 +240,6 @@ public class LabelsSample : ISample
         VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom,
     };
 
-    private static PointFeature CreateFeatureWithCharacterWrap()
-    {
-        var featureWithColors = new PointFeature(new MPoint(0, 10000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak7());
-        return featureWithColors;
-    }
-
     private static LabelStyle CreateLabelStyleWithLineBreak7() => new()
     {
         Text = "Long line break mode test",
@@ -242,15 +249,5 @@ public class LabelsSample : ISample
         WordWrap = LabelStyle.LineBreakMode.CharacterWrap,
         HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
         VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
-    };
-
-    private static PointFeature CreateFeatureWithHalo() => new(new MPoint(0, -12000000)) { Styles = [CreateHaloStyle()] };
-
-    private static LabelStyle CreateHaloStyle() => new()
-    {
-        Text = "Halo Halo Halo",
-        BackColor = new Brush(Color.Transparent),
-        ForeColor = Color.White,
-        Halo = new Pen(Color.Black, 2)
     };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
@@ -25,19 +25,19 @@ public class LabelsSample : ISample
 
     private static List<IFeature> CreateFeatures() => [
             CreateFeatureWithDefaultStyle(),
-            CreateFeatureWithRightAlignedStyle(),
-            CreateFeatureWithBottomAlignedStyle(),
-            CreateFeatureWithColors(),
-            CreatePolygonWithLabel(),
-            CreateFeatureWithHalo(),
-            CreateFeatureWithTailTruncation(),
-            CreateFeatureWithMiddleTruncation(),
-            CreateFeatureWithHeadTruncation(),
-            CreateFeatureWithWordWrapLeft(),
-            CreateFeatureWithWordWrapCenter(),
-            CreateFeatureWithWordWrapRight(),
-            CreateFeatureWithCharacterWrap(),
-        ];
+        CreateFeatureWithRightAlignedStyle(),
+        CreateFeatureWithBottomAlignedStyle(),
+        CreateFeatureWithColors(),
+        CreatePolygonWithLabel(),
+        CreateFeatureWithHalo(),
+        CreateFeatureWithTailTruncation(),
+        CreateFeatureWithMiddleTruncation(),
+        CreateFeatureWithHeadTruncation(),
+        CreateFeatureWithWordWrapLeft(),
+        CreateFeatureWithWordWrapCenter(),
+        CreateFeatureWithWordWrapRight(),
+        CreateFeatureWithCharacterWrap(),
+    ];
 
     private static PointFeature CreateFeatureWithDefaultStyle() => new(new MPoint(0, 0))
     {

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
@@ -50,7 +50,7 @@ public class LabelsSample : ISample
         {
             Text = "Colors",
             BackColor = new Brush(Color.Blue),
-            ForeColor = Color.White
+            ForeColor = Color.White,
         }]
     };
 
@@ -60,7 +60,7 @@ public class LabelsSample : ISample
         {
             Text = "Bottom\nAligned",
             BackColor = new Brush(Color.Gray),
-            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom
+            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom,
         }]
     };
 
@@ -70,7 +70,7 @@ public class LabelsSample : ISample
         {
             Text = "Right Aligned",
             BackColor = new Brush(Color.Gray),
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
         }]
     };
 
@@ -81,7 +81,6 @@ public class LabelsSample : ISample
         {
             Text = "Polygon",
             BackColor = new Brush(Color.Gray),
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center
         }]
     };
 
@@ -96,7 +95,7 @@ public class LabelsSample : ISample
             Halo = new Pen(Color.Black, 2),
             HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
             MaxWidth = 10,
-            WordWrap = LabelStyle.LineBreakMode.TailTruncation
+            WordWrap = LabelStyle.LineBreakMode.TailTruncation,
         }]
     };
 
@@ -111,7 +110,7 @@ public class LabelsSample : ISample
             Halo = new Pen(Color.Black, 2),
             HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
             MaxWidth = 10,
-            WordWrap = LabelStyle.LineBreakMode.HeadTruncation
+            WordWrap = LabelStyle.LineBreakMode.HeadTruncation,
         }]
     };
 
@@ -126,7 +125,7 @@ public class LabelsSample : ISample
             Halo = new Pen(Color.Black, 2),
             HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
             MaxWidth = 10,
-            WordWrap = LabelStyle.LineBreakMode.MiddleTruncation
+            WordWrap = LabelStyle.LineBreakMode.MiddleTruncation,
         }]
     };
 
@@ -156,8 +155,6 @@ public class LabelsSample : ISample
             MaxWidth = 10,
             LineHeight = 1.2,
             WordWrap = LabelStyle.LineBreakMode.WordWrap,
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
         }]
     };
 
@@ -184,8 +181,6 @@ public class LabelsSample : ISample
             ForeColor = Color.Black,
             MaxWidth = 6,
             WordWrap = LabelStyle.LineBreakMode.CharacterWrap,
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
         }]
     };
 
@@ -196,7 +191,7 @@ public class LabelsSample : ISample
             Text = "Halo Halo Halo",
             BackColor = new Brush(Color.Transparent),
             ForeColor = Color.White,
-            Halo = new Pen(Color.Black, 2)
+            Halo = new Pen(Color.Black, 2),
         }]
     };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
@@ -24,7 +24,7 @@ public class LabelsSample : ISample
     public static MemoryLayer CreateLayer() => new() { Name = "Points with labels", Features = CreateFeatures() };
 
     private static List<IFeature> CreateFeatures() => [
-            CreateFeatureWithDefaultStyle(),
+        CreateFeatureWithDefaultStyle(),
         CreateFeatureWithRightAlignedStyle(),
         CreateFeatureWithBottomAlignedStyle(),
         CreateFeatureWithColors(),

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
@@ -45,166 +45,194 @@ public class LabelsSample : ISample
     };
 
     private static PointFeature CreateFeatureWithColors()
-        => new(new MPoint(0, -7000000)) { Styles = [CreateColoredLabelStyle()] };
+    {
+        return new(new MPoint(0, -7000000))
+        {
+            Styles = [new LabelStyle
+            {
+                Text = "Colors",
+                BackColor = new Brush(Color.Blue),
+                ForeColor = Color.White
+            }]
+        };
+    }
 
     private static PointFeature CreateFeatureWithBottomAlignedStyle()
-        => new(new MPoint(0, -5000000)) { Styles = [CreateBottomAlignedStyle()] };
-
-    private static LabelStyle CreateBottomAlignedStyle() => new()
     {
-        Text = "Bottom\nAligned",
-        BackColor = new Brush(Color.Gray),
-        VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom
-    };
+        return new(new MPoint(0, -5000000))
+        {
+            Styles = [new LabelStyle
+            {
+                Text = "Bottom\nAligned",
+                BackColor = new Brush(Color.Gray),
+                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom
+            }]
+        };
+    }
 
-    private static PointFeature CreateFeatureWithRightAlignedStyle() => new(new MPoint(0, -2000000))
+    private static PointFeature CreateFeatureWithRightAlignedStyle()
     {
-        Styles = [CreateRightAlignedLabelStyle()]
-    };
+        return new(new MPoint(0, -2000000))
+        {
+            Styles = [new LabelStyle
+            {
+                Text = "Right Aligned",
+                BackColor = new Brush(Color.Gray),
+                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right
+            }]
+        };
+    }
 
-    private static LabelStyle CreateRightAlignedLabelStyle() => new()
+    private static GeometryFeature CreatePolygonWithLabel()
     {
-        Text = "Right Aligned",
-        BackColor = new Brush(Color.Gray),
-        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right
-    };
-
-    private static GeometryFeature CreatePolygonWithLabel() => new()
-    {
-        Geometry = CreatePolygon(),
-        Styles = [CreatePolygonLabel()]
-    };
-
-    private static LabelStyle CreatePolygonLabel() => new()
-    {
-        Text = "Polygon",
-        BackColor = new Brush(Color.Gray),
-        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center
-    };
-
-    private static NetTopologySuite.Geometries.Geometry CreatePolygon()
-        => new WKTReader().Read("POLYGON((-1000000 -10000000, 1000000 -10000000, 1000000 -8000000, -1000000 -8000000, -1000000 -10000000))");
-
-    private static LabelStyle CreateColoredLabelStyle() => new()
-    {
-        Text = "Colors",
-        BackColor = new Brush(Color.Blue),
-        ForeColor = Color.White
-    };
+        return new()
+        {
+            Geometry = new WKTReader().Read("POLYGON((-1000000 -10000000, 1000000 -10000000, 1000000 -8000000, -1000000 -8000000, -1000000 -10000000))"),
+            Styles = [new LabelStyle
+            {
+                Text = "Polygon",
+                BackColor = new Brush(Color.Gray),
+                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center
+            }]
+        };
+    }
 
     private static PointFeature CreateFeatureWithTailTruncation()
-        => new(new MPoint(8000000, 2000000)) { Styles = [CreateLabelStyleWithTailTruncation()] };
+    {
+        return new(new MPoint(8000000, 2000000))
+        {
+            Styles = [new LabelStyle
+            {
+                Text = "Long line break mode test",
+                Font = new Font { FontFamily = "Courier New", Bold = true, Italic = true, },
+                BackColor = new Brush(Color.Transparent),
+                ForeColor = Color.White,
+                Halo = new Pen(Color.Black, 2),
+                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
+                MaxWidth = 10,
+                WordWrap = LabelStyle.LineBreakMode.TailTruncation
+            }]
+        };
+    }
 
     private static PointFeature CreateFeatureWithHeadTruncation()
-        => new(new MPoint(-8000000, 2000000)) { Styles = [CreateLabelStyleWithHeadTruncation()] };
+    {
+        return new(new MPoint(-8000000, 2000000))
+        {
+            Styles = [new LabelStyle
+            {
+                Text = "Long line break mode test",
+                Font = new Font { Size = 16, Bold = true, Italic = false, },
+                BackColor = new Brush(Color.Transparent),
+                ForeColor = Color.White,
+                Halo = new Pen(Color.Black, 2),
+                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
+                MaxWidth = 10,
+                WordWrap = LabelStyle.LineBreakMode.HeadTruncation
+            }]
+        };
+    }
 
     private static PointFeature CreateFeatureWithMiddleTruncation()
-        => new(new MPoint(0, 2000000)) { Styles = [CreateLabelStyleWithMiddleTruncation()] };
+    {
+        return new(new MPoint(0, 2000000))
+        {
+            Styles = [new LabelStyle
+            {
+                Text = "Long line break mode test",
+                Font = new Font { Size = 30 },
+                BackColor = new Brush(Color.Transparent),
+                ForeColor = Color.White,
+                Halo = new Pen(Color.Black, 2),
+                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+                MaxWidth = 10,
+                WordWrap = LabelStyle.LineBreakMode.MiddleTruncation
+            }]
+        };
+    }
 
     private static PointFeature CreateFeatureWithWordWrapLeft()
-        => new(new MPoint(-8000000, 6000000)) { Styles = [CreateLabelStyleWithWordWrapLeft()] };
+    {
+        return new(new MPoint(-8000000, 6000000))
+        {
+            Styles = [new LabelStyle
+            {
+                Text = "Long line break mode test",
+                BackColor = new Brush(Color.Gray),
+                ForeColor = Color.White,
+                Halo = new Pen(Color.Black, 2),
+                MaxWidth = 10,
+                WordWrap = LabelStyle.LineBreakMode.WordWrap,
+                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
+                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
+            }]
+        };
+    }
 
     private static PointFeature CreateFeatureWithWordWrapCenter()
-        => new(new MPoint(0, 6000000)) { Styles = [CreateLabelStyleWithWordWrapCenter()] };
+    {
+        return new(new MPoint(0, 6000000))
+        {
+            Styles = [new LabelStyle
+            {
+                Text = "Long line break mode test",
+                BackColor = new Brush(Color.Transparent),
+                ForeColor = Color.White,
+                Halo = new Pen(Color.Black, 2),
+                MaxWidth = 10,
+                LineHeight = 1.2,
+                WordWrap = LabelStyle.LineBreakMode.WordWrap,
+                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+            }]
+        };
+    }
 
     private static PointFeature CreateFeatureWithWordWrapRight()
-        => new(new MPoint(8000000, 6000000)) { Styles = [CreateLabelStyleWithWordWrapRight()] };
+    {
+        return new(new MPoint(8000000, 6000000))
+        {
+            Styles = [new LabelStyle
+            {
+                Text = "Long line break mode test",
+                BackColor = new Brush(Color.Gray),
+                ForeColor = Color.White,
+                MaxWidth = 12,
+                WordWrap = LabelStyle.LineBreakMode.WordWrap,
+                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
+                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom,
+            }]
+        };
+    }
 
     private static PointFeature CreateFeatureWithCharacterWrap()
-        => new(new MPoint(0, 10000000)) { Styles = [CreateLabelStyleWithCharacterWrap()] };
-
-    private static PointFeature CreateFeatureWithHalo() => new(new MPoint(0, -12000000)) { Styles = [CreateHaloStyle()] };
-
-    private static LabelStyle CreateHaloStyle() => new()
     {
-        Text = "Halo Halo Halo",
-        BackColor = new Brush(Color.Transparent),
-        ForeColor = Color.White,
-        Halo = new Pen(Color.Black, 2)
-    };
+        return new(new MPoint(0, 10000000))
+        {
+            Styles = [new LabelStyle
+            {
+                Text = "Long line break mode test",
+                BackColor = null,
+                ForeColor = Color.Black,
+                MaxWidth = 6,
+                WordWrap = LabelStyle.LineBreakMode.CharacterWrap,
+                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+            }]
+        };
+    }
 
-    private static LabelStyle CreateLabelStyleWithHeadTruncation() => new()
+    private static PointFeature CreateFeatureWithHalo()
     {
-        Text = "Long line break mode test",
-        Font = new Font { Size = 16, Bold = true, Italic = false, },
-        BackColor = new Brush(Color.Transparent),
-        ForeColor = Color.White,
-        Halo = new Pen(Color.Black, 2),
-        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
-        MaxWidth = 10,
-        WordWrap = LabelStyle.LineBreakMode.HeadTruncation
-    };
-
-    private static LabelStyle CreateLabelStyleWithTailTruncation() => new()
-    {
-        Text = "Long line break mode test",
-        Font = new Font { FontFamily = "Courier New", Bold = true, Italic = true, },
-        BackColor = new Brush(Color.Transparent),
-        ForeColor = Color.White,
-        Halo = new Pen(Color.Black, 2),
-        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
-        MaxWidth = 10,
-        WordWrap = LabelStyle.LineBreakMode.TailTruncation
-    };
-
-
-    private static LabelStyle CreateLabelStyleWithMiddleTruncation() => new()
-    {
-        Text = "Long line break mode test",
-        Font = new Font { Size = 30 },
-        BackColor = new Brush(Color.Transparent),
-        ForeColor = Color.White,
-        Halo = new Pen(Color.Black, 2),
-        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-        MaxWidth = 10,
-        WordWrap = LabelStyle.LineBreakMode.MiddleTruncation
-    };
-
-    private static LabelStyle CreateLabelStyleWithWordWrapLeft() => new()
-    {
-        Text = "Long line break mode test",
-        BackColor = new Brush(Color.Gray),
-        ForeColor = Color.White,
-        Halo = new Pen(Color.Black, 2),
-        MaxWidth = 10,
-        WordWrap = LabelStyle.LineBreakMode.WordWrap,
-        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
-        VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
-    };
-
-
-    private static LabelStyle CreateLabelStyleWithWordWrapCenter() => new()
-    {
-        Text = "Long line break mode test",
-        BackColor = new Brush(Color.Transparent),
-        ForeColor = Color.White,
-        Halo = new Pen(Color.Black, 2),
-        MaxWidth = 10,
-        LineHeight = 1.2,
-        WordWrap = LabelStyle.LineBreakMode.WordWrap,
-        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-        VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
-    };
-
-    private static LabelStyle CreateLabelStyleWithWordWrapRight() => new()
-    {
-        Text = "Long line break mode test",
-        BackColor = new Brush(Color.Gray),
-        ForeColor = Color.White,
-        MaxWidth = 12,
-        WordWrap = LabelStyle.LineBreakMode.WordWrap,
-        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right,
-        VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom,
-    };
-
-    private static LabelStyle CreateLabelStyleWithCharacterWrap() => new()
-    {
-        Text = "Long line break mode test",
-        BackColor = null,
-        ForeColor = Color.Black,
-        MaxWidth = 6,
-        WordWrap = LabelStyle.LineBreakMode.CharacterWrap,
-        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-        VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
-    };
+        return new(new MPoint(0, -12000000))
+        {
+            Styles = [new LabelStyle
+            {
+                Text = "Halo Halo Halo",
+                BackColor = new Brush(Color.Transparent),
+                ForeColor = Color.White,
+                Halo = new Pen(Color.Black, 2)
+            }]
+        };
+    }
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
@@ -44,58 +44,46 @@ public class LabelsSample : ISample
         Styles = [new LabelStyle { Text = "Default Label" }]
     };
 
-    private static PointFeature CreateFeatureWithColors()
+    private static PointFeature CreateFeatureWithColors() => new(new MPoint(0, -7000000))
     {
-        return new(new MPoint(0, -7000000))
+        Styles = [new LabelStyle
         {
-            Styles = [new LabelStyle
-            {
-                Text = "Colors",
-                BackColor = new Brush(Color.Blue),
-                ForeColor = Color.White
-            }]
-        };
-    }
+            Text = "Colors",
+            BackColor = new Brush(Color.Blue),
+            ForeColor = Color.White
+        }]
+    };
 
-    private static PointFeature CreateFeatureWithBottomAlignedStyle()
+    private static PointFeature CreateFeatureWithBottomAlignedStyle() => new(new MPoint(0, -5000000))
     {
-        return new(new MPoint(0, -5000000))
+        Styles = [new LabelStyle
         {
-            Styles = [new LabelStyle
-            {
-                Text = "Bottom\nAligned",
-                BackColor = new Brush(Color.Gray),
-                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom
-            }]
-        };
-    }
+            Text = "Bottom\nAligned",
+            BackColor = new Brush(Color.Gray),
+            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom
+        }]
+    };
 
-    private static PointFeature CreateFeatureWithRightAlignedStyle()
+    private static PointFeature CreateFeatureWithRightAlignedStyle() => new(new MPoint(0, -2000000))
     {
-        return new(new MPoint(0, -2000000))
+        Styles = [new LabelStyle
         {
-            Styles = [new LabelStyle
-            {
-                Text = "Right Aligned",
-                BackColor = new Brush(Color.Gray),
-                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right
-            }]
-        };
-    }
+            Text = "Right Aligned",
+            BackColor = new Brush(Color.Gray),
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right
+        }]
+    };
 
-    private static GeometryFeature CreatePolygonWithLabel()
+    private static GeometryFeature CreatePolygonWithLabel() => new()
     {
-        return new()
+        Geometry = new WKTReader().Read("POLYGON((-1000000 -10000000, 1000000 -10000000, 1000000 -8000000, -1000000 -8000000, -1000000 -10000000))"),
+        Styles = [new LabelStyle
         {
-            Geometry = new WKTReader().Read("POLYGON((-1000000 -10000000, 1000000 -10000000, 1000000 -8000000, -1000000 -8000000, -1000000 -10000000))"),
-            Styles = [new LabelStyle
-            {
-                Text = "Polygon",
-                BackColor = new Brush(Color.Gray),
-                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center
-            }]
-        };
-    }
+            Text = "Polygon",
+            BackColor = new Brush(Color.Gray),
+            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center
+        }]
+    };
 
     private static PointFeature CreateFeatureWithTailTruncation()
     {

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
@@ -110,49 +110,49 @@ public class LabelsSample : ISample
     private static PointFeature CreateFeatureWithTailTruncation()
     {
         var featureWithColors = new PointFeature(new MPoint(8000000, 2000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak1());
+        featureWithColors.Styles.Add(CreateLabelStyleWithTailTrunction());
         return featureWithColors;
     }
 
     private static PointFeature CreateFeatureWithHeadTruncation()
     {
         var featureWithColors = new PointFeature(new MPoint(-8000000, 2000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak());
+        featureWithColors.Styles.Add(CreateLabelStyleWithHeadTruncation());
         return featureWithColors;
     }
 
     private static PointFeature CreateFeatureWithMiddleTruncation()
     {
         var featureWithColors = new PointFeature(new MPoint(0, 2000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak2());
+        featureWithColors.Styles.Add(CreateLabelStyleWithMiddleTruncation());
         return featureWithColors;
     }
 
     private static PointFeature CreateFeatureWithWordWrapLeft()
     {
         var featureWithColors = new PointFeature(new MPoint(-8000000, 6000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak4());
+        featureWithColors.Styles.Add(CreateLabelStyleWithWordWrapLeft());
         return featureWithColors;
     }
 
     private static PointFeature CreateFeatureWithWordWrapCenter()
     {
         var featureWithColors = new PointFeature(new MPoint(0, 6000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak5());
+        featureWithColors.Styles.Add(CreateLabelStyleWithWordWrapCenter());
         return featureWithColors;
     }
 
     private static PointFeature CreateFeatureWithWordWrapRight()
     {
         var featureWithColors = new PointFeature(new MPoint(8000000, 6000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak6());
+        featureWithColors.Styles.Add(CreateLabelStyleWithWordWrapRight());
         return featureWithColors;
     }
 
     private static PointFeature CreateFeatureWithCharacterWrap()
     {
         var featureWithColors = new PointFeature(new MPoint(0, 10000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithLineBreak7());
+        featureWithColors.Styles.Add(CreateLabelStyleWithCharacterWrap());
         return featureWithColors;
     }
 
@@ -166,7 +166,7 @@ public class LabelsSample : ISample
         Halo = new Pen(Color.Black, 2)
     };
 
-    private static LabelStyle CreateLabelStyleWithLineBreak() => new()
+    private static LabelStyle CreateLabelStyleWithHeadTruncation() => new()
     {
         Text = "Long line break mode test",
         Font = new Font { Size = 16, Bold = true, Italic = false, },
@@ -178,7 +178,7 @@ public class LabelsSample : ISample
         WordWrap = LabelStyle.LineBreakMode.HeadTruncation
     };
 
-    private static LabelStyle CreateLabelStyleWithLineBreak1() => new()
+    private static LabelStyle CreateLabelStyleWithTailTrunction() => new()
     {
         Text = "Long line break mode test",
         Font = new Font { FontFamily = "Courier New", Bold = true, Italic = true, },
@@ -191,7 +191,7 @@ public class LabelsSample : ISample
     };
 
 
-    private static LabelStyle CreateLabelStyleWithLineBreak2() => new()
+    private static LabelStyle CreateLabelStyleWithMiddleTruncation() => new()
     {
         Text = "Long line break mode test",
         Font = new Font { Size = 30 },
@@ -203,7 +203,7 @@ public class LabelsSample : ISample
         WordWrap = LabelStyle.LineBreakMode.MiddleTruncation
     };
 
-    private static LabelStyle CreateLabelStyleWithLineBreak4() => new()
+    private static LabelStyle CreateLabelStyleWithWordWrapLeft() => new()
     {
         Text = "Long line break mode test",
         BackColor = new Brush(Color.Gray),
@@ -216,7 +216,7 @@ public class LabelsSample : ISample
     };
 
 
-    private static LabelStyle CreateLabelStyleWithLineBreak5() => new()
+    private static LabelStyle CreateLabelStyleWithWordWrapCenter() => new()
     {
         Text = "Long line break mode test",
         BackColor = new Brush(Color.Transparent),
@@ -229,7 +229,7 @@ public class LabelsSample : ISample
         VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
     };
 
-    private static LabelStyle CreateLabelStyleWithLineBreak6() => new()
+    private static LabelStyle CreateLabelStyleWithWordWrapRight() => new()
     {
         Text = "Long line break mode test",
         BackColor = new Brush(Color.Gray),
@@ -240,7 +240,7 @@ public class LabelsSample : ISample
         VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom,
     };
 
-    private static LabelStyle CreateLabelStyleWithLineBreak7() => new()
+    private static LabelStyle CreateLabelStyleWithCharacterWrap() => new()
     {
         Text = "Long line break mode test",
         BackColor = null,

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/LabelsSample.cs
@@ -21,10 +21,9 @@ public class LabelsSample : ISample
         return Task.FromResult(map);
     }
 
-    public static ILayer CreateLayer()
-    {
-        var features = new List<IFeature>
-        {
+    public static MemoryLayer CreateLayer() => new() { Name = "Points with labels", Features = CreateFeatures() };
+
+    private static List<IFeature> CreateFeatures() => [
             CreateFeatureWithDefaultStyle(),
             CreateFeatureWithRightAlignedStyle(),
             CreateFeatureWithBottomAlignedStyle(),
@@ -38,123 +37,81 @@ public class LabelsSample : ISample
             CreateFeatureWithWordWrapCenter(),
             CreateFeatureWithWordWrapRight(),
             CreateFeatureWithCharacterWrap(),
-        };
+        ];
 
-        return new MemoryLayer { Name = "Points with labels", Features = features };
-    }
-
-    private static PointFeature CreateFeatureWithDefaultStyle()
+    private static PointFeature CreateFeatureWithDefaultStyle() => new(new MPoint(0, 0))
     {
-        var featureWithDefaultStyle = new PointFeature(new MPoint(0, 0));
-        featureWithDefaultStyle.Styles.Add(new LabelStyle { Text = "Default Label" });
-        return featureWithDefaultStyle;
-    }
+        Styles = [new LabelStyle { Text = "Default Label" }]
+    };
 
     private static PointFeature CreateFeatureWithColors()
-    {
-        var featureWithColors = new PointFeature(new MPoint(0, -7000000));
-        featureWithColors.Styles.Add(CreateColoredLabelStyle());
-        return featureWithColors;
-    }
+        => new(new MPoint(0, -7000000)) { Styles = [CreateColoredLabelStyle()] };
 
     private static PointFeature CreateFeatureWithBottomAlignedStyle()
-    {
-        var featureWithBottomAlignedStyle = new PointFeature(new MPoint(0, -5000000));
-        featureWithBottomAlignedStyle.Styles.Add(new LabelStyle
-        {
-            Text = "Bottom\nAligned",
-            BackColor = new Brush(Color.Gray),
-            VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom
-        });
-        return featureWithBottomAlignedStyle;
-    }
+        => new(new MPoint(0, -5000000)) { Styles = [CreateBottomAlignedStyle()] };
 
-    private static PointFeature CreateFeatureWithRightAlignedStyle()
+    private static LabelStyle CreateBottomAlignedStyle() => new()
     {
-        var featureWithRightAlignedStyle = new PointFeature(new MPoint(0, -2000000));
-        featureWithRightAlignedStyle.Styles.Add(new LabelStyle
-        {
-            Text = "Right Aligned",
-            BackColor = new Brush(Color.Gray),
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right
-        });
-        return featureWithRightAlignedStyle;
-    }
+        Text = "Bottom\nAligned",
+        BackColor = new Brush(Color.Gray),
+        VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Bottom
+    };
 
-    private static GeometryFeature CreatePolygonWithLabel()
+    private static PointFeature CreateFeatureWithRightAlignedStyle() => new(new MPoint(0, -2000000))
     {
-        var polygon = new GeometryFeature
-        {
-            Geometry = new WKTReader().Read(
-                "POLYGON((-1000000 -10000000, 1000000 -10000000, 1000000 -8000000, -1000000 -8000000, -1000000 -10000000))")
-        };
-        polygon.Styles.Add(new LabelStyle
-        {
-            Text = "Polygon",
-            BackColor = new Brush(Color.Gray),
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center
-        });
-        return polygon;
-    }
+        Styles = [CreateRightAlignedLabelStyle()]
+    };
 
-    private static LabelStyle CreateColoredLabelStyle()
+    private static LabelStyle CreateRightAlignedLabelStyle() => new()
     {
-        return new LabelStyle
-        {
-            Text = "Colors",
-            BackColor = new Brush(Color.Blue),
-            ForeColor = Color.White
-        };
-    }
+        Text = "Right Aligned",
+        BackColor = new Brush(Color.Gray),
+        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Right
+    };
+
+    private static GeometryFeature CreatePolygonWithLabel() => new()
+    {
+        Geometry = CreatePolygon(),
+        Styles = [CreatePolygonLabel()]
+    };
+
+    private static LabelStyle CreatePolygonLabel() => new()
+    {
+        Text = "Polygon",
+        BackColor = new Brush(Color.Gray),
+        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center
+    };
+
+    private static NetTopologySuite.Geometries.Geometry CreatePolygon()
+        => new WKTReader().Read("POLYGON((-1000000 -10000000, 1000000 -10000000, 1000000 -8000000, -1000000 -8000000, -1000000 -10000000))");
+
+    private static LabelStyle CreateColoredLabelStyle() => new()
+    {
+        Text = "Colors",
+        BackColor = new Brush(Color.Blue),
+        ForeColor = Color.White
+    };
 
     private static PointFeature CreateFeatureWithTailTruncation()
-    {
-        var featureWithColors = new PointFeature(new MPoint(8000000, 2000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithTailTrunction());
-        return featureWithColors;
-    }
+        => new(new MPoint(8000000, 2000000)) { Styles = [CreateLabelStyleWithTailTruncation()] };
 
     private static PointFeature CreateFeatureWithHeadTruncation()
-    {
-        var featureWithColors = new PointFeature(new MPoint(-8000000, 2000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithHeadTruncation());
-        return featureWithColors;
-    }
+        => new(new MPoint(-8000000, 2000000)) { Styles = [CreateLabelStyleWithHeadTruncation()] };
 
     private static PointFeature CreateFeatureWithMiddleTruncation()
-    {
-        var featureWithColors = new PointFeature(new MPoint(0, 2000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithMiddleTruncation());
-        return featureWithColors;
-    }
+        => new(new MPoint(0, 2000000)) { Styles = [CreateLabelStyleWithMiddleTruncation()] };
 
     private static PointFeature CreateFeatureWithWordWrapLeft()
-    {
-        var featureWithColors = new PointFeature(new MPoint(-8000000, 6000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithWordWrapLeft());
-        return featureWithColors;
-    }
+        => new(new MPoint(-8000000, 6000000)) { Styles = [CreateLabelStyleWithWordWrapLeft()] };
 
     private static PointFeature CreateFeatureWithWordWrapCenter()
-    {
-        var featureWithColors = new PointFeature(new MPoint(0, 6000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithWordWrapCenter());
-        return featureWithColors;
-    }
+        => new(new MPoint(0, 6000000)) { Styles = [CreateLabelStyleWithWordWrapCenter()] };
 
     private static PointFeature CreateFeatureWithWordWrapRight()
-    {
-        var featureWithColors = new PointFeature(new MPoint(8000000, 6000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithWordWrapRight());
-        return featureWithColors;
-    }
+        => new(new MPoint(8000000, 6000000)) { Styles = [CreateLabelStyleWithWordWrapRight()] };
 
     private static PointFeature CreateFeatureWithCharacterWrap()
-    {
-        var featureWithColors = new PointFeature(new MPoint(0, 10000000));
-        featureWithColors.Styles.Add(CreateLabelStyleWithCharacterWrap());
-        return featureWithColors;
-    }
+        => new(new MPoint(0, 10000000)) { Styles = [CreateLabelStyleWithCharacterWrap()] };
 
     private static PointFeature CreateFeatureWithHalo() => new(new MPoint(0, -12000000)) { Styles = [CreateHaloStyle()] };
 
@@ -178,7 +135,7 @@ public class LabelsSample : ISample
         WordWrap = LabelStyle.LineBreakMode.HeadTruncation
     };
 
-    private static LabelStyle CreateLabelStyleWithTailTrunction() => new()
+    private static LabelStyle CreateLabelStyleWithTailTruncation() => new()
     {
         Text = "Long line break mode test",
         Font = new Font { FontFamily = "Courier New", Bold = true, Italic = true, },

--- a/Samples/Mapsui.Samples.MapView/AnimatedMyLocationSample.cs
+++ b/Samples/Mapsui.Samples.MapView/AnimatedMyLocationSample.cs
@@ -39,7 +39,7 @@ public sealed class AnimatedMyLocationSample : IMapViewSample, IDisposable
     }
 
     public bool UpdateLocation => false;
-    public bool OnClick(object? sender, EventArgs args)
+    public bool OnTap(object? sender, EventArgs args)
     {
         return true;
     }

--- a/Samples/Mapsui.Samples.MapView/CircleSample.cs
+++ b/Samples/Mapsui.Samples.MapView/CircleSample.cs
@@ -16,7 +16,7 @@ public class CircleSample : IMapViewSample
 
     public bool UpdateLocation => true;
 
-    public bool OnClick(object? sender, EventArgs args)
+    public bool OnTap(object? sender, EventArgs args)
     {
         var mapView = sender as UI.Maui.MapView;
         var e = args as MapClickedEventArgs;

--- a/Samples/Mapsui.Samples.MapView/IMapViewSample.cs
+++ b/Samples/Mapsui.Samples.MapView/IMapViewSample.cs
@@ -5,7 +5,7 @@ namespace Mapsui.Samples.Maui;
 
 public interface IMapViewSample : IMapControlSample
 {
-    bool OnClick(object? sender, EventArgs args);
+    bool OnTap(object? sender, EventArgs args);
 
     bool UpdateLocation { get; }
 }

--- a/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
+++ b/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
@@ -39,7 +39,7 @@ public class ManyPinsSample : IMapViewSample
         foreach (var str in assembly.GetManifestResourceNames())
             System.Diagnostics.Debug.WriteLine(str);
 
-        switch (e?.NumOfTaps)
+        switch (e?.TapType)
         {
             case 1:
                 var pin = new Pin(mapView)

--- a/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
+++ b/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
@@ -1,4 +1,5 @@
 ﻿using Mapsui.Extensions;
+using Mapsui.Manipulations;
 using Mapsui.Samples.Common;
 using Mapsui.Samples.Common.Maps.Demo;
 using Mapsui.Styles;
@@ -41,7 +42,7 @@ public class ManyPinsSample : IMapViewSample
 
         switch (e?.TapType)
         {
-            case 1:
+            case TapType.Single:
                 var pin = new Pin(mapView)
                 {
                     Label = $"PinType.Pin {markerNum++}",
@@ -76,7 +77,7 @@ public class ManyPinsSample : IMapViewSample
                 mapView.Pins.Add(pin);
                 pin.ShowCallout();
                 break;
-            case 2:
+            case TapType.Double:
                 foreach (var r in assembly.GetManifestResourceNames())
                     System.Diagnostics.Debug.WriteLine(r);
 
@@ -95,17 +96,8 @@ public class ManyPinsSample : IMapViewSample
                 }
 
                 break;
-            case 3:
-                var icon = assembly.GetManifestResourceStream("Mapsui.Samples.Common.Images.loc.png")!.ToBytes();
-                mapView?.Pins.Add(new Pin(mapView)
-                {
-                    Label = $"PinType.Icon {markerNum++}",
-                    Position = e.Point,
-                    Type = PinType.Icon,
-                    Scale = 0.5f,
-                    Icon = icon
-                });
-                break;
+            default:
+                throw new Exception("Unknown TapType. This is bug in Mapsui.");
         }
 
         return true;

--- a/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
+++ b/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
@@ -28,7 +28,7 @@ public class ManyPinsSample : IMapViewSample
 
     public bool UpdateLocation => true;
 
-    public bool OnClick(object? sender, EventArgs args)
+    public bool OnTap(object? sender, EventArgs args)
     {
         var mapView = sender as UI.Maui.MapView;
         var e = args as MapClickedEventArgs;

--- a/Samples/Mapsui.Samples.MapView/MyLocationSample.cs
+++ b/Samples/Mapsui.Samples.MapView/MyLocationSample.cs
@@ -13,7 +13,7 @@ public class MyLocationSample : IMapViewSample
 
     public bool UpdateLocation => true;
 
-    public bool OnClick(object? sender, EventArgs args)
+    public bool OnTap(object? sender, EventArgs args)
     {
         var mapView = sender as UI.Maui.MapView;
         var e = args as MapClickedEventArgs;

--- a/Samples/Mapsui.Samples.MapView/PinSample.cs
+++ b/Samples/Mapsui.Samples.MapView/PinSample.cs
@@ -25,9 +25,9 @@ public class PinSample : IMapViewSample
 
     public bool UpdateLocation => true;
 
-    public bool OnClick(object? sender, EventArgs args)
+    public bool OnTap(object? sender, EventArgs args)
     {
-        var mapView = sender as MapView;
+        var mapView = sender as UI.Maui.MapView; // The namespace prefix is somehow necessary on Linux.
         var mapClickedArgs = (MapClickedEventArgs)args;
 
         if (mapView == null)

--- a/Samples/Mapsui.Samples.MapView/PinSample.cs
+++ b/Samples/Mapsui.Samples.MapView/PinSample.cs
@@ -11,6 +11,7 @@ using Mapsui.UI.Maui;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui;
 using Color = Microsoft.Maui.Graphics.Color;
+using Mapsui.Manipulations;
 
 namespace Mapsui.Samples.Maui;
 
@@ -37,7 +38,7 @@ public class PinSample : IMapViewSample
         foreach (var str in assembly.GetManifestResourceNames())
             System.Diagnostics.Debug.WriteLine(str);
 
-        switch (mapClickedArgs.NumOfTaps)
+        switch (mapClickedArgs.TapType)
         {
             case 1:
                 var pin = new Pin(mapView)
@@ -82,7 +83,7 @@ public class PinSample : IMapViewSample
                 }
                 pin.Callout.CalloutClicked += (s, e) =>
                 {
-                    if (e.NumOfTaps == 2)
+                    if (e.TapType == TapType.Double)
                     {
                         // Double click on callout moves pin
                         var p = e.Callout?.Pin;

--- a/Samples/Mapsui.Samples.MapView/PinSample.cs
+++ b/Samples/Mapsui.Samples.MapView/PinSample.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
-using Mapsui.Extensions;
 using Mapsui.Samples.Common;
 using Mapsui.Samples.Common.Maps.Demo;
 using Mapsui.Samples.Common.PersistentCaches;
@@ -18,7 +17,7 @@ namespace Mapsui.Samples.Maui;
 public class PinSample : IMapViewSample
 {
     int _markerNum = 1;
-    readonly Random _random = new Random(4);
+    readonly Random _random = new(4);
 
     public string Name => "Add Pin Sample";
 
@@ -28,7 +27,7 @@ public class PinSample : IMapViewSample
 
     public bool OnClick(object? sender, EventArgs args)
     {
-        var mapView = sender as UI.Maui.MapView;
+        var mapView = sender as MapView;
         var mapClickedArgs = (MapClickedEventArgs)args;
 
         if (mapView == null)
@@ -40,7 +39,7 @@ public class PinSample : IMapViewSample
 
         switch (mapClickedArgs.TapType)
         {
-            case 1:
+            case TapType.Single:
                 var pin = new Pin(mapView)
                 {
                     Label = $"PinType.Pin {_markerNum++}",
@@ -105,7 +104,7 @@ public class PinSample : IMapViewSample
                 mapView.Pins.Add(pin);
                 pin.ShowCallout();
                 break;
-            case 2:
+            case TapType.Double:
                 var resourceName = "Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg";
                 var stream = assembly.GetManifestResourceStream(resourceName);
                 if (stream == null) throw new Exception($"Could not find EmbeddedResource {resourceName}");
@@ -123,20 +122,6 @@ public class PinSample : IMapViewSample
                     });
                 }
 
-                break;
-            case 3:
-                using (var manifestResourceStream = assembly.GetManifestResourceStream("Mapsui.Samples.Common.Images.loc.png"))
-                {
-                    var icon = manifestResourceStream!.ToBytes();
-                    mapView.Pins.Add(new Pin(mapView)
-                    {
-                        Label = $"PinType.Icon {_markerNum++}",
-                        Position = mapClickedArgs.Point,
-                        Type = PinType.Icon,
-                        Scale = 0.5f,
-                        Icon = icon
-                    });
-                }
                 break;
         }
 

--- a/Samples/Mapsui.Samples.MapView/PolygonSample.cs
+++ b/Samples/Mapsui.Samples.MapView/PolygonSample.cs
@@ -16,7 +16,7 @@ public class PolygonSample : IMapViewSample
 
     public bool UpdateLocation => true;
 
-    public bool OnClick(object? sender, EventArgs args)
+    public bool OnTap(object? sender, EventArgs args)
     {
         var mapView = sender as UI.Maui.MapView;
         var e = args as MapClickedEventArgs;

--- a/Samples/Mapsui.Samples.MapView/PolylineSample.cs
+++ b/Samples/Mapsui.Samples.MapView/PolylineSample.cs
@@ -15,7 +15,7 @@ public class PolylineSample : IMapViewSample
 
     public bool UpdateLocation => true;
 
-    public bool OnClick(object? sender, EventArgs args)
+    public bool OnTap(object? sender, EventArgs args)
     {
         var mapView = sender as UI.Maui.MapView;
         var e = args as MapClickedEventArgs;

--- a/Samples/Mapsui.Samples.MapView/SnapshotSample.cs
+++ b/Samples/Mapsui.Samples.MapView/SnapshotSample.cs
@@ -15,7 +15,7 @@ public class SnapshotSample : IMapViewSample
 
     public bool UpdateLocation => true;
 
-    public bool OnClick(object? sender, EventArgs args)
+    public bool OnTap(object? sender, EventArgs args)
     {
         var mapView = sender as UI.Maui.MapView;
         var e = args as MapClickedEventArgs;

--- a/Samples/Mapsui.Samples.Maui.MapView/MainPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MainPage.xaml.cs
@@ -58,7 +58,7 @@ public partial class MainPage : ContentPage
 
         clicker = null;
         if (sample is IMapViewSample formsSample)
-            clicker = formsSample.OnClick;
+            clicker = formsSample.OnTap;
 
         if (sample != null)
             (Application.Current?.MainPage as NavigationPage)?.PushAsync(new MapPage(sample, clicker));

--- a/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
@@ -14,6 +14,7 @@ using Mapsui.UI.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Devices.Sensors;
+using Mapsui.Manipulations;
 
 namespace Mapsui.Samples.Maui;
 
@@ -140,13 +141,13 @@ public sealed partial class MainPageLarge : ContentPage, IDisposable
     {
         if (e.Pin != null)
         {
-            if (e.NumOfTaps == 2)
+            if (e.TapType == TapType.Double)
             {
                 // Hide Pin when double click
                 //DisplayAlert($"Pin {e.Pin.Label}", $"Is at position {e.Pin.Position}", "Ok");
                 e.Pin.IsVisible = false;
             }
-            if (e.NumOfTaps == 1)
+            if (e.TapType == TapType.Single)
                 if (e.Pin.Callout.IsVisible)
                     e.Pin.HideCallout();
                 else

--- a/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
@@ -128,7 +128,7 @@ public sealed partial class MainPageLarge : ContentPage, IDisposable
         _clicker = null;
         if (sample is IMapViewSample formsSample)
         {
-            _clicker = formsSample.OnClick;
+            _clicker = formsSample.OnTap;
             _updateLocation = formsSample.UpdateLocation;
         }
         else

--- a/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
@@ -13,6 +13,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Devices.Sensors;
 using Compass = Microsoft.Maui.Devices.Sensors.Compass;
 using Microsoft.Maui.Dispatching;
+using Mapsui.Manipulations;
 
 namespace Mapsui.Samples.Maui;
 
@@ -104,13 +105,13 @@ public sealed partial class MapPage : ContentPage, IDisposable
     {
         if (e.Pin != null)
         {
-            if (e.NumOfTaps == 2)
+            if (e.TapType == TapType.Double)
             {
                 // Hide Pin when double click
                 //DisplayAlert($"Pin {e.Pin.Label}", $"Is at position {e.Pin.Position}", "Ok");
                 e.Pin.IsVisible = false;
             }
-            if (e.NumOfTaps == 1)
+            if (e.TapType == TapType.Single)
                 if (e.Pin.Callout.IsVisible)
                     e.Pin.HideCallout();
                 else

--- a/Tests/Mapsui.Rendering.Skia.Tests/RegressionMapControl.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/RegressionMapControl.cs
@@ -81,7 +81,7 @@ public sealed class RegressionMapControl : IMapControl
         throw new NotImplementedException();
     }
 
-    public MapInfo? GetMapInfo(ScreenPosition? screenPosition, int margin = 0)
+    public MapInfo GetMapInfo(ScreenPosition screenPosition, int margin = 0)
     {
         throw new NotImplementedException();
     }


### PR DESCRIPTION
- Make MapInfo non-nullable. This was easy to fix in the core and avoids having to pass the nullable MapInfo to many other method.
- Use TapType in MapInfo
- Some renaming from Info to MapInfo, but not yet on the event, perhaps I should rename that as well.
- Add GetMapInfo() to the WidgetEventArgs to make it easy to call from all events. By adding it as a method it will not affect performance unless users will actually call the GetMapInfo(). I am considering adding a list of layer to query as argument and remove the ILayer.IsInfoLayer.
- Cleanup LabelsSample.cs (completely unrelated)