### PR TITLE
Reorganize the internals of BitmapRegistry

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -257,6 +257,7 @@ dotnet_diagnostic.IDE0005.severity = error # Remove unused usings, works only wh
 dotnet_diagnostic.CA1512.severity = silent # CA1512: Use ArgumentOutOfRangeException throw helper - Why set to silent? Because we use net7 and it is not supported there.
 dotnet_diagnostic.IDE0059.severity = warning # IDE0059: Unnecessary assignment of a value
 dotnet_diagnostic.CA2208.severity = silent # CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.VSTHRD200.severity = warning # VSTHRD200: Use "Async" suffix for async methods 
 
 # Spelling
 spelling_exclusion_path = spelling_exclusion.txt

--- a/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
@@ -125,7 +125,7 @@ public class CalloutStyleRenderer : ISkiaStyleRenderer
             if (callout.BitmapId < 0)
                 callout.BitmapId = BitmapRegistry.Instance.Register(picture);
             else
-                BitmapRegistry.Instance.Set(callout.BitmapId, picture);
+                BitmapRegistry.Instance.Update(callout.BitmapId, picture);
         }
 
         callout.Invalidated = false;
@@ -242,7 +242,7 @@ public class CalloutStyleRenderer : ISkiaStyleRenderer
         var picture = rec.EndRecording();
         if (callout.InternalContent >= 0)
         {
-            BitmapRegistry.Instance.Set(callout.InternalContent, picture);
+            BitmapRegistry.Instance.Update(callout.InternalContent, picture);
         }
         else
         {

--- a/Mapsui/Extensions/StreamExtensions.cs
+++ b/Mapsui/Extensions/StreamExtensions.cs
@@ -134,4 +134,12 @@ public static class StreamExtensions
             haystack.Position = position;
         }
     }
+
+    public static MemoryStream CopyToMemoryStream(this Stream input)
+    {
+        var memoryStream = new MemoryStream();
+        input.CopyTo(memoryStream);
+        memoryStream.Position = 0;
+        return memoryStream;
+    }
 }

--- a/Mapsui/Styles/BitmapRegistry.cs
+++ b/Mapsui/Styles/BitmapRegistry.cs
@@ -99,8 +99,16 @@ public sealed class BitmapRegistry : IBitmapRegistry
     /// <inheritdoc />
     public object? Unregister(int id)
     {
-        _register.Remove(id, out var val);
+        _register.TryRemove(id, out var val);
+        TryRemoveLookup(_lookup, id);
         return val;
+    }
+
+    private static void TryRemoveLookup(ConcurrentDictionary<string, int> lookup, int id)
+    {
+        var kpv = lookup.FirstOrDefault(kpv => kpv.Value == id);
+        if (!kpv.Equals(default(KeyValuePair<string, int>)))
+            lookup.TryRemove(kpv.Key, out _);
     }
 
     public void Dispose()

--- a/Mapsui/Styles/IBitmapRegistry.cs
+++ b/Mapsui/Styles/IBitmapRegistry.cs
@@ -20,11 +20,6 @@ public interface IBitmapRegistry : IDisposable
     /// <returns>Id of registered bitmap data</returns>
     Task<int> RegisterAsync(Uri bitmapPath);
 
-    /// <summary> Unregister an existing bitmap </summary>
-    /// <param name="id">Id of registered bitmap data</param>
-    /// <returns>The unregistered object</returns>
-    object? Unregister(int id);
-
     /// <summary>
     /// Get bitmap data of registered bitmap
     /// </summary>
@@ -32,17 +27,23 @@ public interface IBitmapRegistry : IDisposable
     /// <returns></returns>
     object Get(int id);
 
-    /// <summary>
-    /// Set new bitmap data for a already registered bitmap
-    /// </summary>
-    /// <param name="id">Id of existing bitmap data</param>
-    /// <param name="bitmapData">New bitmap data to replace</param>
-    /// <returns>True, if replacing worked correct</returns>
-    bool Set(int id, object bitmapData);
-
     /// <summary> Try Get Bitmap Id </summary>
     /// <param name="key">key</param>
     /// <param name="bitmapId">bitmap id</param>
     /// <returns>true if found</returns>
     bool TryGetBitmapId(string key, out int bitmapId);
+
+    /// <summary>
+    /// Update the bitmap data for a already registered bitmap
+    /// </summary>
+    /// <param name="id">Id of existing bitmap data</param>
+    /// <param name="bitmapData">New bitmap data to replace</param>
+    /// <returns>True, if replacing worked correct</returns>
+
+    bool Update(int id, object bitmapData);
+
+    /// <summary> Unregister an existing bitmap </summary>
+    /// <param name="id">Id of registered bitmap data</param>
+    /// <returns>The unregistered object</returns>
+    object? Unregister(int id);
 }

--- a/Tests/Mapsui.Tests/Styles/BitmapRegistryTests.cs
+++ b/Tests/Mapsui.Tests/Styles/BitmapRegistryTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using BruTile.Wms;
 using Mapsui.Extensions;
 using Mapsui.Styles;
 using Mapsui.Tests.Common.Maps;
@@ -28,7 +29,7 @@ public static class BitmapRegistryTests
     }
 
     [Test]
-    public static async Task UriResourceEmbeddedRegisterAsyncAddAndRemove()
+    public static async Task AddAndRemoveUriResourceEmbeddedRegisterAsync()
     {
         // Arrange
         var svgTigerPath = typeof(BitmapAtlasSample).LoadSvgPath("Resources.Images.Ghostscript_Tiger.svg");
@@ -42,7 +43,7 @@ public static class BitmapRegistryTests
     }
 
     [Test]
-    public static async Task UriResourceEmbeddedRegisterAsyncAdd()
+    public static async Task AddUriResourceEmbeddedRegisterAsync()
     {
         // Arrange
         var svgTigerPath = typeof(BitmapAtlasSample).LoadSvgPath("Resources.Images.Ghostscript_Tiger.svg");
@@ -58,10 +59,10 @@ public static class BitmapRegistryTests
     }
 
     [Test]
-    public static async Task UriFileRegisterAsyncAddAndRemove()
+    public static async Task AddAndRemoveUriFileRegisterAsync()
     {
         // Arrange
-        var examplePath = new Uri($"file://{System.AppContext.BaseDirectory}/Resources/example.tif");
+        var examplePath = new Uri($"file://{AppContext.BaseDirectory}/Resources/example.tif");
         var bitmapId = await BitmapRegistry.Instance.RegisterAsync(examplePath);
 
         // Act
@@ -72,10 +73,10 @@ public static class BitmapRegistryTests
     }
 
     [Test]
-    public static async Task UriFileRegisterAsyncAdd()
+    public static async Task AddUriFileRegisterAsync()
     {
         // Arrange
-        var examplePath = new Uri($"file://{System.AppContext.BaseDirectory}/Resources/example.tif");
+        var examplePath = new Uri($"file://{AppContext.BaseDirectory}/Resources/example.tif");
         var bitmapId = await BitmapRegistry.Instance.RegisterAsync(examplePath);
 
         // Act
@@ -88,7 +89,7 @@ public static class BitmapRegistryTests
     }
 
     [Test]
-    public static async Task UriHttpsRegisterAsyncAddAndRemove()
+    public static async Task AddAndRemoveUriHttpsRegisterAsync()
     {
         // Arrange
         var mapsuiLogo = new Uri("https://mapsui.com/images/logo.svg");
@@ -102,7 +103,7 @@ public static class BitmapRegistryTests
     }
 
     [Test]
-    public static async Task UriHttpsRegisterAsyncAdd()
+    public static async Task AddUriHttpsRegisterAsync()
     {
         // Arrange
         var mapsuiLogo = new Uri("https://mapsui.com/images/logo.svg");
@@ -115,5 +116,21 @@ public static class BitmapRegistryTests
         var stream = bitmap as Stream;
         Assert.That(stream is not null);
         Assert.That(stream?.ToBytes().Length > 0);
+    }
+
+    [Test]
+    public static void UrlShouldDoValueCompare()
+    {
+        // This is to be sure that Url implements value compare.
+        // They don't mention it in the documentation.
+        // https://learn.microsoft.com/en-us/dotnet/api/system.security.policy.url.equals?view=net-8.0#system-security-policy-url-equals(system-object)
+
+        // Arrange
+        var logoUrl = new Uri("https://mapsui.com/images/logo.svg");
+        var otherInstanceOfSameUrl = new Uri("https://mapsui.com/images/logo.svg");
+
+        // Act and Assert
+        Assert.That(logoUrl == otherInstanceOfSameUrl, Is.True);
+        Assert.That(logoUrl.Equals(otherInstanceOfSameUrl), Is.True);
     }
 }

--- a/Tests/Mapsui.Tests/Styles/BitmapRegistryTests.cs
+++ b/Tests/Mapsui.Tests/Styles/BitmapRegistryTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using BruTile.Wms;
 using Mapsui.Extensions;
 using Mapsui.Styles;
 using Mapsui.Tests.Common.Maps;

--- a/spelling_exclusion.txt
+++ b/spelling_exclusion.txt
@@ -26,3 +26,4 @@ esri
 nuget
 onscroll
 bbox
+embeddedresource


### PR DESCRIPTION
To get a better understanding of the current design of bitmap registering I rewrote the internal code of BitmapRegistry. This PR does not have a lot of overlap with your bitmapPath PR, so this is a small step that could be merged. However, I want to further investigate the BitmapRegistry, and following PRs could have bigger conflicts. 

### Follow up
I think it is necessary to first reorganize the basics before we build more on it. I would like to remove the objects stored in the cache and only have streams in there. Which means we have to think of something entirely different for the object logic. I see that the non-Streams we use are SKPicture, Sprite and a string for svgs. 
- Perhaps the svg string could be a Stream instead. 
- The SKPicture is something that you would want to store in the render cache because is SkiaSharp specific. But a problem is the SKPicture is often not just a resource converted to Skia but our custom code. I have to think about this. 
- I need a better understanding of the Sprite. In a way it is just a bitmap, but only a specific part of it. Perhaps this specific part can be represented in the url. For instance with a query parameter or a fragment: https://en.wikipedia.org/wiki/URL#Syntax.

Splitting the objects into their own cache, so that at least the BitmapRegistry is not problematic, might also be a step to improve things.

btw, the idea of the url based registry was that the url itself would be the key, and it would replace the bitmapId.