### PR TITLE
Fix Delayer hang

### DIFF
--- a/Mapsui/Fetcher/Delayer.cs
+++ b/Mapsui/Fetcher/Delayer.cs
@@ -1,27 +1,33 @@
-﻿using System;
-using System.Threading;
+﻿using Mapsui.Extensions;
+using System;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 
 namespace Mapsui.Fetcher;
 
 /// <summary>
 /// Makes sure a method is always called 'MillisecondsToDelay' after the previous call.
 /// </summary>
-public class Delayer : IDisposable
+public class Delayer
 {
-    private readonly Timer _waitTimer;
-    private Action? _action;
-    private bool _waiting;
-
+    private int _ticksPreviousCall = int.MinValue;
     /// <summary>
-    /// The delay between two calls.
+    /// The minimum delay between two calls.
     /// </summary>
-    public int MillisecondsToWait { get; set; } = 500;
+    public int MillisecondsBetweenCalls { get; set; } = 500;
+    /// <summary>
+    /// The delay between the call to ExecuteDelayed and the actual call to the method.
+    /// </summary>
+    public int MillisecondsBeforeCall { get; set; } = 0;
+    public Channel<Func<Task>> _queue = Channel.CreateBounded<Func<Task>>(
+        new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropOldest });
 
-    public bool StartWithDelay { get; set; } = false;
+    public Delayer() => Catch.TaskRun(() => AddConsumerAsync(_queue));
 
-    public Delayer()
+    private static async Task AddConsumerAsync(Channel<Func<Task>> queue)
     {
-        _waitTimer = new Timer(WaitTimerElapsed, null, Timeout.Infinite, Timeout.Infinite);
+        await foreach (var action in queue.Reader.ReadAllAsync())
+            await action();
     }
 
     /// <summary>
@@ -30,69 +36,27 @@ public class Delayer : IDisposable
     /// When ExecuteRequest is called before the previous delayed action was executed 
     /// the previous one will be cancelled.
     /// </summary>
-    /// <param name="action">The action to be executed after the possible delay</param>
+    /// <param name="func">The action to be executed after the possible delay</param>
     /// <remarks>When the previous call was more than 'MillisecondsToWait' ago there will
     /// be no delay.</remarks>
+    public void ExecuteDelayed(Func<Task> func)
+    {
+        _queue.Writer.TryWrite(() => CallAsync(func));
+    }
+
     public void ExecuteDelayed(Action action)
     {
-        if (_waiting)
-        {
-            // If waiting, just assign the action and wait for it to be called.
-            _action = action;
-        }
-        else
-        {
-            // If not waiting call the action immediately.
-            if (!StartWithDelay)
-                action();
-            else
-                _action = action;
-            // Then wait for another interval to check if more actions come in.
-            StartWaiting();
-        }
+        _queue.Writer.TryWrite(() => CallAsync(async () => { action(); await Task.CompletedTask; }));
     }
 
-    public void Dispose()
+    private async Task CallAsync(Func<Task> action)
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _waitTimer.Dispose();
-        }
-    }
-
-    private void WaitTimerElapsed(object? state)
-    {
-        if (_action != null)
-        {
-            // Waiting is done, we can call the action.
-            _action?.Invoke();
-            // Set the action to null. This indicates there is no new request.
-            _action = null;
-            // Now we keep the timer running. It will stop if _action is still null.
-        }
-        else
-        {
-            // The _action is null, so during the previous interval no new request came in.
-            // Next time a new request comes in we don't have to wait.
-            StopWaiting();
-        }
-    }
-
-    private void StartWaiting()
-    {
-        _waiting = true;
-        _waitTimer.Change(MillisecondsToWait, MillisecondsToWait);
-    }
-
-    private void StopWaiting()
-    {
-        _waiting = false;
-        _waitTimer.Change(Timeout.Infinite, Timeout.Infinite);
+        if (MillisecondsBeforeCall > 0)
+            await Task.Delay(MillisecondsBeforeCall);
+        var ticksToWait = Math.Max(MillisecondsBetweenCalls - Math.Max(Environment.TickCount - _ticksPreviousCall, 0), 0);
+        if (ticksToWait > 0)
+            await Task.Delay(ticksToWait);
+        await action();
+        _ticksPreviousCall = Environment.TickCount;
     }
 }

--- a/Mapsui/Layers/Layer.cs
+++ b/Mapsui/Layers/Layer.cs
@@ -51,8 +51,8 @@ public class Layer : BaseLayer, IAsyncDataFetcher, ILayerDataSource<IProvider>
     // ReSharper disable once UnusedMember.Global // todo: Create a sample for this field
     public int FetchingPostponedInMilliseconds
     {
-        get => Delayer.MillisecondsToWait;
-        set => Delayer.MillisecondsToWait = value;
+        get => Delayer.MillisecondsBetweenCalls;
+        set => Delayer.MillisecondsBetweenCalls = value;
     }
     /// <summary>
     /// Data source for this layer

--- a/Mapsui/Layers/RasterizingLayer.cs
+++ b/Mapsui/Layers/RasterizingLayer.cs
@@ -47,8 +47,8 @@ public class RasterizingLayer : BaseLayer, IAsyncDataFetcher, ISourceLayer
         _cache = new ConcurrentStack<RasterFeature>();
         _pixelDensity = pixelDensity;
         _layer.DataChanged += LayerOnDataChanged;
-        Delayer.StartWithDelay = true;
-        Delayer.MillisecondsToWait = delayBeforeRasterize;
+        Delayer.MillisecondsBeforeCall = 500;
+        Delayer.MillisecondsBetweenCalls = delayBeforeRasterize;
         Style = new RasterStyle(); // default raster style
     }
 

--- a/Tests/Mapsui.Tests/Fetcher/DelayerTests.cs
+++ b/Tests/Mapsui.Tests/Fetcher/DelayerTests.cs
@@ -1,0 +1,61 @@
+﻿using Mapsui.Fetcher;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+
+namespace Mapsui.Tests.Fetcher;
+
+[TestFixture]
+public class DelayerTests
+{
+    [Test]
+    [Repeat(1000)]
+    public async Task DelayerShouldNotHangAsync()
+    {
+        // Arrange
+        var delayer = new Delayer();
+        Random random = new(43434768);
+        delayer.MillisecondsBetweenCalls = 1;
+        var backgroundProcesses = new BackgroundProcesses();
+        backgroundProcesses.Start(random);
+        int iterationCount = 10000; // Increase this value to make it hang. I tested wth 10000
+
+        // Act
+        for (var i = 0; i < iterationCount; i++)
+        {
+            delayer.ExecuteDelayed(() => Math.Sqrt(random.NextDouble()));
+            await Task.Delay(1);
+        }
+
+        // Assert
+        backgroundProcesses.Stop();
+        var delayedMethodIsCalled = false;
+        delayer.ExecuteDelayed(() => delayedMethodIsCalled = true);
+
+        await Task.Delay(100); // Wait for the delayed method to be called
+        Assert.That(delayedMethodIsCalled, Is.True, "The delayed method is called");
+    }
+
+    private class BackgroundProcesses
+    {
+        private bool _running;
+
+        public void Start(Random random)
+        {
+            _running = true;
+            for (int i = 0; i < 100; i++)
+                _ = Task.Run(() => DoSomethingAsync(random)); // Fire and forget
+        }
+
+        public void Stop() => _running = false;
+
+        private async Task DoSomethingAsync(Random random)
+        {
+            while (_running)
+            {
+                Math.Sqrt(random.NextDouble());
+                await Task.Delay(1);
+            }
+        }
+    }
+}

--- a/Tests/Mapsui.Tests/Fetcher/FeatureFetcherTests.cs
+++ b/Tests/Mapsui.Tests/Fetcher/FeatureFetcherTests.cs
@@ -20,7 +20,7 @@ public class FeatureFetcherTests
         {
             DataSource = new MemoryProvider(GenerateRandomPoints(extent, 25))
         };
-        layer.Delayer.MillisecondsToWait = 0;
+        layer.Delayer.MillisecondsBetweenCalls = 0;
 
         var notifications = new List<bool>();
         layer.PropertyChanged += (_, args) =>


### PR DESCRIPTION
Fix for https://github.com/Mapsui/Mapsui/issues/2607 but now in main.

Changed the Delayer implementation to not use Timers and locks (as in the 4.1 fix) but a Channel. The Channel has a capacity of just 1 and if full will drop the oldest, so that if the method on the queue is not called yet the new call will replace the old one. This way it won't do outdated requests.

