### PR TITLE
Use string instead of Uri in ImageSource

### DIFF
--- a/Mapsui.Rendering.Skia/Cache/SymbolCache.cs
+++ b/Mapsui.Rendering.Skia/Cache/SymbolCache.cs
@@ -20,7 +20,7 @@ public sealed class SymbolCache : ISymbolCache
             }
         }
 
-        var imageStream = ImageSourceCache.Instance.Get(new Uri(key));
+        var imageStream = ImageSourceCache.Instance.Get(key);
         if (imageStream == null)
         {
             return null;

--- a/Mapsui.Rendering.Skia/Predefined/SymbolStyles.cs
+++ b/Mapsui.Rendering.Skia/Predefined/SymbolStyles.cs
@@ -11,7 +11,7 @@ public static class SymbolStyles
         // precedes a paint phase. https://github.com/Mapsui/Mapsui/issues/1448
         return new SymbolStyle
         {
-            ImageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg",
+            ImageSource = "embedded://Mapsui.Resources.Images.Pin.svg",
             SymbolOffset = new RelativeOffset(0.0, 0.5),
             SymbolScale = symbolScale,
             BlendModeColor = pinColor ?? Color.FromArgb(255, 57, 115, 199) // Determines color of the pin

--- a/Mapsui.Rendering.Skia/Predefined/SymbolStyles.cs
+++ b/Mapsui.Rendering.Skia/Predefined/SymbolStyles.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Mapsui.Styles;
+﻿namespace Mapsui.Styles;
 
 public static class SymbolStyles
 {
@@ -11,10 +9,9 @@ public static class SymbolStyles
         // It should be possible to create a style with just a reference to the platform
         // independent resource. The conversion to an image should happen in a render phase that
         // precedes a paint phase. https://github.com/Mapsui/Mapsui/issues/1448
-        var pinImageSource = new Uri("embeddedresource://Mapsui.Resources.Images.Pin.svg");
         return new SymbolStyle
         {
-            ImageSource = pinImageSource,
+            ImageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg",
             SymbolOffset = new RelativeOffset(0.0, 0.5),
             SymbolScale = symbolScale,
             BlendModeColor = pinColor ?? Color.FromArgb(255, 57, 115, 199) // Determines color of the pin

--- a/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
@@ -25,13 +25,13 @@ public class MyLocationLayer : BaseLayer
 {
     private MapView _mapView;
     private readonly GeometryFeature _feature;
-    private SymbolStyle _locStyle;  // style for the location indicator
-    private SymbolStyle _dirStyle;  // style for the view-direction indicator
-    private CalloutStyle _coStyle;  // style for the callout
+    private readonly SymbolStyle _locStyle;  // style for the location indicator
+    private readonly SymbolStyle _dirStyle;  // style for the view-direction indicator
+    private readonly CalloutStyle _coStyle;  // style for the callout
 
-    private static readonly Uri _movingImageSource = new("embeddedresource://Mapsui.Resources.Images.MyLocationMoving.svg");
-    private static readonly Uri _stillImageSource = new("embeddedresource://Mapsui.Resources.Images.MyLocationStill.svg");
-    private static readonly Uri _directionImageSource = new("embeddedresource://Mapsui.Resources.Images.MyLocationDir.svg");
+    private static readonly string _movingImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationMoving.svg";
+    private static readonly string _stillImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationStill.svg";
+    private static readonly string _directionImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationDir.svg";
 
     private Position _animationMyLocationStart;
     private Position _animationMyLocationEnd;

--- a/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
@@ -29,9 +29,9 @@ public class MyLocationLayer : BaseLayer
     private readonly SymbolStyle _dirStyle;  // style for the view-direction indicator
     private readonly CalloutStyle _coStyle;  // style for the callout
 
-    private static readonly string _movingImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationMoving.svg";
-    private static readonly string _stillImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationStill.svg";
-    private static readonly string _directionImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationDir.svg";
+    private static readonly string _movingImageSource = "embedded://Mapsui.Resources.Images.MyLocationMoving.svg";
+    private static readonly string _stillImageSource = "embedded://Mapsui.Resources.Images.MyLocationStill.svg";
+    private static readonly string _directionImageSource = "embedded://Mapsui.Resources.Images.MyLocationDir.svg";
 
     private Position _animationMyLocationStart;
     private Position _animationMyLocationEnd;

--- a/Mapsui/Layers/MyLocationLayer.cs
+++ b/Mapsui/Layers/MyLocationLayer.cs
@@ -23,9 +23,9 @@ public class MyLocationLayer : BaseLayer, IDisposable
     private readonly SymbolStyle _dirStyle;  // style for the view-direction indicator
     private readonly CalloutStyle _coStyle;  // style for the callout
 
-    private static readonly string _movingImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationMoving.svg";
-    private static readonly string _stillImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationStill.svg";
-    private static readonly string _directionImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationDir.svg";
+    private static readonly string _movingImageSource = "embedded://Mapsui.Resources.Images.MyLocationMoving.svg";
+    private static readonly string _stillImageSource = "embedded://Mapsui.Resources.Images.MyLocationStill.svg";
+    private static readonly string _directionImageSource = "embedded://Mapsui.Resources.Images.MyLocationDir.svg";
 
     private MPoint? _animationMyLocationStart;
     private MPoint? _animationMyLocationEnd;

--- a/Mapsui/Layers/MyLocationLayer.cs
+++ b/Mapsui/Layers/MyLocationLayer.cs
@@ -23,9 +23,9 @@ public class MyLocationLayer : BaseLayer, IDisposable
     private readonly SymbolStyle _dirStyle;  // style for the view-direction indicator
     private readonly CalloutStyle _coStyle;  // style for the callout
 
-    private static readonly Uri _movingImageSource = new("embeddedresource://Mapsui.Resources.Images.MyLocationMoving.svg");
-    private static readonly Uri _stillImageSource = new("embeddedresource://Mapsui.Resources.Images.MyLocationStill.svg");
-    private static readonly Uri _directionImageSource = new("embeddedresource://Mapsui.Resources.Images.MyLocationDir.svg");
+    private static readonly string _movingImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationMoving.svg";
+    private static readonly string _stillImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationStill.svg";
+    private static readonly string _directionImageSource = "embeddedresource://Mapsui.Resources.Images.MyLocationDir.svg";
 
     private MPoint? _animationMyLocationStart;
     private MPoint? _animationMyLocationEnd;

--- a/Mapsui/Styles/Brush.cs
+++ b/Mapsui/Styles/Brush.cs
@@ -6,7 +6,7 @@ namespace Mapsui.Styles;
 
 public class Brush
 {
-    private Uri? _imageSource;
+    private string? _imageSource;
 
     public Brush()
     {
@@ -37,11 +37,13 @@ public class Brush
     /// </summary>
     public Sprite? Sprite { get; set; }
 
-    public Uri? ImageSource
+    public string? ImageSource
     {
         get => _imageSource;
         set
         {
+            if (value != null)
+                ValidateImageSource(value);
             _imageSource = value;
             if (_imageSource != null)
             {
@@ -100,5 +102,11 @@ public class Brush
     public static bool operator !=(Brush? brush1, Brush? brush2)
     {
         return !Equals(brush1, brush2);
+    }
+
+    private static void ValidateImageSource(string imageSource)
+    {
+        // Will throw a UriFormatException exception if the imageSource is not a valid Uri
+        _ = new Uri(imageSource);
     }
 }

--- a/Mapsui/Styles/ImageFetcher.cs
+++ b/Mapsui/Styles/ImageFetcher.cs
@@ -16,7 +16,7 @@ public static class ImageFetcher
         var imageSourceUrl = new Uri(imageSource);
         var stream = imageSourceUrl.Scheme switch
         {
-            "embeddedresource" => LoadEmbeddedResourceFromPath(imageSourceUrl),
+            "embedded" => LoadEmbeddedResourceFromPath(imageSourceUrl),
             "file" => LoadFromFileSystem(imageSourceUrl),
             "http" or "https" => await LoadFromUrlAsync(imageSourceUrl),
             _ => throw new ArgumentException($"Scheme is not supported '{imageSourceUrl.Scheme}' of '{imageSource}'"),
@@ -25,7 +25,7 @@ public static class ImageFetcher
         return stream;
     }
 
-    private static Stream LoadEmbeddedResourceFromPath(Uri imageSource)
+    private static MemoryStream LoadEmbeddedResourceFromPath(Uri imageSource)
     {
         try
         {
@@ -54,14 +54,12 @@ public static class ImageFetcher
         }
     }
 
-    static private IEnumerable<Assembly> GetMatchingAssemblies(Uri imageSource)
+    static private List<Assembly> GetMatchingAssemblies(Uri imageSource)
     {
         var result = new List<Assembly>();
         foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
         {
-            var name = assembly.GetName().Name;
-            if (name is null)
-                throw new Exception($"Assembly name is null: '{assembly}'");
+            var name = assembly.GetName().Name ?? throw new Exception($"Assembly name is null: '{assembly}'");
             if (imageSource.Host.StartsWith(name, StringComparison.InvariantCultureIgnoreCase))
             {
                 result.Add(assembly);
@@ -92,7 +90,7 @@ public static class ImageFetcher
         }
     }
 
-    private static Stream LoadFromFileSystem(Uri imageSource)
+    private static FileStream LoadFromFileSystem(Uri imageSource)
     {
         try
         {

--- a/Mapsui/Styles/ImageFetcher.cs
+++ b/Mapsui/Styles/ImageFetcher.cs
@@ -11,14 +11,15 @@ using System.Linq;
 namespace Mapsui.Styles;
 public static class ImageFetcher
 {
-    public static async Task<Stream> FetchStreamFromImageSourceAsync(Uri imageSource)
+    public static async Task<Stream> FetchStreamFromImageSourceAsync(string imageSource)
     {
-        var stream = imageSource.Scheme switch
+        var imageSourceUrl = new Uri(imageSource);
+        var stream = imageSourceUrl.Scheme switch
         {
-            "embeddedresource" => LoadEmbeddedResourceFromPath(imageSource),
-            "file" => LoadFromFileSystem(imageSource),
-            "http" or "https" => await LoadFromUrlAsync(imageSource),
-            _ => throw new ArgumentException($"Scheme is not supported '{imageSource.Scheme}' of '{imageSource}'"),
+            "embeddedresource" => LoadEmbeddedResourceFromPath(imageSourceUrl),
+            "file" => LoadFromFileSystem(imageSourceUrl),
+            "http" or "https" => await LoadFromUrlAsync(imageSourceUrl),
+            _ => throw new ArgumentException($"Scheme is not supported '{imageSourceUrl.Scheme}' of '{imageSource}'"),
         };
         ValidateBitmapData(stream);
         return stream;

--- a/Mapsui/Styles/ImageSourceCache.cs
+++ b/Mapsui/Styles/ImageSourceCache.cs
@@ -23,7 +23,7 @@ public sealed class ImageSourceCache : IDisposable
     public static ImageSourceCache Instance => _instance ??= new ImageSourceCache();
 
     /// <inheritdoc />
-    public async Task RegisterAsync(Uri imageSource)
+    public async Task RegisterAsync(string imageSource)
     {
         var key = imageSource.ToString();
         if (_register.ContainsKey(key))
@@ -36,14 +36,14 @@ public sealed class ImageSourceCache : IDisposable
     }
 
     /// <inheritdoc />
-    public Stream? Get(Uri key)
+    public Stream? Get(string key)
     {
         _register.TryGetValue(key.ToString(), out var val);
         return val;
     }
 
     /// <inheritdoc />
-    public Stream? Unregister(Uri key)
+    public Stream? Unregister(string key)
     {
         _register.TryRemove(key.ToString(), out var val);
         return val;

--- a/Mapsui/Styles/ImageSourceInitializer.cs
+++ b/Mapsui/Styles/ImageSourceInitializer.cs
@@ -8,11 +8,11 @@ using System.Linq;
 namespace Mapsui.Styles;
 public static class ImageSourceInitializer
 {
-    static readonly ConcurrentHashSet<Uri> _register = [];
+    static readonly ConcurrentHashSet<string> _register = [];
     static readonly object _lockObject = new();
     static readonly FetchMachine _fetchMachine = new(1);
 
-    public static void Add(Uri imageSource)
+    public static void Add(string imageSource)
     {
         lock (_lockObject)
         {
@@ -51,12 +51,12 @@ public static class ImageSourceInitializer
         });
     }
 
-    private static IEnumerable<Uri> GetAndClear()
+    private static IEnumerable<string> GetAndClear()
     {
         lock (_lockObject)
         {
             if (_register.Count == 0)
-                return Array.Empty<Uri>();
+                return [];
             var result = _register.ToArray();
             _register.Clear();
             return result;

--- a/Mapsui/Styles/SymbolStyle.cs
+++ b/Mapsui/Styles/SymbolStyle.cs
@@ -27,16 +27,18 @@ public class SymbolStyle : VectorStyle
 
     public UnitType UnitType { get; set; }
 
-    private Uri? _imageSource;
+    private string? _imageSource;
 
     /// <summary>
-    /// Bitmap of the image to display during rendering
+    /// Path to the the image to display during rendering. This can be url, file path or embedded resource.
     /// </summary>
-    public Uri? ImageSource
+    public string? ImageSource
     {
         get => _imageSource;
         set
         {
+            if (value != null)
+                ValidateImageSource(value);
             _imageSource = value;
             if (value != null)
             {
@@ -158,5 +160,11 @@ public class SymbolStyle : VectorStyle
     public static bool operator !=(SymbolStyle? symbolStyle1, SymbolStyle? symbolStyle2)
     {
         return !Equals(symbolStyle1, symbolStyle2);
+    }
+
+    private static void ValidateImageSource(string imageSource)
+    {
+        // Will throw a UriFormatException exception if the imageSource is not a valid Uri
+        _ = new Uri(imageSource);
     }
 }

--- a/Mapsui/Utilities/EmbeddedResourceLoader.cs
+++ b/Mapsui/Utilities/EmbeddedResourceLoader.cs
@@ -29,7 +29,7 @@ public static class EmbeddedResourceLoader
     {
         var assembly = typeInAssemblyOfEmbeddedResource.GetTypeInfo().Assembly;
         var fullName = assembly.GetFullName(relativePathToEmbeddedResource);
-        return new Uri($"embeddedresource://{fullName}");
+        return new Uri($"embedded://{fullName}");
     }
 
     private static string ConstructExceptionMessage(string path, Assembly assembly)

--- a/Samples/Mapsui.Samples.Common/DataBuilders/GeodanOfficesLayerBuilder.cs
+++ b/Samples/Mapsui.Samples.Common/DataBuilders/GeodanOfficesLayerBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using Mapsui.Extensions;
 using Mapsui.Layers;
 using Mapsui.Styles;
-using System;
 
 namespace Mapsui.Samples.Common.DataBuilders;
 
@@ -11,7 +10,7 @@ public class GeodanOfficesLayerBuilder
     {
         var geodanAmsterdam = new MPoint(122698, 483922);
         var geodanDenBosch = new MPoint(148949, 411446);
-        var imageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.location.png");
+        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.location.png";
 
         var layer = new MemoryLayer
         {

--- a/Samples/Mapsui.Samples.Common/DataBuilders/GeodanOfficesLayerBuilder.cs
+++ b/Samples/Mapsui.Samples.Common/DataBuilders/GeodanOfficesLayerBuilder.cs
@@ -10,7 +10,7 @@ public class GeodanOfficesLayerBuilder
     {
         var geodanAmsterdam = new MPoint(122698, 483922);
         var geodanDenBosch = new MPoint(148949, 411446);
-        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.location.png";
+        var imageSource = "embedded://Mapsui.Samples.Common.Images.location.png";
 
         var layer = new MemoryLayer
         {

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSample.cs
@@ -1,9 +1,7 @@
-﻿using Mapsui.Layers;
-using Mapsui.Layers.AnimatedLayers;
+﻿using Mapsui.Layers.AnimatedLayers;
 using Mapsui.Styles;
 using Mapsui.Styles.Thematics;
 using Mapsui.Tiling;
-using System;
 using System.Threading.Tasks;
 
 namespace Mapsui.Samples.Common.Maps.Animations;
@@ -22,29 +20,20 @@ public class AnimatedPointsSample : ISample
         return Task.FromResult(map);
     }
 
-    private static ILayer CreateAnimatedPointLayer()
+    private static AnimatedPointLayer CreateAnimatedPointLayer() => new(new AnimatedPointsSampleProvider())
     {
-        return new AnimatedPointLayer(new AnimatedPointsSampleProvider())
-        {
-            Name = "Animated Points",
-            Style = CreatePointStyle()
-        };
-    }
+        Name = "Animated Points",
+        Style = CreatePointStyle()
+    };
 
-    private static ThemeStyle CreatePointStyle() => new(f =>
-    {
-        return CreateSvgArrowStyle("embeddedresource://Mapsui.Samples.Common.Images.arrow.svg", 0.5, f);
-    });
+    private static ThemeStyle CreatePointStyle() => new(CreateSvgArrowStyle);
 
-    private static SymbolStyle CreateSvgArrowStyle(string embeddedResourcePath, double scale, IFeature feature)
+    private static SymbolStyle CreateSvgArrowStyle(IFeature feature) => new()
     {
-        return new SymbolStyle
-        {
-            ImageSource = new Uri(embeddedResourcePath),
-            SymbolScale = scale,
-            SymbolOffset = new RelativeOffset(0.0, 0.5),
-            Opacity = 0.5f,
-            SymbolRotation = (double)feature["rotation"]!
-        };
-    }
+        ImageSource = "embeddedresource://Mapsui.Samples.Common.Images.arrow.svg",
+        SymbolScale = 0.5,
+        SymbolOffset = new RelativeOffset(0.0, 0.5),
+        Opacity = 0.5f,
+        SymbolRotation = (double)feature["rotation"]!
+    };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSample.cs
@@ -30,7 +30,7 @@ public class AnimatedPointsSample : ISample
 
     private static SymbolStyle CreateSvgArrowStyle(IFeature feature) => new()
     {
-        ImageSource = "embeddedresource://Mapsui.Samples.Common.Images.arrow.svg",
+        ImageSource = "embedded://Mapsui.Samples.Common.Images.arrow.svg",
         SymbolScale = 0.5,
         SymbolOffset = new RelativeOffset(0.0, 0.5),
         Opacity = 0.5f,

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSample.cs
@@ -2,25 +2,40 @@
 using Mapsui.Styles;
 using Mapsui.Styles.Thematics;
 using Mapsui.Tiling;
+using System;
 using System.Threading.Tasks;
 
 namespace Mapsui.Samples.Common.Maps.Animations;
 
-public class AnimatedPointsSample : ISample
+public sealed class AnimatedPointsSample : ISample, IDisposable
 {
-    public string Name => "Animated Points";
+    private bool _disposed;
+    readonly AnimatedPointsSampleProvider _animatedPointsSampleProvider = new();
 
+    public string Name => "Animated Points";
     public string Category => "Animations";
 
     public Task<Map> CreateMapAsync()
     {
         var map = new Map();
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(CreateAnimatedPointLayer());
+        map.Layers.Add(CreateAnimatedPointLayer(_animatedPointsSampleProvider));
         return Task.FromResult(map);
     }
 
-    private static AnimatedPointLayer CreateAnimatedPointLayer() => new(new AnimatedPointsSampleProvider())
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _animatedPointsSampleProvider.Dispose();
+
+        _disposed = true;
+    }
+
+    private static AnimatedPointLayer CreateAnimatedPointLayer(AnimatedPointsSampleProvider animatedPointsSampleProvider) => new(animatedPointsSampleProvider)
     {
         Name = "Animated Points",
         Style = CreatePointStyle()
@@ -36,4 +51,5 @@ public class AnimatedPointsSample : ISample
         Opacity = 0.5f,
         SymbolRotation = (double)feature["rotation"]!
     };
+
 }

--- a/Samples/Mapsui.Samples.Common/Maps/DataFormats/ShapefileSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/DataFormats/ShapefileSample.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using Mapsui.Layers;
 using Mapsui.Nts.Providers.Shapefile;
@@ -87,7 +86,7 @@ public class ShapefileSample : ISample
         // Scaling city icons based on city population.
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
-        var imageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.icon.png");
+        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.icon.png";
         var cityMin = new SymbolStyle { ImageSource = imageSource, SymbolScale = 0.5f };
         var cityMax = new SymbolStyle { ImageSource = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);

--- a/Samples/Mapsui.Samples.Common/Maps/DataFormats/ShapefileSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/DataFormats/ShapefileSample.cs
@@ -86,7 +86,7 @@ public class ShapefileSample : ISample
         // Scaling city icons based on city population.
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
-        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.icon.png";
+        var imageSource = "embedded://Mapsui.Samples.Common.Images.icon.png";
         var cityMin = new SymbolStyle { ImageSource = imageSource, SymbolScale = 0.5f };
         var cityMax = new SymbolStyle { ImageSource = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
@@ -44,7 +44,7 @@ public class DynamicSvgStyleSample : ISample
 
     private IStyle CreateDynamicSvgStyle(Func<MPoint> getInfoPosition) // Use Func to make it get the latest clicked position
     {
-        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.arrow.svg";
+        var imageSource = "embedded://Mapsui.Samples.Common.Images.arrow.svg";
 
         return new ThemeStyle((f) =>
         {

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
@@ -44,7 +44,7 @@ public class DynamicSvgStyleSample : ISample
 
     private IStyle CreateDynamicSvgStyle(Func<MPoint> getInfoPosition) // Use Func to make it get the latest clicked position
     {
-        var imageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.arrow.svg");
+        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.arrow.svg";
 
         return new ThemeStyle((f) =>
         {

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
@@ -77,7 +77,7 @@ public class PointsSample : ISample
 
     private static SymbolStyle CreateBitmapStyle()
     {
-        var imageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.home.png"); // Designed by Freepik http://www.freepik.com
+        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.home.png"; // Designed by Freepik http://www.freepik.com
         var bitmapHeight = 176; // To set the offset correct we need to know the bitmap height
         return new SymbolStyle { ImageSource = imageSource, SymbolScale = 0.20, SymbolOffset = new Offset(0, bitmapHeight * 0.5) };
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
@@ -77,7 +77,7 @@ public class PointsSample : ISample
 
     private static SymbolStyle CreateBitmapStyle()
     {
-        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.home.png"; // Designed by Freepik http://www.freepik.com
+        var imageSource = "embedded://Mapsui.Samples.Common.Images.home.png"; // Designed by Freepik http://www.freepik.com
         var bitmapHeight = 176; // To set the offset correct we need to know the bitmap height
         return new SymbolStyle { ImageSource = imageSource, SymbolScale = 0.20, SymbolOffset = new Offset(0, bitmapHeight * 0.5) };
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/VariousSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/VariousSample.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Mapsui.UI;
-using System;
 
 namespace Mapsui.Samples.Common.Maps.Geometries;
 
@@ -58,7 +57,7 @@ public class VariousSample : ISample, ISampleTest
 
     private static SymbolStyle CreateBitmapStyle(string embeddedResourcePath)
     {
-        return new SymbolStyle { ImageSource = new Uri(embeddedResourcePath), SymbolScale = 0.75 };
+        return new SymbolStyle { ImageSource = embeddedResourcePath, SymbolScale = 0.75 };
     }
 
     public async Task InitializeTestAsync(IMapControl mapControl)

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/VariousSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/VariousSample.cs
@@ -34,13 +34,13 @@ public class VariousSample : ISample, ISampleTest
         return new Layer("Style on Layer")
         {
             DataSource = new MemoryProvider(RandomPointsBuilder.GenerateRandomPoints(envelope, count).ToFeatures()),
-            Style = CreateBitmapStyle("embeddedresource://Mapsui.Samples.Common.Images.ic_place_black_24dp.png")
+            Style = CreateBitmapStyle("embedded://Mapsui.Samples.Common.Images.ic_place_black_24dp.png")
         };
     }
 
     private static ILayer CreateLayerWithStyleOnFeature(MRect? envelope, int count = 25)
     {
-        var style = CreateBitmapStyle("embeddedresource://Mapsui.Samples.Common.Images.loc.png");
+        var style = CreateBitmapStyle("embedded://Mapsui.Samples.Common.Images.loc.png");
 
         return new Layer("Style on feature")
         {

--- a/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutSample.cs
@@ -64,7 +64,7 @@ public class CustomCalloutSample : ISample
             feature["name"] = c.Name;
             feature["country"] = c.Country;
 
-            var calloutStyle = CreateCalloutStyle("embeddedresource://Mapsui.Samples.Common.Images.loc.png");
+            var calloutStyle = CreateCalloutStyle("embedded://Mapsui.Samples.Common.Images.loc.png");
             feature.Styles.Add(calloutStyle);
             return feature;
         });

--- a/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutSample.cs
@@ -72,7 +72,7 @@ public class CustomCalloutSample : ISample
 
     private static IStyle CreateCalloutStyle(string ImageSource)
     {
-        var calloutStyle = new CalloutStyle { ImageSource = new Uri(ImageSource), ArrowPosition = _random.Next(1, 9) * 0.1f, RotateWithMap = true, Type = CalloutType.Image };
+        var calloutStyle = new CalloutStyle { ImageSource = ImageSource, ArrowPosition = _random.Next(1, 9) * 0.1f, RotateWithMap = true, Type = CalloutType.Image };
         switch (_random.Next(0, 4))
         {
             case 0:

--- a/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithShapefileSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithShapefileSample.cs
@@ -7,7 +7,6 @@ using Mapsui.Samples.Common.Utilities;
 using Mapsui.Styles;
 using Mapsui.Styles.Thematics;
 using Mapsui.Tiling.Layers;
-using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -92,7 +91,7 @@ public class ShapefileTileSample : ISample
         // Scaling city icons based on city population.
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
-        var imageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.icon.png");
+        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.icon.png";
         var cityMin = new SymbolStyle { ImageSource = imageSource, SymbolScale = 0.5f };
         var cityMax = new SymbolStyle { ImageSource = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);

--- a/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithShapefileSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithShapefileSample.cs
@@ -91,7 +91,7 @@ public class ShapefileTileSample : ISample
         // Scaling city icons based on city population.
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
-        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.icon.png";
+        var imageSource = "embedded://Mapsui.Samples.Common.Images.icon.png";
         var cityMin = new SymbolStyle { ImageSource = imageSource, SymbolScale = 0.5f };
         var cityMax = new SymbolStyle { ImageSource = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);

--- a/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
@@ -5,7 +5,6 @@ using Mapsui.Samples.Common.DataBuilders;
 using Mapsui.Styles;
 using Mapsui.Tiling;
 using Mapsui.Widgets.InfoWidgets;
-using System;
 using System.Threading.Tasks;
 
 namespace Mapsui.Samples.Common.Maps.Projection;
@@ -68,7 +67,7 @@ public class PointProjectionSample : ISample
 
     private static SymbolStyle CreateCityStyle()
     {
-        var imageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.location.png");
+        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.location.png";
 
         return new SymbolStyle
         {

--- a/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
@@ -67,7 +67,7 @@ public class PointProjectionSample : ISample
 
     private static SymbolStyle CreateCityStyle()
     {
-        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.location.png";
+        var imageSource = "embedded://Mapsui.Samples.Common.Images.location.png";
 
         return new SymbolStyle
         {

--- a/Samples/Mapsui.Samples.Common/Maps/Projection/ShapefileProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Projection/ShapefileProjectionSample.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using Mapsui.Extensions.Projections;
 using Mapsui.Layers;
@@ -105,7 +104,7 @@ public class ShapefileProjectionSample : ISample
         // Scaling city icons based on city population.
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
-        var imageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.icon.png");
+        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.icon.png";
         var cityMin = new SymbolStyle { ImageSource = imageSource, SymbolScale = 0.5f };
         var cityMax = new SymbolStyle { ImageSource = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);

--- a/Samples/Mapsui.Samples.Common/Maps/Projection/ShapefileProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Projection/ShapefileProjectionSample.cs
@@ -104,7 +104,7 @@ public class ShapefileProjectionSample : ISample
         // Scaling city icons based on city population.
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
-        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.icon.png";
+        var imageSource = "embedded://Mapsui.Samples.Common.Images.icon.png";
         var cityMin = new SymbolStyle { ImageSource = imageSource, SymbolScale = 0.5f };
         var cityMax = new SymbolStyle { ImageSource = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);

--- a/Samples/Mapsui.Samples.Common/Maps/Special/ShapefileTilingFilteringSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/ShapefileTilingFilteringSample.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using Mapsui.Layers;
 using Mapsui.Nts;
@@ -101,7 +100,7 @@ public class ShapefileTilingFilteringSample : ISample
         // Scaling city icons based on city population.
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
-        var imageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.icon.png");
+        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.icon.png";
         var cityMin = new SymbolStyle { ImageSource = imageSource, SymbolScale = 0.5f };
         var cityMax = new SymbolStyle { ImageSource = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);

--- a/Samples/Mapsui.Samples.Common/Maps/Special/ShapefileTilingFilteringSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/ShapefileTilingFilteringSample.cs
@@ -100,7 +100,7 @@ public class ShapefileTilingFilteringSample : ISample
         // Scaling city icons based on city population.
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
-        var imageSource = "embeddedresource://Mapsui.Samples.Common.Images.icon.png";
+        var imageSource = "embedded://Mapsui.Samples.Common.Images.icon.png";
         var cityMin = new SymbolStyle { ImageSource = imageSource, SymbolScale = 0.5f };
         var cityMax = new SymbolStyle { ImageSource = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/AtlasSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/AtlasSample.cs
@@ -14,7 +14,6 @@ namespace Mapsui.Samples.Common.Maps.Styles;
 public class AtlasSample : ISample
 {
     private const string _layerName = "Sprites";
-    private static readonly Uri _atlasImageSource = new("embeddedresource://mapsui.samples.common.images.osm-liberty.png");
     private static readonly Random _random = new(1);
 
     public string Name => "Sprites";
@@ -53,9 +52,15 @@ public class AtlasSample : ISample
             var feature = new PointFeature(p) { ["Label"] = counter.ToString() };
             var x = 0 + _random.Next(0, 12) * 21;
             var y = 64 + _random.Next(0, 6) * 21;
-            feature.Styles.Add(new SymbolStyle { ImageSource = _atlasImageSource, Sprite = new Sprite(x, y, 21, 21) });
+            feature.Styles.Add(CreateSymbolStyle(x, y));
             counter++;
             return feature;
         }).ToList();
     }
+
+    private static SymbolStyle CreateSymbolStyle(int x, int y) => new()
+    {
+        ImageSource = "embeddedresource://mapsui.samples.common.images.osm-liberty.png",
+        Sprite = new Sprite(x, y, 21, 21)
+    };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/AtlasSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/AtlasSample.cs
@@ -60,7 +60,7 @@ public class AtlasSample : ISample
 
     private static SymbolStyle CreateSymbolStyle(int x, int y) => new()
     {
-        ImageSource = "embeddedresource://mapsui.samples.common.images.osm-liberty.png",
+        ImageSource = "embedded://mapsui.samples.common.images.osm-liberty.png",
         Sprite = new Sprite(x, y, 21, 21)
     };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SvgSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SvgSample.cs
@@ -4,7 +4,6 @@ using Mapsui.Samples.Common.DataBuilders;
 using Mapsui.Styles;
 using Mapsui.Tiling;
 using Mapsui.Widgets.InfoWidgets;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -46,14 +45,16 @@ public class SvgSample : ISample
         return randomPoints.Select(p =>
         {
             var feature = new PointFeature(p) { ["Label"] = counter.ToString() };
-            feature.Styles.Add(CreateSvgStyle("embeddedresource://Mapsui.Samples.Common.Images.Pin.svg", 0.5));
+            feature.Styles.Add(CreateSvgStyle());
             counter++;
             return feature;
         });
     }
 
-    private static SymbolStyle CreateSvgStyle(string embeddedResourcePath, double scale)
+    private static SymbolStyle CreateSvgStyle() => new()
     {
-        return new SymbolStyle { ImageSource = new Uri(embeddedResourcePath), SymbolScale = scale, SymbolOffset = new RelativeOffset(0.0, 0.5) };
-    }
+        ImageSource = "embeddedresource://Mapsui.Samples.Common.Images.Pin.svg",
+        SymbolScale = 0.5,
+        SymbolOffset = new RelativeOffset(0.0, 0.5)
+    };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SvgSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SvgSample.cs
@@ -53,7 +53,7 @@ public class SvgSample : ISample
 
     private static SymbolStyle CreateSvgStyle() => new()
     {
-        ImageSource = "embeddedresource://Mapsui.Samples.Common.Images.Pin.svg",
+        ImageSource = "embedded://Mapsui.Samples.Common.Images.Pin.svg",
         SymbolScale = 0.5,
         SymbolOffset = new RelativeOffset(0.0, 0.5)
     };

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SymbolsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SymbolsSample.cs
@@ -4,7 +4,6 @@ using Mapsui.Samples.Common.DataBuilders;
 using Mapsui.Styles;
 using Mapsui.Tiling;
 using Mapsui.Widgets.InfoWidgets;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -93,43 +92,39 @@ public class SymbolsSample : ISample
 
     private static SymbolStyle CreateBitmapStyle(string embeddedResourcePath, double scale)
     {
-        return new SymbolStyle { ImageSource = new Uri(embeddedResourcePath), SymbolScale = scale, SymbolOffset = new Offset(0, 32) };
+        return new SymbolStyle { ImageSource = embeddedResourcePath, SymbolScale = scale, SymbolOffset = new Offset(0, 32) };
     }
 
     private static SymbolStyle CreateSvgStyle(string embeddedResourcePath, double scale)
     {
-        return new SymbolStyle { ImageSource = new Uri(embeddedResourcePath), SymbolScale = scale, SymbolOffset = new RelativeOffset(0.0, 0.5) };
+        return new SymbolStyle { ImageSource = embeddedResourcePath, SymbolScale = scale, SymbolOffset = new RelativeOffset(0.0, 0.5) };
     }
 
-    private static IFeature CreatePointWithStackedStyles()
+    private static PointFeature CreatePointWithStackedStyles() => new(new MPoint(5000000, -5000000))
     {
-        var feature = new PointFeature(new MPoint(5000000, -5000000));
-
-        feature.Styles.Add(new SymbolStyle
-        {
-            SymbolScale = 2.0f,
-            Fill = null,
-            Outline = new Pen { Color = Color.Yellow }
-        });
-
-        feature.Styles.Add(new SymbolStyle
-        {
-            SymbolScale = 0.8f,
-            Fill = new Brush { Color = Color.Red }
-        });
-
-        feature.Styles.Add(new SymbolStyle
-        {
-            SymbolScale = 0.5f,
-            Fill = new Brush { Color = Color.Black }
-        });
-
-        feature.Styles.Add(new LabelStyle
-        {
-            Text = "Stacked Styles",
-            HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left
-        });
-
-        return feature;
-    }
+        Styles =
+        [
+            new SymbolStyle
+            {
+                SymbolScale = 2.0f,
+                Fill = null,
+                Outline = new Pen { Color = Color.Yellow }
+            },
+            new SymbolStyle
+            {
+                SymbolScale = 0.8f,
+                Fill = new Brush { Color = Color.Red }
+            },
+            new SymbolStyle
+            {
+                SymbolScale = 0.5f,
+                Fill = new Brush { Color = Color.Black }
+            },
+            new LabelStyle
+            {
+                Text = "Stacked Styles",
+                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left
+            }
+        ]
+    };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SymbolsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SymbolsSample.cs
@@ -79,14 +79,14 @@ public class SymbolsSample : ISample
             new SymbolStyle {SymbolScale = 1.2, SymbolOffset = new Offset(diameter, 0)},
             new SymbolStyle {SymbolScale = 1, SymbolOffset = new Offset(0, diameter)},
             new SymbolStyle {SymbolScale = 1, SymbolOffset = new Offset(diameter, diameter)},
-            CreateBitmapStyle("embeddedresource://Mapsui.Samples.Common.Images.ic_place_black_24dp.png", 0.7),
-            CreateBitmapStyle("embeddedresource://Mapsui.Samples.Common.Images.ic_place_black_24dp.png", 0.8),
-            CreateBitmapStyle("embeddedresource://Mapsui.Samples.Common.Images.ic_place_black_24dp.png", 0.9),
-            CreateBitmapStyle("embeddedresource://Mapsui.Samples.Common.Images.ic_place_black_24dp.png", 1.0),
-            CreateSvgStyle("embeddedresource://Mapsui.Samples.Common.Images.Pin.svg", 0.7),
-            CreateSvgStyle("embeddedresource://Mapsui.Samples.Common.Images.Pin.svg", 0.8),
-            CreateSvgStyle("embeddedresource://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg", 0.05),
-            CreateSvgStyle("embeddedresource://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg", 0.1),
+            CreateBitmapStyle("embedded://Mapsui.Samples.Common.Images.ic_place_black_24dp.png", 0.7),
+            CreateBitmapStyle("embedded://Mapsui.Samples.Common.Images.ic_place_black_24dp.png", 0.8),
+            CreateBitmapStyle("embedded://Mapsui.Samples.Common.Images.ic_place_black_24dp.png", 0.9),
+            CreateBitmapStyle("embedded://Mapsui.Samples.Common.Images.ic_place_black_24dp.png", 1.0),
+            CreateSvgStyle("embedded://Mapsui.Samples.Common.Images.Pin.svg", 0.7),
+            CreateSvgStyle("embedded://Mapsui.Samples.Common.Images.Pin.svg", 0.8),
+            CreateSvgStyle("embedded://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg", 0.05),
+            CreateSvgStyle("embedded://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg", 0.1),
         };
     }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/ThemeStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/ThemeStyleSample.cs
@@ -105,7 +105,7 @@ public class ThemeStyleSample : ISample
 
     private static SymbolStyle CreateCityStyle() => new()
     {
-        ImageSource = "embeddedresource://Mapsui.Samples.Common.Images.location.png",
+        ImageSource = "embedded://Mapsui.Samples.Common.Images.location.png",
         SymbolOffset = new Offset { Y = 64 },
         SymbolScale = 0.25
     };

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/ThemeStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/ThemeStyleSample.cs
@@ -9,7 +9,6 @@ using Mapsui.Styles;
 using Mapsui.Styles.Thematics;
 using Mapsui.Widgets.InfoWidgets;
 using NetTopologySuite.Geometries;
-using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -104,15 +103,10 @@ public class ThemeStyleSample : ISample
         };
     }
 
-    private static SymbolStyle CreateCityStyle()
+    private static SymbolStyle CreateCityStyle() => new()
     {
-        var imageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.location.png");
-
-        return new SymbolStyle
-        {
-            ImageSource = imageSource,
-            SymbolOffset = new Offset { Y = 64 },
-            SymbolScale = 0.25
-        };
-    }
+        ImageSource = "embeddedresource://Mapsui.Samples.Common.Images.location.png",
+        SymbolOffset = new Offset { Y = 64 },
+        SymbolScale = 0.25
+    };
 }

--- a/Tests/Mapsui.Rendering.Skia.Tests/SymbolStyleFeatureSizeTests.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/SymbolStyleFeatureSizeTests.cs
@@ -90,7 +90,7 @@ public class SymbolStyleFeatureSizeTests
         using var renderService = new RenderService();
         var symbolStyle = new SymbolStyle
         {
-            ImageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg",
+            ImageSource = "embedded://Mapsui.Resources.Images.Pin.svg",
         };
 
         ImageSourceInitializer.InitializeWhenNeeded((r) =>

--- a/Tests/Mapsui.Rendering.Skia.Tests/SymbolStyleFeatureSizeTests.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/SymbolStyleFeatureSizeTests.cs
@@ -88,10 +88,9 @@ public class SymbolStyleFeatureSizeTests
     {
         // Arrange
         using var renderService = new RenderService();
-        var imageSource = new Uri("embeddedresource://Mapsui.Resources.Images.Pin.svg");
         var symbolStyle = new SymbolStyle
         {
-            ImageSource = imageSource,
+            ImageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg",
         };
 
         ImageSourceInitializer.InitializeWhenNeeded((r) =>

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapAtlasSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapAtlasSample.cs
@@ -42,8 +42,8 @@ public class BitmapAtlasSample : ISample
 
     public static List<IFeature> CreateFeatures()
     {
-        var atlasImageSource = "embeddedresource://Mapsui.Samples.Common.Images.osm-liberty.png";
-        var svgTigerImageSource = "embeddedresource://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg";
+        var atlasImageSource = "embedded://Mapsui.Samples.Common.Images.osm-liberty.png";
+        var svgTigerImageSource = "embedded://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg";
         var spriteAmusementPark15 = new Sprite(106, 0, 21, 21);
         var spriteClothingStore15 = new Sprite(84, 106, 21, 21);
         var spriteDentist15 = new Sprite(147, 64, 21, 21);

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapAtlasSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapAtlasSample.cs
@@ -1,7 +1,6 @@
 ﻿using Mapsui.Layers;
 using Mapsui.Samples.Common;
 using Mapsui.Styles;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -43,12 +42,12 @@ public class BitmapAtlasSample : ISample
 
     public static List<IFeature> CreateFeatures()
     {
-        var atlasImageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.osm-liberty.png");
+        var atlasImageSource = "embeddedresource://Mapsui.Samples.Common.Images.osm-liberty.png";
+        var svgTigerImageSource = "embeddedresource://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg";
         var spriteAmusementPark15 = new Sprite(106, 0, 21, 21);
         var spriteClothingStore15 = new Sprite(84, 106, 21, 21);
         var spriteDentist15 = new Sprite(147, 64, 21, 21);
         var spritePedestrianPolygon = new Sprite(0, 0, 64, 64);
-        var svgTigerImageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg");
 
         return new List<IFeature>
         {

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolInCollectionSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolInCollectionSample.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Mapsui.Layers;
 using Mapsui.Nts;
@@ -40,8 +39,8 @@ public class BitmapSymbolInCollectionSample : ISample
 
     public static IEnumerable<IFeature> CreateFeatures()
     {
-        var circleImageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.circle.png");
-        var checkeredIconImageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.checkered.png");
+        var circleImageSource = "embeddedresource://Mapsui.Samples.Common.Images.circle.png";
+        var checkeredIconImageSource = "embeddedresource://Mapsui.Samples.Common.Images.checkered.png";
 
         // This test was created the easy way, by copying BitmapSymbol and the GeometryCollection. A test 
         // written specifically for GeometryCollection would probably look different.

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolInCollectionSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolInCollectionSample.cs
@@ -39,8 +39,8 @@ public class BitmapSymbolInCollectionSample : ISample
 
     public static IEnumerable<IFeature> CreateFeatures()
     {
-        var circleImageSource = "embeddedresource://Mapsui.Samples.Common.Images.circle.png";
-        var checkeredIconImageSource = "embeddedresource://Mapsui.Samples.Common.Images.checkered.png";
+        var circleImageSource = "embedded://Mapsui.Samples.Common.Images.circle.png";
+        var checkeredIconImageSource = "embedded://Mapsui.Samples.Common.Images.checkered.png";
 
         // This test was created the easy way, by copying BitmapSymbol and the GeometryCollection. A test 
         // written specifically for GeometryCollection would probably look different.

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolSample.cs
@@ -37,8 +37,8 @@ public class BitmapSymbolSample : ISample
 
     public static IEnumerable<IFeature> CreateFeatures()
     {
-        var circleImageSource = "embeddedresource://Mapsui.Samples.Common.Images.circle.png";
-        var checkeredImageSource = "embeddedresource://Mapsui.Samples.Common.Images.checkered.png";
+        var circleImageSource = "embedded://Mapsui.Samples.Common.Images.circle.png";
+        var checkeredImageSource = "embedded://Mapsui.Samples.Common.Images.checkered.png";
 
         return
         [

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolSample.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Mapsui.Layers;
 using Mapsui.Samples.Common;
@@ -38,8 +37,8 @@ public class BitmapSymbolSample : ISample
 
     public static IEnumerable<IFeature> CreateFeatures()
     {
-        var circleImageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.circle.png");
-        var checkeredImageSource = new Uri("embeddedresource://Mapsui.Samples.Common.Images.checkered.png");
+        var circleImageSource = "embeddedresource://Mapsui.Samples.Common.Images.circle.png";
+        var checkeredImageSource = "embeddedresource://Mapsui.Samples.Common.Images.checkered.png";
 
         return
         [

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolWithRotationAndOffsetSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolWithRotationAndOffsetSample.cs
@@ -54,7 +54,7 @@ public class BitmapSymbolWithRotationAndOffsetSample : ISample
 
     private static GeometryFeature CreateFeatureWithRotatedBitmapSymbol(double x, double y, double rotation)
     {
-        var imageSource = "embeddedresource://Mapsui.Tests.Common.Resources.Images.iconthatneedsoffset.png";
+        var imageSource = "embedded://Mapsui.Tests.Common.Resources.Images.iconthatneedsoffset.png";
 
         var feature = new GeometryFeature { Geometry = new Point(x, y) };
 

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolWithRotationAndOffsetSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolWithRotationAndOffsetSample.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Mapsui.Layers;
 using Mapsui.Nts;
@@ -55,7 +54,7 @@ public class BitmapSymbolWithRotationAndOffsetSample : ISample
 
     private static GeometryFeature CreateFeatureWithRotatedBitmapSymbol(double x, double y, double rotation)
     {
-        var imageSource = new Uri("embeddedresource://Mapsui.Tests.Common.Resources.Images.iconthatneedsoffset.png");
+        var imageSource = "embeddedresource://Mapsui.Tests.Common.Resources.Images.iconthatneedsoffset.png";
 
         var feature = new GeometryFeature { Geometry = new Point(x, y) };
 

--- a/Tests/Mapsui.Tests.Common/Maps/PolygonTestSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/PolygonTestSample.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Mapsui.Layers;
@@ -19,7 +18,7 @@ public class PolygonTestSample : ISample
 
     public static Map CreateMap()
     {
-        var imageSource = new Uri("embeddedresource://mapsui.tests.common.resources.images.avion_silhouette.png");
+        var imageSource = "embeddedresource://mapsui.tests.common.resources.images.avion_silhouette.png";
 
         var layer = CreateLayer(imageSource);
 
@@ -35,7 +34,7 @@ public class PolygonTestSample : ISample
         return map;
     }
 
-    private static MemoryLayer CreateLayer(Uri imageSource)
+    private static MemoryLayer CreateLayer(string imageSource)
     {
         return new MemoryLayer
         {
@@ -45,7 +44,7 @@ public class PolygonTestSample : ISample
     }
 
     [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP003:Dispose previous before re-assigning")]
-    public static IEnumerable<IFeature> CreatePolygonProvider(Uri imageSource)
+    public static IEnumerable<IFeature> CreatePolygonProvider(string imageSource)
     {
         var wktReader = new WKTReader();
         var features = new List<IFeature>();
@@ -186,7 +185,7 @@ public class PolygonTestSample : ISample
         return features;
     }
 
-    private static Brush CreateBrush(Color color, FillStyle fillStyle, Uri? imageSource = null)
+    private static Brush CreateBrush(Color color, FillStyle fillStyle, string? imageSource = null)
     {
         if (imageSource is not null && !(fillStyle == FillStyle.Bitmap || fillStyle == FillStyle.BitmapRotated))
             fillStyle = FillStyle.Bitmap;

--- a/Tests/Mapsui.Tests.Common/Maps/PolygonTestSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/PolygonTestSample.cs
@@ -18,7 +18,7 @@ public class PolygonTestSample : ISample
 
     public static Map CreateMap()
     {
-        var imageSource = "embeddedresource://mapsui.tests.common.resources.images.avion_silhouette.png";
+        var imageSource = "embedded://mapsui.tests.common.resources.images.avion_silhouette.png";
 
         var layer = CreateLayer(imageSource);
 

--- a/Tests/Mapsui.Tests.Common/Maps/SvgSymbolSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/SvgSymbolSample.cs
@@ -57,9 +57,9 @@ public class SvgSymbolSample : ISample
         ];
     }
 
-    private static SymbolStyle CreateSymbolStyle(string pinImageSource) => new()
+    private static SymbolStyle CreateSymbolStyle(string imageSource) => new()
     {
-        ImageSource = pinImageSource,
+        ImageSource = imageSource,
         BlendModeColor = Color.FromRgba(0, 177, 0, 255)
     };
 }

--- a/Tests/Mapsui.Tests.Common/Maps/SvgSymbolSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/SvgSymbolSample.cs
@@ -42,16 +42,20 @@ public class SvgSymbolSample : ISample
 
         return
         [
-            new PointFeature(new MPoint(50, 50)) {
+            new PointFeature(new MPoint(50, 50))
+            {
                 Styles = new[] { CreateSymbolStyle(imageSourceOfPinSymbol) }
             },
-            new PointFeature(new MPoint(50, 100)) {
+            new PointFeature(new MPoint(50, 100))
+            {
                 Styles = new[] { CreateSymbolStyle(imageSourceOfPinSymbol) }
             },
-            new PointFeature(new MPoint(100, 50)) {
+            new PointFeature(new MPoint(100, 50))
+            {
                 Styles = new[] { CreateSymbolStyle(imageSourceOfPinSymbol) }
             },
-            new PointFeature(new MPoint(100, 100)) {
+            new PointFeature(new MPoint(100, 100))
+            {
                 Styles = new[] { CreateSymbolStyle(imageSourceOfPinSymbol) }
             }
         ];

--- a/Tests/Mapsui.Tests.Common/Maps/SvgSymbolSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/SvgSymbolSample.cs
@@ -38,7 +38,7 @@ public class SvgSymbolSample : ISample
 
     public static IEnumerable<IFeature> CreateFeatures()
     {
-        var imageSourceOfPinSymbol = "embeddedresource://mapsui.resources.images.pin.svg";
+        var imageSourceOfPinSymbol = "embedded://mapsui.resources.images.pin.svg";
 
         return
         [

--- a/Tests/Mapsui.Tests.Common/Maps/SvgSymbolSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/SvgSymbolSample.cs
@@ -1,7 +1,6 @@
 ﻿using Mapsui.Layers;
 using Mapsui.Samples.Common;
 using Mapsui.Styles;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -39,26 +38,26 @@ public class SvgSymbolSample : ISample
 
     public static IEnumerable<IFeature> CreateFeatures()
     {
-        var pinImageSource = new Uri("embeddedresource://mapsui.resources.images.pin.svg");
+        var imageSourceOfPinSymbol = "embeddedresource://mapsui.resources.images.pin.svg";
 
         return
         [
             new PointFeature(new MPoint(50, 50)) {
-                Styles = new[] { CreateSymbolStyle(pinImageSource) }
+                Styles = new[] { CreateSymbolStyle(imageSourceOfPinSymbol) }
             },
             new PointFeature(new MPoint(50, 100)) {
-                Styles = new[] { CreateSymbolStyle(pinImageSource) }
+                Styles = new[] { CreateSymbolStyle(imageSourceOfPinSymbol) }
             },
             new PointFeature(new MPoint(100, 50)) {
-                Styles = new[] { CreateSymbolStyle(pinImageSource) }
+                Styles = new[] { CreateSymbolStyle(imageSourceOfPinSymbol) }
             },
             new PointFeature(new MPoint(100, 100)) {
-                Styles = new[] { CreateSymbolStyle(pinImageSource) }
+                Styles = new[] { CreateSymbolStyle(imageSourceOfPinSymbol) }
             }
         ];
     }
 
-    private static SymbolStyle CreateSymbolStyle(Uri pinImageSource) => new()
+    private static SymbolStyle CreateSymbolStyle(string pinImageSource) => new()
     {
         ImageSource = pinImageSource,
         BlendModeColor = Color.FromRgba(0, 177, 0, 255)

--- a/Tests/Mapsui.Tests/Styles/BitmapPathRegistryTests.cs
+++ b/Tests/Mapsui.Tests/Styles/BitmapPathRegistryTests.cs
@@ -13,7 +13,7 @@ public static class ImageSourceCacheTests
     public static async Task AddAndRemoveEntryAsync()
     {
         // Arrange
-        var imageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg";
+        var imageSource = "embedded://Mapsui.Resources.Images.Pin.svg";
         await ImageSourceCache.Instance.RegisterAsync(imageSource);
 
         // Act
@@ -27,7 +27,7 @@ public static class ImageSourceCacheTests
     public static async Task AddAndRemoveUriResourceEmbeddedRegisterAsync()
     {
         // Arrange
-        var imageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg";
+        var imageSource = "embedded://Mapsui.Resources.Images.Pin.svg";
         await ImageSourceCache.Instance.RegisterAsync(imageSource);
 
         // Act
@@ -41,7 +41,7 @@ public static class ImageSourceCacheTests
     public static async Task AddUriResourceEmbeddedRegisterAsync()
     {
         // Arrange
-        var imageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg";
+        var imageSource = "embedded://Mapsui.Resources.Images.Pin.svg";
         await ImageSourceCache.Instance.RegisterAsync(imageSource);
 
         // Act
@@ -114,7 +114,7 @@ public static class ImageSourceCacheTests
     public async static Task RenderBitmapRegistryDisposeShouldRemoveBitmapAsync()
     {
         // Arrange
-        var imageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg";
+        var imageSource = "embedded://Mapsui.Resources.Images.Pin.svg";
         var imageSourceCache = ImageSourceCache.Instance;
         await imageSourceCache.RegisterAsync(imageSource);
 

--- a/Tests/Mapsui.Tests/Styles/BitmapPathRegistryTests.cs
+++ b/Tests/Mapsui.Tests/Styles/BitmapPathRegistryTests.cs
@@ -13,7 +13,7 @@ public static class ImageSourceCacheTests
     public static async Task AddAndRemoveEntryAsync()
     {
         // Arrange
-        var imageSource = new Uri("embeddedresource://Mapsui.Resources.Images.Pin.svg");
+        var imageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg";
         await ImageSourceCache.Instance.RegisterAsync(imageSource);
 
         // Act
@@ -27,7 +27,7 @@ public static class ImageSourceCacheTests
     public static async Task AddAndRemoveUriResourceEmbeddedRegisterAsync()
     {
         // Arrange
-        var imageSource = new Uri("embeddedresource://Mapsui.Resources.Images.Pin.svg");
+        var imageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg";
         await ImageSourceCache.Instance.RegisterAsync(imageSource);
 
         // Act
@@ -41,7 +41,7 @@ public static class ImageSourceCacheTests
     public static async Task AddUriResourceEmbeddedRegisterAsync()
     {
         // Arrange
-        var imageSource = new Uri("embeddedresource://Mapsui.Resources.Images.Pin.svg");
+        var imageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg";
         await ImageSourceCache.Instance.RegisterAsync(imageSource);
 
         // Act
@@ -56,7 +56,7 @@ public static class ImageSourceCacheTests
     public static async Task AddAndRemoveUriFileRegisterAsync()
     {
         // Arrange
-        var examplePath = new Uri($"file://{AppContext.BaseDirectory}/Resources/example.tif");
+        var examplePath = $"file://{AppContext.BaseDirectory}/Resources/example.tif";
         await ImageSourceCache.Instance.RegisterAsync(examplePath);
 
         // Act
@@ -70,7 +70,7 @@ public static class ImageSourceCacheTests
     public static async Task AddUriFileRegisterAsync()
     {
         // Arrange
-        var examplePath = new Uri($"file://{AppContext.BaseDirectory}/Resources/example.tif");
+        var examplePath = $"file://{AppContext.BaseDirectory}/Resources/example.tif";
         await ImageSourceCache.Instance.RegisterAsync(examplePath);
 
         // Act
@@ -85,7 +85,7 @@ public static class ImageSourceCacheTests
     public static async Task AddAndRemoveUriHttpsRegisterAsync()
     {
         // Arrange
-        var mapsuiLogo = new Uri("https://mapsui.com/images/logo.svg");
+        var mapsuiLogo = "https://mapsui.com/images/logo.svg";
         await ImageSourceCache.Instance.RegisterAsync(mapsuiLogo);
 
         // Act
@@ -99,7 +99,7 @@ public static class ImageSourceCacheTests
     public static async Task AddUriHttpsRegisterAsync()
     {
         // Arrange
-        var mapsuiLogo = new Uri("https://mapsui.com/images/logo.svg");
+        var mapsuiLogo = "https://mapsui.com/images/logo.svg";
         await ImageSourceCache.Instance.RegisterAsync(mapsuiLogo);
 
         // Act
@@ -114,7 +114,7 @@ public static class ImageSourceCacheTests
     public async static Task RenderBitmapRegistryDisposeShouldRemoveBitmapAsync()
     {
         // Arrange
-        var imageSource = new Uri("embeddedresource://Mapsui.Resources.Images.Pin.svg");
+        var imageSource = "embeddedresource://Mapsui.Resources.Images.Pin.svg";
         var imageSourceCache = ImageSourceCache.Instance;
         await imageSourceCache.RegisterAsync(imageSource);
 
@@ -124,21 +124,5 @@ public static class ImageSourceCacheTests
 
         // Assert
         // Todo: fix test before merging to main: Assert.Throws<ObjectDisposedException>(() => imageSourceCache.Get(imageSource));
-    }
-
-    [Test]
-    public static void UrlShouldDoValueCompare()
-    {
-        // This is to be sure that Url implements value compare.
-        // They don't mention it in the documentation.
-        // https://learn.microsoft.com/en-us/dotnet/api/system.security.policy.url.equals?view=net-8.0#system-security-policy-url-equals(system-object)
-
-        // Arrange
-        var logoUrl = new Uri("https://mapsui.com/images/logo.svg");
-        var otherInstanceOfSameUrl = new Uri("https://mapsui.com/images/logo.svg");
-
-        // Act and Assert
-        Assert.That(logoUrl == otherInstanceOfSameUrl, Is.True);
-        Assert.That(logoUrl.Equals(otherInstanceOfSameUrl), Is.True);
     }
 }


### PR DESCRIPTION
- Although I liked the Uri initially I prefer string now. I use the ImageSource as cache key and although a Uri can be used as key as well I prefer to use something basic like a string. Also the initialization of the ImagePath is slightly simpler if you can just assign a string to the field. Internally I still use the Uri for the validation and for fetching.
- Instead of `"embeddedresource://"` I now use `"embedded://"`. I found embeddedresource a bit too long, it is easy to make typos and forced line wrapping more often.