### PR TITLE
Remove: SkiaSharp.Views.Maui.Controls.Compatibility 

### DIFF
--- a/Benchmarks/Mapsui.Rendering.Benchmarks/Mapsui.Rendering.Benchmarks.csproj
+++ b/Benchmarks/Mapsui.Rendering.Benchmarks/Mapsui.Rendering.Benchmarks.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
-    <PackageReference Include="SkiaSharp.Views.Forms.WPF" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,14 +72,11 @@
     <PackageVersion Include="SkiaSharp.Skottie" Version="[2.88.8,3.0.0)" />
     <PackageVersion Include="SkiaSharp.Views" Version="[2.88.8,3.0.0)" />
     <PackageVersion Include="SkiaSharp.Views.Blazor" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Views.Forms" Version="[2.88.8,3.0.0)" />
     <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Views.Maui.Controls.Compatibility" Version="[2.88.8,3.0.0)" />
     <PackageVersion Include="SkiaSharp.Views.Uno" Version="[2.88.8,3.0.0)" />
     <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="[2.88.8,3.0.0)" />
     <PackageVersion Include="SkiaSharp.Views.WinUI" Version="[2.88.8,3.0.0)" />
     <PackageVersion Include="SkiaSharp.Views.WPF" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Views.Forms.WPF" Version="[2.88.8,3.0.0)" />
     <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="[2.88.8,3.0.0)" />
     <PackageVersion Include="sqlite-net-pcl" Version="[1.9.172,2.0.0)" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="[2.1.6,3.0.0)" />

--- a/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
+++ b/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
@@ -33,7 +33,6 @@
   <ItemGroup>
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.Views.Maui.Controls" />
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls.Compatibility" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">

--- a/Samples/Mapsui.Samples.Maui.MapView/Mapsui.Samples.Maui.MapView.csproj
+++ b/Samples/Mapsui.Samples.Maui.MapView/Mapsui.Samples.Maui.MapView.csproj
@@ -66,7 +66,6 @@
 		<PackageReference Include="SkiaSharp" />
 		<PackageReference Include="SkiaSharp.HarfBuzz" />
 		<PackageReference Include="SkiaSharp.Views.Maui.Controls" />
-		<PackageReference Include="SkiaSharp.Views.Maui.Controls.Compatibility" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.StartsWith('net8.0'))">

--- a/Samples/Mapsui.Samples.Maui.MapView/MauiProgram.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MauiProgram.cs
@@ -10,7 +10,7 @@ public static class MauiProgram
     {
         var builder = MauiApp.CreateBuilder();
         builder
-            .UseSkiaSharp(true)
+            .UseSkiaSharp()
             .UseMauiApp<App>()
             .ConfigureFonts(fonts =>
             {

--- a/Samples/Mapsui.Samples.Maui/AppShell.xaml
+++ b/Samples/Mapsui.Samples.Maui/AppShell.xaml
@@ -3,12 +3,12 @@
     x:Class="Mapsui.Samples.Maui.AppShell"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:Mapsui.Samples.Maui"
+    xmlns:view="clr-namespace:Mapsui.Samples.Maui.View"
     Shell.FlyoutBehavior="Disabled">
 
     <ShellContent
         Title="Home"
-        ContentTemplate="{DataTemplate local:View.MainPage}"
+        ContentTemplate="{DataTemplate view:MainPage}"
         Route="MainPage" />
 
 </Shell>

--- a/Samples/Mapsui.Samples.Maui/MauiProgram.cs
+++ b/Samples/Mapsui.Samples.Maui/MauiProgram.cs
@@ -15,7 +15,7 @@ public static class MauiProgram
         // "Microsoft.Maui.Platform.HandlerNotFoundException: 'Handler not found for view SkiaSharp.Views.Maui.Controls.SKGLView.'"
         builder
             .UseMauiApp<App>()
-            .UseSkiaSharp(true)
+            .UseSkiaSharp()
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");


### PR DESCRIPTION
SkiaSharp.Views.Maui.Controls.Compatibility is removed and the remaining SkiaSharp.Forms references.
SkiaSharp.Views.Maui.Controls.Compatibility isn't needed anymore. I discovered this while doing.
https://github.com/Mapsui/Mapsui/pull/2603


