### PR TITLE
Remove upper limit on Microsoft.AspNetCore.Component._ packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,9 +56,9 @@
     <PackageVersion Include="Mapsui.Uno.WinUI" Version="4.0.0-beta.8" />
     <PackageVersion Include="Mapsui.WinUI" Version="4.0.0-beta.8" />
     <PackageVersion Include="Mapsui.Wpf" Version="4.0.0-beta.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="[7.0.5,8.0.0)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="[7.0.5,8.0.0)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="[7.0.5,8.0.0)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="7.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.5" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="[16.11.0,17.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[7.0.0,8.0.0)" />

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "version": "8.0.200",
+    "version": "8.0.400",
     "rollForward": "latestMajor"
   },
   "tools": {
     "allowPrerelease": false,
-    "dotnet": "8.0.200",
+    "dotnet": "8.0.400",
     "rollForward": "latestMajor"
   }  
 }

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "version": "8.0.400",
+    "version": "8.0.300",
     "rollForward": "latestMajor"
   },
   "tools": {
     "allowPrerelease": false,
-    "dotnet": "8.0.400",
+    "dotnet": "8.0.300",
     "rollForward": "latestMajor"
   }  
 }


### PR DESCRIPTION
Installing Mapsui.Blazor fails on Blazor 8 because the nuget excludes this. Our own samples already run it in Blazor 8 so it should be compatible. 