### PR TITLE
Remove a few of the null-forgiving operators (!)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,7 +27,7 @@ csharp_style_expression_bodied_accessors = true:silent
 csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = false:silent
 csharp_style_inlined_variable_declaration = true:suggestion
-csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:silent
 csharp_style_var_for_built_in_types = true:silent
 csharp_style_var_when_type_is_apparent = true:silent
 csharp_style_var_elsewhere = true:silent
@@ -251,11 +251,12 @@ dotnet_code_quality_unused_parameters = all:suggestion
 dotnet_style_collection_initializer = true:suggestion
 
 ### dotnet_diagnostic
-dotnet_diagnostic.CS1591.severity = none # CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = silent # CS1591: Missing XML comment for publicly visible type or member
 dotnet_diagnostic.IDE0055.severity = error # fix formatting
 dotnet_diagnostic.IDE0005.severity = error # Remove unused usings, works only while editing, not when running dotnet format
 dotnet_diagnostic.CA1512.severity = silent # CA1512: Use ArgumentOutOfRangeException throw helper - Why set to silent? Because we use net7 and it is not supported there.
 dotnet_diagnostic.IDE0059.severity = warning # IDE0059: Unnecessary assignment of a value
+dotnet_diagnostic.CA2208.severity = silent # CA2208: Instantiate argument exceptions correctly
 
 # Spelling
 spelling_exclusion_path = spelling_exclusion.txt

--- a/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToBitmapPerformance.cs
+++ b/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToBitmapPerformance.cs
@@ -50,8 +50,8 @@ public class RenderToBitmapPerformance
         _webpMap.WaitForLoadingAsync().Wait();
         _map.WaitForLoadingAsync().Wait();
         _mapCached.WaitForLoadingAsync().Wait();
-        // render one time the map so that the sk path are cached.
-        using var bitmap = _mapRendererCached.RenderToBitmapStream(_mapCached.Map.Navigator.Viewport, _mapCached.Map!.Layers, Color.White);
+        // Render one time the map so that the sk path are cached.
+        using var bitmap = _mapRendererCached.RenderToBitmapStream(_mapCached.Map.Navigator.Viewport, _mapCached.Map.Layers, Color.White);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits", Justification = "Needs to be synchronous")]
@@ -138,7 +138,7 @@ public class RenderToBitmapPerformance
     [Benchmark]
     public void RenderDefault()
     {
-        using var bitmap = _mapRenderer.RenderToBitmapStream(_map.Map.Navigator.Viewport, _map.Map!.Layers, Color.White);
+        using var bitmap = _mapRenderer.RenderToBitmapStream(_map.Map.Navigator.Viewport, _map.Map.Layers, Color.White);
 #if DEBUG
         File.WriteAllBytes(@$"{OutputFolder()}\Test.png", bitmap.ToArray());
 #endif
@@ -147,7 +147,7 @@ public class RenderToBitmapPerformance
     [Benchmark]
     public void RenderDefaultCached()
     {
-        using var bitmap = _mapRendererCached.RenderToBitmapStream(_mapCached.Map.Navigator.Viewport, _mapCached.Map!.Layers, Color.White);
+        using var bitmap = _mapRendererCached.RenderToBitmapStream(_mapCached.Map.Navigator.Viewport, _mapCached.Map.Layers, Color.White);
 #if DEBUG
         File.WriteAllBytes(@$"{OutputFolder()}\Test.png", bitmap.ToArray());
 #endif
@@ -156,7 +156,7 @@ public class RenderToBitmapPerformance
     [Benchmark]
     public void RenderRasterizingTilingPng()
     {
-        using var bitmap = _mapRendererPng.RenderToBitmapStream(_pngMap.Map.Navigator.Viewport, _pngMap.Map!.Layers, Color.White);
+        using var bitmap = _mapRendererPng.RenderToBitmapStream(_pngMap.Map.Navigator.Viewport, _pngMap.Map.Layers, Color.White);
 #if DEBUG
         File.WriteAllBytes(@$"{OutputFolder()}\Testpng.png", bitmap.ToArray());
 #endif
@@ -165,7 +165,7 @@ public class RenderToBitmapPerformance
     [Benchmark]
     public void RenderRasterizingTilingWebP()
     {
-        using var bitmap = _mapRendererWebp.RenderToBitmapStream(_webpMap.Map.Navigator.Viewport, _webpMap.Map!.Layers, Color.White);
+        using var bitmap = _mapRendererWebp.RenderToBitmapStream(_webpMap.Map.Navigator.Viewport, _webpMap.Map.Layers, Color.White);
 #if DEBUG
         File.WriteAllBytes(@$"{OutputFolder()}\Testwebp.png", bitmap.ToArray());
 #endif
@@ -174,7 +174,7 @@ public class RenderToBitmapPerformance
     [Benchmark]
     public void RenderRasterizingTilingSkp()
     {
-        using var bitmap = _mapRendererSkp.RenderToBitmapStream(_skpMap.Map.Navigator.Viewport, _skpMap.Map!.Layers, Color.White);
+        using var bitmap = _mapRendererSkp.RenderToBitmapStream(_skpMap.Map.Navigator.Viewport, _skpMap.Map.Layers, Color.White);
 #if DEBUG
         File.WriteAllBytes(@$"{OutputFolder()}\Testskp.png", bitmap.ToArray());
 #endif

--- a/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToCpuPerformance.cs
+++ b/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToCpuPerformance.cs
@@ -179,25 +179,25 @@ public class RenderToCpuPerformance : IDisposable
     [Benchmark]
     public void RenderRasterizingPng()
     {
-        _mapRenderer.Render(_skCanvas, _rasterizingPngMap.Map.Navigator.Viewport, _rasterizingPngMap.Map!.Layers, _rasterizingPngMap.Map!.Widgets, Color.White);
+        _mapRenderer.Render(_skCanvas, _rasterizingPngMap.Map.Navigator.Viewport, _rasterizingPngMap.Map.Layers, _rasterizingPngMap.Map!.Widgets, Color.White);
     }
 
     [Benchmark]
     public void RenderRasterizingSkp()
     {
-        _mapRenderer.Render(_skCanvas, _rasterizingSkpMap.Map.Navigator.Viewport, _rasterizingSkpMap.Map!.Layers, _rasterizingSkpMap.Map!.Widgets, Color.White);
+        _mapRenderer.Render(_skCanvas, _rasterizingSkpMap.Map.Navigator.Viewport, _rasterizingSkpMap.Map.Layers, _rasterizingSkpMap.Map!.Widgets, Color.White);
     }
 
     [Benchmark]
     public void RenderRasterizingTilingSkp()
     {
-        _mapRenderer.Render(_skCanvas, _rasterizingTilingSkpMap.Map.Navigator.Viewport, _rasterizingTilingSkpMap.Map!.Layers, _rasterizingTilingSkpMap.Map!.Widgets, Color.White);
+        _mapRenderer.Render(_skCanvas, _rasterizingTilingSkpMap.Map.Navigator.Viewport, _rasterizingTilingSkpMap.Map.Layers, _rasterizingTilingSkpMap.Map.Widgets, Color.White);
     }
 
     [Benchmark]
     public void RenderTilingPng()
     {
-        _mapRenderer.Render(_skCanvas, _tilingPngMap.Map.Navigator.Viewport, _tilingPngMap.Map!.Layers, _tilingPngMap.Map!.Widgets, Color.White);
+        _mapRenderer.Render(_skCanvas, _tilingPngMap.Map.Navigator.Viewport, _tilingPngMap.Map.Layers, _tilingPngMap.Map.Widgets, Color.White);
     }
 
     [Benchmark]

--- a/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToCpuPerformance.cs
+++ b/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToCpuPerformance.cs
@@ -179,13 +179,13 @@ public class RenderToCpuPerformance : IDisposable
     [Benchmark]
     public void RenderRasterizingPng()
     {
-        _mapRenderer.Render(_skCanvas, _rasterizingPngMap.Map.Navigator.Viewport, _rasterizingPngMap.Map.Layers, _rasterizingPngMap.Map!.Widgets, Color.White);
+        _mapRenderer.Render(_skCanvas, _rasterizingPngMap.Map.Navigator.Viewport, _rasterizingPngMap.Map.Layers, _rasterizingPngMap.Map.Widgets, Color.White);
     }
 
     [Benchmark]
     public void RenderRasterizingSkp()
     {
-        _mapRenderer.Render(_skCanvas, _rasterizingSkpMap.Map.Navigator.Viewport, _rasterizingSkpMap.Map.Layers, _rasterizingSkpMap.Map!.Widgets, Color.White);
+        _mapRenderer.Render(_skCanvas, _rasterizingSkpMap.Map.Navigator.Viewport, _rasterizingSkpMap.Map.Layers, _rasterizingSkpMap.Map.Widgets, Color.White);
     }
 
     [Benchmark]

--- a/Mapsui.Extensions/Cache/SqlitePersistentCache.cs
+++ b/Mapsui.Extensions/Cache/SqlitePersistentCache.cs
@@ -253,7 +253,7 @@ public class SqlitePersistentCache : IPersistentCache<byte[]>, IUrlPersistentCac
         if (bytes == null || string.IsNullOrEmpty(compression) || string.Equals(compression, _noCompression, StringComparison.InvariantCultureIgnoreCase))
             return bytes;
 
-        switch (compression!.ToLower())
+        switch (compression.ToLower())
         {
             case _brotliCompression:
                 {

--- a/Mapsui.Extensions/Projections/DotSpatialProjection.cs
+++ b/Mapsui.Extensions/Projections/DotSpatialProjection.cs
@@ -49,7 +49,7 @@ public class DotSpatialProjection : IProjection, IProjectionCrs
         var fromId = GetIdFromCrs(fromCRS);
         var toId = GetIdFromCrs(toCRS);
         if (fromId == toId)
-            return (x, y); // No transformation needed
+            return (x, y);
 
         var transform = GetTransformation(fromId, toId);
         if (transform == null) throw new ArgumentException();
@@ -61,7 +61,7 @@ public class DotSpatialProjection : IProjection, IProjectionCrs
         [DisallowNull] (ProjectionInfo From, ProjectionInfo To)? transform)
     {
         var pointsXy = new[] { x, y };
-        Reproject.ReprojectPoints(pointsXy, Array.Empty<double>(), transform.Value.From, transform.Value.To, 0, 1);
+        Reproject.ReprojectPoints(pointsXy, [], transform.Value.From, transform.Value.To, 0, 1);
         return (pointsXy[0], pointsXy[1]);
     }
 
@@ -70,7 +70,6 @@ public class DotSpatialProjection : IProjection, IProjectionCrs
         var fromId = GetIdFromCrs(fromCRS);
         var toId = GetIdFromCrs(toCRS);
         if (fromId == toId)
-            // no transformation needed
             return;
 
         var transform = GetTransformation(fromId, toId);
@@ -84,7 +83,6 @@ public class DotSpatialProjection : IProjection, IProjectionCrs
         var fromId = GetIdFromCrs(fromCRS);
         var toId = GetIdFromCrs(toCRS);
         if (fromId == toId)
-            // no transformation needed
             return;
 
         var transform = GetTransformation(fromId, toId);
@@ -101,7 +99,7 @@ public class DotSpatialProjection : IProjection, IProjectionCrs
         var fromId = GetIdFromCrs(fromCRS);
         var toId = GetIdFromCrs(toCRS);
         if (fromId == toId)
-            return true; // No transformation needed
+            return true; // This is supported because we do not need to project
 
         var fromCoordinateSystem = GetCoordinateSystemById(fromId);
         if (fromCoordinateSystem == null) return false;
@@ -141,7 +139,6 @@ public class DotSpatialProjection : IProjection, IProjectionCrs
         var fromId = GetIdFromCrs(fromCRS);
         var toId = GetIdFromCrs(toCRS);
         if (fromId == toId)
-            // no transformation needed
             return;
 
         if (feature is GeometryFeature geometryFeature)

--- a/Mapsui.Nts/Editing/EditManager.cs
+++ b/Mapsui.Nts/Editing/EditManager.cs
@@ -422,6 +422,6 @@ public class EditManager
         if (Layer?.Extent is null)
             return null;
 
-        return Layer.Extent!.Grow(Layer.Extent.Width * 0.2);
+        return Layer.Extent.Grow(Layer.Extent.Width * 0.2);
     }
 }

--- a/Mapsui.Rendering.Skia/SkiaWidgets/ScaleBarWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/ScaleBarWidgetRenderer.cs
@@ -9,10 +9,10 @@ namespace Mapsui.Rendering.Skia.SkiaWidgets;
 
 public class ScaleBarWidgetRenderer : ISkiaWidgetRenderer, IDisposable
 {
-    private SKPaint? _paintScaleBar;
-    private SKPaint? _paintScaleBarStroke;
-    private SKPaint? _paintScaleText;
-    private SKPaint? _paintScaleTextStroke;
+    private readonly SKPaint _paintScaleBar = CreateScaleBarPaint(SKPaintStyle.Fill);
+    private readonly SKPaint _paintScaleBarStroke = CreateScaleBarPaint(SKPaintStyle.Stroke);
+    private readonly SKPaint _paintScaleText = CreateTextPaint(SKPaintStyle.Fill);
+    private readonly SKPaint _paintScaleTextStroke = CreateTextPaint(SKPaintStyle.Stroke);
 
     public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget,
         float layerOpacity)
@@ -20,20 +20,10 @@ public class ScaleBarWidgetRenderer : ISkiaWidgetRenderer, IDisposable
         var scaleBar = (ScaleBarWidget)widget;
         if (!scaleBar.CanProject()) return;
 
-        // If this is the first time, we call this renderer, ...
-        if (_paintScaleBar == null)
-        {
-            // ... than create the paints
-            _paintScaleBar = CreateScaleBarPaint(SKPaintStyle.Fill);
-            _paintScaleBarStroke = CreateScaleBarPaint(SKPaintStyle.Stroke);
-            _paintScaleText = CreateTextPaint(SKPaintStyle.Fill);
-            _paintScaleTextStroke = CreateTextPaint(SKPaintStyle.Stroke);
-        }
-
         // Update paints with new values
         _paintScaleBar.Color = scaleBar.TextColor.ToSkia(layerOpacity);
         _paintScaleBar.StrokeWidth = (float)(scaleBar.StrokeWidth * scaleBar.Scale);
-        _paintScaleBarStroke!.Color = scaleBar.Halo.ToSkia(layerOpacity);
+        _paintScaleBarStroke.Color = scaleBar.Halo.ToSkia(layerOpacity);
         _paintScaleBarStroke.StrokeWidth = (float)(scaleBar.StrokeWidthHalo * scaleBar.Scale);
         _paintScaleText!.Color = scaleBar.TextColor.ToSkia(layerOpacity);
         _paintScaleText.StrokeWidth = (float)(scaleBar.StrokeWidth * scaleBar.Scale);
@@ -167,10 +157,10 @@ public class ScaleBarWidgetRenderer : ISkiaWidgetRenderer, IDisposable
     {
         if (disposing)
         {
-            _paintScaleBar?.Dispose();
-            _paintScaleBarStroke?.Dispose();
-            _paintScaleText?.Dispose();
-            _paintScaleTextStroke?.Dispose();
+            _paintScaleBar.Dispose();
+            _paintScaleBarStroke.Dispose();
+            _paintScaleText.Dispose();
+            _paintScaleTextStroke.Dispose();
         }
     }
 }

--- a/Mapsui/Layers/WritableLayer.cs
+++ b/Mapsui/Layers/WritableLayer.cs
@@ -22,19 +22,19 @@ public class WritableLayer : BaseLayer
 
     private MRect? GetExtent()
     {
-        // todo: Calculate extent only once. Use a _modified field to determine when this is needed.
+        // Todo: Calculate extent only once. Use a _modified field to determine when this is needed.
 
         var extents = _cache
-            .Select(f => f.Extent)
-            .Where(g => g != null)
+            .Where(f => f.Extent is not null)
+            .Select(f => f.Extent!)
             .ToList();
 
         if (extents.Count == 0) return null;
 
-        var minX = extents.Min(g => g!.MinX);
-        var minY = extents.Min(g => g!.MinY);
-        var maxX = extents.Max(g => g!.MaxX);
-        var maxY = extents.Max(g => g!.MaxY);
+        var minX = extents.Min(e => e.MinX);
+        var minY = extents.Min(e => e.MinY);
+        var maxX = extents.Max(e => e.MaxX);
+        var maxY = extents.Max(e => e.MaxY);
 
         return new MRect(minX, minY, maxX, maxY);
     }

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolInCollectionSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolInCollectionSample.cs
@@ -46,28 +46,28 @@ public class BitmapSymbolInCollectionSample : ISample
         // This test was created the easy way, by copying BitmapSymbol and the GeometryCollection. A test 
         // written specifically for GeometryCollection would probably look different.
 
-        return new List<IFeature>
-        {
+        return
+        [
             new GeometryFeature
             {
-                Geometry = new  GeometryCollection(new Geometry[]  { new Point(50, 50) } ),
-                Styles = new[] {new VectorStyle {Fill = new Brush(Color.Red)}}
+                Geometry = new GeometryCollection([new Point(50, 50)]),
+                Styles = [new VectorStyle { Fill = new Brush(Color.Red) }]
             },
             new GeometryFeature
             {
-                Geometry = new  GeometryCollection(new Geometry[]  {  new Point(50, 100) } ),
-                Styles = new[] {new SymbolStyle { BitmapId = circleIconId}}
+                Geometry = new GeometryCollection([new Point(50, 100)]),
+                Styles = [new SymbolStyle { BitmapId = circleIconId }]
             },
             new GeometryFeature
             {
-                Geometry = new GeometryCollection(new Geometry[]  {  new Point(100, 50) } ),
-                Styles = new[] {new SymbolStyle { BitmapId = checkeredIconId}}
+                Geometry = new GeometryCollection([new Point(100, 50)]),
+                Styles = [new SymbolStyle { BitmapId = checkeredIconId }]
             },
             new GeometryFeature
             {
-                Geometry = new GeometryCollection(new Geometry[]  {  new Point(100, 100) } ),
-                Styles = new[] {new VectorStyle {Fill = new Brush(Color.Green), Outline = null}}
+                Geometry = new GeometryCollection([new Point(100, 100)]),
+                Styles = [new VectorStyle { Fill = new Brush(Color.Green) }]
             }
-        };
+        ];
     }
 }


### PR DESCRIPTION
The bang operator is an easy way to suppress the null warning. Perhaps this could be the best option in some cases but it should not be the general way to go about the null warnings, because that would defeat the purpose of turning nullable on. When working more with nullable=true, and working on new code, I feel less need to add the bang, perhaps it may not be needed at all. Also it may be better to have no bang, because if the compiler does not understand that something can not be null it is not easy to understand for the developer either. If we make it easy for the compiler we also make it easy for the developer.