### PR TITLE
Fix: Nullreference exception in MapView Constructor

### DIFF
--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -32,9 +32,9 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     private const string _calloutLayerName = "Callouts";
     private const string _pinLayerName = "Pins";
     private const string _drawableLayerName = "Drawables";
-    private readonly ObservableMemoryLayer<Callout> _mapCalloutLayer;
-    private readonly ObservableMemoryLayer<Pin> _mapPinLayer;
-    private readonly ObservableMemoryLayer<Drawable> _mapDrawableLayer;
+    private readonly ObservableMemoryLayer<Callout> _mapCalloutLayer = new(f => f.Feature) { Name = _calloutLayerName, IsMapInfoLayer = true };
+    private readonly ObservableMemoryLayer<Pin> _mapPinLayer = new(f => f.Feature) { Name = _pinLayerName, IsMapInfoLayer = true };
+    private readonly ObservableMemoryLayer<Drawable> _mapDrawableLayer = new(f => f.Feature) { Name = _drawableLayerName, IsMapInfoLayer = true };
     private IconButtonWidget? _mapZoomInButton;
     private IconButtonWidget? _mapZoomOutButton;
     private IconButtonWidget? _mapMyLocationButton;
@@ -54,10 +54,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
         IsClippedToBounds = true;
 
-        MyLocationLayer = new Objects.MyLocationLayer(this) { Enabled = true };
-        _mapCalloutLayer = new ObservableMemoryLayer<Callout>(f => f.Feature) { Name = _calloutLayerName, IsMapInfoLayer = true };
-        _mapPinLayer = new ObservableMemoryLayer<Pin>(f => f.Feature) { Name = _pinLayerName, IsMapInfoLayer = true };
-        _mapDrawableLayer = new ObservableMemoryLayer<Drawable>(f => f.Feature) { Name = _drawableLayerName, IsMapInfoLayer = true };
+        MyLocationLayer.MapView = this;
 
         // Get defaults from MapControl
         RotationLock = Map.Navigator.RotationLock;
@@ -143,7 +140,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     /// <summary>
     /// MyLocation layer
     /// </summary>
-    public Objects.MyLocationLayer MyLocationLayer { get; }
+    public Objects.MyLocationLayer MyLocationLayer { get; } = new() { Enabled = true };
 
     /// <summary>
     /// Should my location be visible on map

--- a/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
@@ -9,7 +9,6 @@ using Mapsui.Nts.Extensions;
 using Mapsui.Utilities;
 using Animation = Mapsui.Animations.Animation;
 using Mapsui.UI.Maui;
-using HarfBuzzSharp;
 
 #pragma warning disable IDISP004 // Don't ignore created IDisposable
 

--- a/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
@@ -9,6 +9,7 @@ using Mapsui.Nts.Extensions;
 using Mapsui.Utilities;
 using Animation = Mapsui.Animations.Animation;
 using Mapsui.UI.Maui;
+using HarfBuzzSharp;
 
 #pragma warning disable IDISP004 // Don't ignore created IDisposable
 
@@ -23,7 +24,7 @@ namespace Mapsui.UI.Objects;
 /// </remarks>
 public class MyLocationLayer : BaseLayer
 {
-    private readonly MapView _mapView;
+    private MapView _mapView;
     private readonly GeometryFeature _feature;
     private SymbolStyle _locStyle;  // style for the location indicator
     private SymbolStyle _dirStyle;  // style for the view-direction indicator
@@ -112,6 +113,12 @@ public class MyLocationLayer : BaseLayer
         }
     }
 
+    /// <summary> Sets Map View </summary>
+    internal MapView MapView
+    {
+        set => _mapView = value ?? throw new NullReferenceException();
+    }
+
     /// <summary>
     /// This event is triggered whenever the MyLocation symbol or label is clicked.
     /// </summary>
@@ -132,10 +139,17 @@ public class MyLocationLayer : BaseLayer
     /// Initializes a new instance of the <see cref="T:Mapsui.UI.Objects.MyLocationLayer"/> class.
     /// </summary>
     /// <param name="view">MapView, to which this layer belongs</param>
-    public MyLocationLayer(MapView view)
+    public MyLocationLayer(MapView view) : this()
     {
         _mapView = view ?? throw new ArgumentNullException("MapView shouldn't be null");
+    }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="T:Mapsui.UI.Objects.MyLocationLayer"/> class.
+    /// </summary>
+    internal MyLocationLayer()
+    {
+        _mapView = default!; // will be set in constructor with MapView
         Enabled = false;
         IsMapInfoLayer = true;
 


### PR DESCRIPTION
Fixes a Bug when a null Reference Exception occurs when new MapView Control is created.
This is because the Layer Fields are not initialized when when Layer Changed Events are called. 
So I initialized the Layers now in the Fields or Properties instead of the Constructor fixing this.
To reproduce before this pull request only the Mapview Test sample needs to be opened.

