### PR TITLE
Always log in Blazor samples

### DIFF
--- a/Samples/Mapsui.Samples.Blazor/Pages/Index.razor.cs
+++ b/Samples/Mapsui.Samples.Blazor/Pages/Index.razor.cs
@@ -3,6 +3,7 @@ using Mapsui.Samples.Common;
 using Mapsui.Samples.Common.Extensions;
 using Mapsui.Samples.Common.Maps.Widgets;
 using Mapsui.UI.Blazor;
+using Mapsui.Widgets.InfoWidgets;
 using Microsoft.AspNetCore.Components;
 
 namespace Mapsui.Samples.Blazor.Pages;
@@ -59,6 +60,7 @@ public partial class Index
     protected override void OnInitialized()
     {
         base.OnInitialized();
+        LoggingWidget.ShowLoggingInMap = ShowLoggingInMap.WhenLoggingWidgetIsEnabled; // To show logging in release mode
         FillComboBoxWithCategories();
     }
 


### PR DESCRIPTION
In our own sample we want logging enabled.

### Future work: LogLevel
btw, we currently have no filtering on log level anywhere in our own code. I would think this is up to the specific loggers. Perhaps the LoggingWidget should have it's own. Should it be a static (which I think was the best option for the ShowLoggingInMap field) or an instance field. Or perhaps a LoggingWidget.DefaultLogLevel which is static and an instance LoggingWidget.LogLevel.