### PR TITLE
Fixed: MultiPolygons in WFS Services only loaded the First Polygon (4.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,13 +41,14 @@
 	  <Compile Include="$(MSBuildThisFileDirectory)/InitProperty.cs" />
   </ItemGroup>
 
-	<ItemGroup Condition="'$(SolutionName)'=='Mapsui.Mac.Legacy'" >
-		<!--Specify Compiler for Mac Builds-->
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" VersionOverride="4.10.0-3.final">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+    <!-- for fixing the windows build-->
+    <ItemGroup> 
+	    <!--Specify Compiler for Mac Builds-->
+	    <PackageReference Include="Microsoft.Net.Compilers.Toolset" VersionOverride="4.10.0-3.final">
+		    <PrivateAssets>all</PrivateAssets>
+		    <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+	    </PackageReference>
+    </ItemGroup>
 
   <ItemGroup>
     <!--Disposable Analyzer-->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
 
 	<ItemGroup Condition="'$(SolutionName)'=='Mapsui.Mac.Legacy'" >
 		<!--Specify Compiler for Mac Builds-->
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" VersionOverride="4.9.2">
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" VersionOverride="4.10.0-3.final">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/Mapsui.Nts/Providers/Wfs/Utilities/GeometryFactories.cs
+++ b/Mapsui.Nts/Providers/Wfs/Utilities/GeometryFactories.cs
@@ -743,7 +743,8 @@ internal class MultiPolygonFactory : GeometryFactory
                      GetSubReaderOf(FeatureReader, labelValues, multiPolygonNodeAlt)) != null)
                 {
                     using GeometryFactory geomFactory = new PolygonFactory(GeomReader, FeatureTypeInfo) { AxisOrder = AxisOrder };
-                    var polygons = (await geomFactory.CreateGeometriesAsync(features)).Cast<Polygon>();
+                    var tempFeatures = new List<IFeature>();
+                    var polygons = (await geomFactory.CreateGeometriesAsync(tempFeatures)).Cast<Polygon>();
                     Geoms.Add(new MultiPolygon(polygons.ToArray()));
                     geomFound = true;
                 }

--- a/Mapsui.Nts/Providers/Wfs/Utilities/GeometryFactories.cs
+++ b/Mapsui.Nts/Providers/Wfs/Utilities/GeometryFactories.cs
@@ -730,10 +730,6 @@ internal class MultiPolygonFactory : GeometryFactory
         IPathNode multiPolygonNode = new PathNode(Gmlns, "MultiPolygon", (NameTable)XmlReader!.NameTable);
         IPathNode multiSurfaceNode = new PathNode(Gmlns, "MultiSurface", (NameTable)XmlReader.NameTable);
         IPathNode multiPolygonNodeAlt = new AlternativePathNodesCollection(multiPolygonNode, multiSurfaceNode);
-        IPathNode polygonMemberNode = new PathNode(Gmlns, "polygonMember", (NameTable)XmlReader.NameTable);
-        IPathNode surfaceMemberNode = new PathNode(Gmlns, "surfaceMember", (NameTable)XmlReader.NameTable);
-        IPathNode polygonMemberNodeAlt = new AlternativePathNodesCollection(polygonMemberNode, surfaceMemberNode);
-        IPathNode linearRingNode = new PathNode(Gmlns, "LinearRing", (NameTable)XmlReader.NameTable);
         var labelValues = new Dictionary<string, string>();
         var geomFound = false;
 
@@ -744,7 +740,7 @@ internal class MultiPolygonFactory : GeometryFactory
             {
                 while (
                     (GeomReader =
-                     GetSubReaderOf(FeatureReader, labelValues, multiPolygonNodeAlt, polygonMemberNodeAlt)) != null)
+                     GetSubReaderOf(FeatureReader, labelValues, multiPolygonNodeAlt)) != null)
                 {
                     using GeometryFactory geomFactory = new PolygonFactory(GeomReader, FeatureTypeInfo) { AxisOrder = AxisOrder };
                     var polygons = (await geomFactory.CreateGeometriesAsync(features)).Cast<Polygon>();

--- a/Mapsui.Nts/Providers/Wfs/WFSProvider.cs
+++ b/Mapsui.Nts/Providers/Wfs/WFSProvider.cs
@@ -323,7 +323,7 @@ public class WFSProvider : IProvider, IDisposable
     private WFSProvider(string getCapabilitiesUri, string nsPrefix, string featureType, GeometryTypeEnum geometryType,
                WFSVersionEnum wfsVersion, IUrlPersistentCache? persistentCache = null)
     {
-        _persistentCache = persistentCache;
+        _persistentCache = persistentCache ?? DefaultCache;
         _getCapabilitiesUri = getCapabilitiesUri;
         _featureType = featureType;
 


### PR DESCRIPTION
Fixed: MultiPolygons in WFS Services only loaded the First Polygon (4.1)