### PR TITLE
Implement GetShiftPressed on Eto

### DIFF
--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -16,7 +16,6 @@ public partial class MapControl : ComponentBase, IMapControl
     protected readonly string _elementId = Guid.NewGuid().ToString("N");
     private SKImageInfo? _canvasSize;
     private bool _onLoaded;
-    private readonly HashSet<string> _pressedKeys = [];
     private double _pixelDensityFromInterop = 1;
     private BoundingClientRect _clientRect = new();
     private MapsuiJsInterop? _interop;
@@ -54,16 +53,6 @@ public partial class MapControl : ComponentBase, IMapControl
     {
         base.OnInitialized();
         RefreshGraphics();
-    }
-
-    protected void OnKeyDown(KeyboardEventArgs e)
-    {
-        _pressedKeys.Add(e.Code);
-    }
-
-    protected void OnKeyUp(KeyboardEventArgs e)
-    {
-        _pressedKeys.Remove(e.Code);
     }
 
     protected void OnPaintSurfaceCPU(SKPaintSurfaceEventArgs e)
@@ -232,11 +221,6 @@ public partial class MapControl : ComponentBase, IMapControl
         });
     }
 
-    private bool GetShiftPressed()
-    {
-        return _pressedKeys.Contains("ShiftLeft") || _pressedKeys.Contains("ShiftRight") || _pressedKeys.Contains("Shift");
-    }
-
     public void OnTouchStart(TouchEventArgs e)
     {
         Catch.Exceptions(() =>
@@ -277,4 +261,6 @@ public partial class MapControl : ComponentBase, IMapControl
             OnMapPointerReleased([position]);
         });
     }
+
+    private bool GetShiftPressed() => false; // Could not get keydown/up to work. Please try to get this to work if possible. 
 }

--- a/Mapsui.UI.Blazor/MapControlComponent.razor
+++ b/Mapsui.UI.Blazor/MapControlComponent.razor
@@ -4,7 +4,6 @@
 
 <div @onmouseup=@OnMouseUp @onmousedown=@OnMouseDown 
      @onmousewheel=@OnMouseWheel @onmousemove=@OnMouseMove 
-     @onkeydown=@OnKeyDown @onkeyup=@OnKeyUp
      @ontouchstart=@OnTouchStart @ontouchmove=@OnTouchMove @ontouchend=@OnTouchEnd
      @onwheel="OnMouseWheel" 
      name="@_elementId" id="@_elementId">

--- a/Mapsui.UI.Eto/MapControl.cs
+++ b/Mapsui.UI.Eto/MapControl.cs
@@ -12,6 +12,7 @@ public partial class MapControl : SkiaDrawable, IMapControl
 {
     private Cursor _defaultCursor = Cursors.Default;
     private readonly ManipulationTracker _manipulationTracker = new();
+    private bool _shiftPressed;
 
     public MapControl()
     {
@@ -120,6 +121,19 @@ public partial class MapControl : SkiaDrawable, IMapControl
         base.Dispose(disposing);
     }
 
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _shiftPressed = e.Shift;
+    }
+
+    protected override void OnKeyUp(KeyEventArgs e)
+    {
+        base.OnKeyUp(e);
+        _shiftPressed = e.Shift;
+    }
+
     private double GetPixelDensity()
     {
         var center = PointToScreen(Location + Size / 2);
@@ -141,6 +155,6 @@ public partial class MapControl : SkiaDrawable, IMapControl
 
     private bool GetShiftPressed()
     {
-        return false; // Todo: Implement
+        return _shiftPressed;
     }
 }

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -328,5 +328,5 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
             : _canvasView!.CanvasSize.Width / Width;
     }
 
-    private static bool GetShiftPressed() => false;
+    private static bool GetShiftPressed() => false; // Work in progress: https://github.com/dotnet/maui/issues/16202
 }


### PR DESCRIPTION
Added GetShiftPressed  for Eto but not for Blazor and MAUI. This is the status for now:

- WPF: Done
- Eto: Done
- Avalonia: Done
- WinUI/Uno: Done. I can't say anything about if this could work on Android or iOS
- Blazor: There was some code but it did not work and I did not see a way to fix it, so I remove the existing code.
- MAUI: It seems there is no support for this in .NET 8, but might be in .NET 9.
- .NET Android: Not implemented
- .NET iOS: Not implemented

My plan is to leave it like this is for the time being.

Currently the shift state is checked in the EditingWidget to:
- Finalize adding a linestring or polygon
- Delete a vertex in a linestring or polygon

Both can also be done with a double tap.

### Future work:
- Change EditingWidget into a generic ManipulationWidget and move the EditManipuation and EditManager back to the samples.
- In double tap check if the second tap is near the first tap.







