### PR TITLE
Add ImageButtonWidget.ImageSource

### DIFF
--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -208,7 +208,7 @@ public sealed class MapRenderer : IRenderer, IDisposable
 
     private void Render(object canvas, Viewport viewport, IEnumerable<IWidget> widgets, float layerOpacity)
     {
-        WidgetRenderer.Render(canvas, viewport, widgets, WidgetRenders, layerOpacity);
+        WidgetRenderer.Render(canvas, viewport, widgets, WidgetRenders, SkiaRenderService, layerOpacity);
     }
 
     public MapInfo GetMapInfo(double x, double y, Viewport viewport, IEnumerable<ILayer> layers, int margin = 0)

--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -58,7 +58,7 @@ public sealed class MapRenderer : IRenderer, IDisposable
         WidgetRenders[typeof(TextBoxWidget)] = new TextBoxWidgetRenderer();
         WidgetRenders[typeof(ScaleBarWidget)] = new ScaleBarWidgetRenderer();
         WidgetRenders[typeof(ZoomInOutWidget)] = new ZoomInOutWidgetRenderer();
-        WidgetRenders[typeof(IconButtonWidget)] = new IconButtonWidgetRenderer();
+        WidgetRenders[typeof(ImageButtonWidget)] = new ImageButtonWidgetRenderer();
         WidgetRenders[typeof(BoxWidget)] = new BoxWidgetRenderer();
         WidgetRenders[typeof(LoggingWidget)] = new LoggingWidgetRenderer();
         WidgetRenders[typeof(InputOnlyWidget)] = new InputOnlyWidgetRenderer();

--- a/Mapsui.Rendering.Skia/SkiaStyles/PolygonRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/PolygonRenderer.cs
@@ -212,31 +212,32 @@ internal static class PolygonRenderer
 
     private static SKImage? GetImage(DrawableImageCache drawableImageCache, Brush brush)
     {
-        if (drawableImageCache == null)
-            return null;
         if (brush.ImageSource is null)
             return null;
-        var image = drawableImageCache.GetOrCreate(brush.ImageSource,
+        var drawableImage = drawableImageCache.GetOrCreate(brush.ImageSource,
             () => SymbolStyleRenderer.TryCreateDrawableImage(brush.ImageSource));
-        if (image == null)
+        if (drawableImage == null)
             return null;
 
-        if (image is BitmapImage bitmapImage)
+        if (drawableImage is BitmapImage bitmapImage)
         {
             if (brush.BitmapRegion is null)
                 return bitmapImage.Image;
             else
             {
                 if (brush.ImageSource is null)
-                    throw new Exception("If Sprite is assigned ImageSource should be set.");
-                var sprite = brush.BitmapRegion;
+                    throw new Exception("If BitmapRegion is not null the ImageSource should be set.");
 
-                // The line below generates a string. For performance is it not great to have this in the render loop.
-                var spriteKey = SymbolStyleRenderer.ToSpriteKey(brush.ImageSource.ToString(), brush.BitmapRegion);
-                drawableImageCache.GetOrCreate(spriteKey, () => CreateBitmapImage(bitmapImage.Image, sprite));
+                var imageRegionKey = SymbolStyleRenderer.ToSpriteKey(brush.ImageSource.ToString(), brush.BitmapRegion);
+                var regionDrawableImage = drawableImageCache.GetOrCreate(imageRegionKey, () => CreateBitmapImage(bitmapImage.Image, brush.BitmapRegion));
+                if (regionDrawableImage == null)
+                    return null;
+                if (regionDrawableImage is BitmapImage regionBitmapImage)
+                    return regionBitmapImage.Image;
+                throw new Exception("Only bitmaps are is supported for polygon fill.");
             }
         }
-        return null;
+        throw new Exception("Only bitmaps are is supported for polygon fill.");
     }
 
     private static BitmapImage CreateBitmapImage(SKImage skImage, BitmapRegion bitmapRegion)

--- a/Mapsui.Rendering.Skia/SkiaWidgets/BoxWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/BoxWidgetRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Mapsui.Rendering.Skia.Extensions;
+﻿using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Rendering.Skia.Extensions;
 using Mapsui.Widgets;
 using Mapsui.Widgets.BoxWidgets;
 using SkiaSharp;
@@ -7,7 +8,7 @@ namespace Mapsui.Rendering.Skia.SkiaWidgets;
 
 public class BoxWidgetRenderer : ISkiaWidgetRenderer
 {
-    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, float layerOpacity)
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity)
     {
         var boxWidget = (BoxWidget)widget;
 

--- a/Mapsui.Rendering.Skia/SkiaWidgets/ISkiaWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/ISkiaWidgetRenderer.cs
@@ -1,9 +1,10 @@
-﻿using Mapsui.Widgets;
+﻿using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Widgets;
 using SkiaSharp;
 
 namespace Mapsui.Rendering.Skia.SkiaWidgets;
 
 public interface ISkiaWidgetRenderer : IWidgetRenderer
 {
-    void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, float layerOpacity);
+    void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity);
 }

--- a/Mapsui.Rendering.Skia/SkiaWidgets/IconButtonWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/IconButtonWidgetRenderer.cs
@@ -1,30 +1,30 @@
-﻿using Mapsui.Rendering.Skia.Extensions;
+﻿using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Rendering.Skia.Extensions;
+using Mapsui.Rendering.Skia.Images;
 using Mapsui.Widgets;
 using Mapsui.Widgets.ButtonWidgets;
 using SkiaSharp;
+using System;
 
 namespace Mapsui.Rendering.Skia.SkiaWidgets;
 
 public class IconButtonWidgetRenderer : ISkiaWidgetRenderer
 {
-    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, float layerOpacity)
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity)
     {
         var button = (IconButtonWidget)widget;
 
-        if (button.Picture == null && string.IsNullOrEmpty(button.SvgImage))
+        if (button.ImageSource == null)
+            throw new InvalidOperationException("ImageSource is not set");
+
+        var drawableImage = renderService.DrawableImageCache.GetOrCreate(button.ImageSource,
+            () => SymbolStyleRenderer.TryCreateDrawableImage(button.ImageSource));
+        if (drawableImage == null)
             return;
 
-        button.Picture ??= button.SvgImage?.LoadSvgPicture();
-
-        var picture = button.Picture as SKPicture;
-
-        if (picture == null)
-            return;
-
-        // Calc Envelope by Width/Height or, if not set, by size of content
         button.UpdateEnvelope(
-            button.Width != 0 ? button.Width : picture.CullRect.Width + button.Padding.Left + button.Padding.Right,
-            button.Height != 0 ? button.Height : picture.CullRect.Height + button.Padding.Top + button.Padding.Bottom,
+            button.Width != 0 ? button.Width : drawableImage.Width + button.Padding.Left + button.Padding.Right,
+            button.Height != 0 ? button.Height : drawableImage.Height + button.Padding.Top + button.Padding.Bottom,
             viewport.Width,
 
             viewport.Height);
@@ -36,19 +36,33 @@ public class IconButtonWidgetRenderer : ISkiaWidgetRenderer
         canvas.DrawRoundRect(button.Envelope.ToSkia(), (float)button.CornerRadius, (float)button.CornerRadius, backPaint);
 
         // Get the scale for picture in each direction
-        var scaleX = (button.Envelope.Width - button.Padding.Left - button.Padding.Right) / picture.CullRect.Width;
-        var scaleY = (button.Envelope.Height - button.Padding.Top - button.Padding.Bottom) / picture.CullRect.Height;
+        var scaleX = (button.Envelope.Width - button.Padding.Left - button.Padding.Right) / drawableImage.Width;
+        var scaleY = (button.Envelope.Height - button.Padding.Top - button.Padding.Bottom) / drawableImage.Height;
 
-        // Rotate picture
-        var matrix = SKMatrix.CreateRotationDegrees((float)button.Rotation, picture.CullRect.Width / 2f, picture.CullRect.Height / 2f);
-
-        // Create a scale matrix
-        matrix = matrix.PostConcat(SKMatrix.CreateScale((float)scaleX, (float)scaleY));
-
-        // Translate picture to right place
-        matrix = matrix.PostConcat(SKMatrix.CreateTranslation((float)(button.Envelope.MinX + button.Padding.Left), (float)(button.Envelope.MinY + button.Padding.Top)));
 
         using var skPaint = new SKPaint { IsAntialias = true };
-        canvas.DrawPicture(picture, ref matrix, skPaint);
+        if (drawableImage is BitmapImage bitmapImage)
+        {
+            throw new Exception($"BitmapImage is not supported as {nameof(button.ImageSource)}  or {nameof(IconButtonWidget)}");
+            // Todo: Implement this. It should have a tested sample. Perhaps in a separate ImageButtonWidgetSample. Things like scale and
+            // rotation should be tested. Could be something like this:
+            // BitmapRenderer.Draw(canvas, bitmapImage.Image,
+            //    (float)button.Envelope.Centroid.X, (float)button.Envelope.Centroid.Y, (float)button.Rotation);
+        }
+        else if (drawableImage is SvgImage svgImage)
+        {
+            // Rotate picture
+            var matrix = SKMatrix.CreateRotationDegrees((float)button.Rotation, drawableImage.Width / 2f, drawableImage.Height / 2f);
+            // Create a scale matrix
+            matrix = matrix.PostConcat(SKMatrix.CreateScale((float)scaleX, (float)scaleY));
+            // Translate picture to right place
+            matrix = matrix.PostConcat(SKMatrix.CreateTranslation((float)(button.Envelope.MinX + button.Padding.Left), (float)(button.Envelope.MinY + button.Padding.Top)));
+            // Draw picture
+            canvas.DrawPicture(svgImage.Picture, ref matrix, skPaint);
+        }
+        else
+            throw new NotSupportedException("DrawableImage type not supported");
+
+
     }
 }

--- a/Mapsui.Rendering.Skia/SkiaWidgets/ImageButtonWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/ImageButtonWidgetRenderer.cs
@@ -8,11 +8,11 @@ using System;
 
 namespace Mapsui.Rendering.Skia.SkiaWidgets;
 
-public class IconButtonWidgetRenderer : ISkiaWidgetRenderer
+public class ImageButtonWidgetRenderer : ISkiaWidgetRenderer
 {
     public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity)
     {
-        var button = (IconButtonWidget)widget;
+        var button = (ImageButtonWidget)widget;
 
         if (button.ImageSource == null)
             throw new InvalidOperationException("ImageSource is not set");
@@ -43,7 +43,7 @@ public class IconButtonWidgetRenderer : ISkiaWidgetRenderer
         using var skPaint = new SKPaint { IsAntialias = true };
         if (drawableImage is BitmapImage bitmapImage)
         {
-            throw new Exception($"BitmapImage is not supported as {nameof(button.ImageSource)}  or {nameof(IconButtonWidget)}");
+            throw new Exception($"BitmapImage is not supported as {nameof(button.ImageSource)}  or {nameof(ImageButtonWidget)}");
             // Todo: Implement this. It should have a tested sample. Perhaps in a separate ImageButtonWidgetSample. Things like scale and
             // rotation should be tested. Could be something like this:
             // BitmapRenderer.Draw(canvas, bitmapImage.Image,

--- a/Mapsui.Rendering.Skia/SkiaWidgets/InputOnlyWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/InputOnlyWidgetRenderer.cs
@@ -1,10 +1,11 @@
-﻿using Mapsui.Widgets;
+﻿using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Widgets;
 using SkiaSharp;
 
 namespace Mapsui.Rendering.Skia.SkiaWidgets;
 public class InputOnlyWidgetRenderer : ISkiaWidgetRenderer
 {
-    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, float layerOpacity)
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity)
     {
         // Do nothing. Widgets derived from the InputOnlyWidget class are not drawn.
     }

--- a/Mapsui.Rendering.Skia/SkiaWidgets/LoggingWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/LoggingWidgetRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using Mapsui.Logging;
+using Mapsui.Rendering.Skia.Cache;
 using Mapsui.Rendering.Skia.Extensions;
 using Mapsui.Widgets;
 using Mapsui.Widgets.InfoWidgets;
@@ -29,7 +30,7 @@ public class LoggingWidgetRenderer : ISkiaWidgetRenderer, IDisposable
         _levelWidth = _informationTextPaint.MeasureText(LogLevel.Information.ToString());
     }
 
-    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, float layerOpacity)
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity)
     {
         var loggingWidget = (LoggingWidget)widget;
 

--- a/Mapsui.Rendering.Skia/SkiaWidgets/PerformanceWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/PerformanceWidgetRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Mapsui.Rendering.Skia.Extensions;
+﻿using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Rendering.Skia.Extensions;
 using Mapsui.Widgets;
 using Mapsui.Widgets.InfoWidgets;
 using SkiaSharp;
@@ -10,7 +11,7 @@ public class PerformanceWidgetRenderer : ISkiaWidgetRenderer
     private readonly string[] _textHeader = { "Last", "Mean", "Frames", "Min", "Max", "Count", "Dropped" };
     private readonly string[] _text = new string[7];
 
-    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, float layerOpacity)
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity)
     {
         var performanceWidget = (PerformanceWidget)widget;
         var textSize = performanceWidget.TextSize;

--- a/Mapsui.Rendering.Skia/SkiaWidgets/ScaleBarWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/ScaleBarWidgetRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Mapsui.Rendering.Skia.Cache;
 using Mapsui.Rendering.Skia.Extensions;
 using Mapsui.Widgets;
 using Mapsui.Widgets.ScaleBar;
@@ -14,7 +15,7 @@ public class ScaleBarWidgetRenderer : ISkiaWidgetRenderer, IDisposable
     private readonly SKPaint _paintScaleText = CreateTextPaint(SKPaintStyle.Fill);
     private readonly SKPaint _paintScaleTextStroke = CreateTextPaint(SKPaintStyle.Stroke);
 
-    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget,
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService,
         float layerOpacity)
     {
         var scaleBar = (ScaleBarWidget)widget;

--- a/Mapsui.Rendering.Skia/SkiaWidgets/TextBoxWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/TextBoxWidgetRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Mapsui.Rendering.Skia.Extensions;
+﻿using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Rendering.Skia.Extensions;
 using Mapsui.Widgets;
 using Mapsui.Widgets.BoxWidgets;
 using SkiaSharp;
@@ -7,7 +8,8 @@ namespace Mapsui.Rendering.Skia.SkiaWidgets;
 
 public class TextBoxWidgetRenderer : ISkiaWidgetRenderer
 {
-    public virtual void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, float layerOpacity)
+    public virtual void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService,
+        float layerOpacity)
     {
         DrawText(canvas, viewport, widget, layerOpacity);
     }

--- a/Mapsui.Rendering.Skia/SkiaWidgets/WidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/WidgetRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Mapsui.Rendering.Skia.Cache;
 using Mapsui.Widgets;
 using SkiaSharp;
 
@@ -8,7 +9,7 @@ namespace Mapsui.Rendering.Skia.SkiaWidgets;
 public static class WidgetRenderer
 {
     public static void Render(object target, Viewport viewport, IEnumerable<IWidget> widgets,
-        IDictionary<Type, IWidgetRenderer> renders, float layerOpacity)
+        IDictionary<Type, IWidgetRenderer> renders, RenderService renderService, float layerOpacity)
     {
         var canvas = (SKCanvas)target;
 
@@ -40,7 +41,7 @@ public static class WidgetRenderer
                 renderer = renders[widget.GetType()];
             }
 
-            ((ISkiaWidgetRenderer)renderer).Draw(canvas, viewport, widget, layerOpacity);
+            ((ISkiaWidgetRenderer)renderer).Draw(canvas, viewport, widget, renderService, layerOpacity);
 
             // Widget is redrawn
             widget.NeedsRedraw = false;

--- a/Mapsui.Rendering.Skia/SkiaWidgets/ZoomInOutWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/ZoomInOutWidgetRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Mapsui.Rendering.Skia.Extensions;
+﻿using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Rendering.Skia.Extensions;
 using Mapsui.Widgets;
 using Mapsui.Widgets.ButtonWidgets;
 using SkiaSharp;
@@ -13,7 +14,7 @@ public class ZoomInOutWidgetRenderer : ISkiaWidgetRenderer
     private static SKPaint? _paintBackground;
     private static SKPaint? _paintText;
 
-    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget,
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService,
         float layerOpacity)
     {
         var zoomInOut = (ZoomInOutWidget)widget;

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -362,12 +362,12 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         {
             if (MyLocationFollow)
             {
-                _mapMyLocationButton!.Picture = _pictMyLocationCenter;
+                //_mapMyLocationButton!.Picture = _pictMyLocationCenter;
                 Map.Navigator.CenterOn(MyLocationLayer.MyLocation.ToMapsui());
             }
             else
             {
-                _mapMyLocationButton!.Picture = _pictMyLocationNoCenter;
+                //_mapMyLocationButton!.Picture = _pictMyLocationNoCenter;
             }
 
             Refresh();
@@ -771,22 +771,22 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     private void CreateButtons()
     {
         _mapZoomInButton ??= CreateButton(0, 0, _pictZoomIn, (s, e) => { Map.Navigator.ZoomIn(); return true; });
-        _mapZoomInButton.Picture = _pictZoomIn;
+        //_mapZoomInButton.Picture = _pictZoomIn;
         _mapZoomInButton.Enabled = IsZoomButtonVisible;
         Map!.Widgets.Add(_mapZoomInButton);
 
         _mapZoomOutButton ??= CreateButton(0, 40, _pictZoomOut, (s, e) => { Map.Navigator.ZoomOut(); return true; });
-        _mapZoomOutButton.Picture = _pictZoomOut;
+        //_mapZoomOutButton.Picture = _pictZoomOut;
         _mapZoomOutButton.Enabled = IsZoomButtonVisible;
         Map!.Widgets.Add(_mapZoomOutButton);
 
         _mapMyLocationButton ??= CreateButton(0, 88, _pictMyLocationNoCenter, (s, e) => { MyLocationFollow = true; return true; });
-        _mapMyLocationButton.Picture = _pictMyLocationNoCenter;
+        //_mapMyLocationButton.Picture = _pictMyLocationNoCenter;
         _mapMyLocationButton.Enabled = IsMyLocationButtonVisible;
         Map!.Widgets.Add(_mapMyLocationButton);
 
         _mapNorthingButton ??= CreateButton(0, 136, _pictNorthing, (s, e) => { RunOnUIThread(() => Map.Navigator.RotateTo(0)); return true; });
-        _mapNorthingButton.Picture = _pictNorthing;
+        //_mapNorthingButton.Picture = _pictNorthing;
         _mapNorthingButton.Enabled = IsNorthingButtonVisible;
         Map!.Widgets.Add(_mapNorthingButton);
 
@@ -796,7 +796,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     private IconButtonWidget CreateButton(
         float x, float y, SKPicture picture, Func<IconButtonWidget, WidgetEventArgs, bool> tapped) => new()
         {
-            Picture = picture,
+            //Picture = picture,
             HorizontalAlignment = Widgets.HorizontalAlignment.Absolute,
             VerticalAlignment = Widgets.VerticalAlignment.Absolute,
             Position = new MPoint(x, y),

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -34,10 +34,10 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     private readonly ObservableMemoryLayer<Callout> _mapCalloutLayer = new(f => f.Feature) { Name = _calloutLayerName, IsMapInfoLayer = true };
     private readonly ObservableMemoryLayer<Pin> _mapPinLayer = new(f => f.Feature) { Name = _pinLayerName, IsMapInfoLayer = true };
     private readonly ObservableMemoryLayer<Drawable> _mapDrawableLayer = new(f => f.Feature) { Name = _drawableLayerName, IsMapInfoLayer = true };
-    private IconButtonWidget? _mapZoomInButton;
-    private IconButtonWidget? _mapZoomOutButton;
-    private IconButtonWidget? _mapMyLocationButton;
-    private IconButtonWidget? _mapNorthingButton;
+    private ImageButtonWidget? _mapZoomInButton;
+    private ImageButtonWidget? _mapZoomOutButton;
+    private ImageButtonWidget? _mapMyLocationButton;
+    private ImageButtonWidget? _mapNorthingButton;
     private readonly SKPicture _pictMyLocationNoCenter;
     private readonly SKPicture _pictMyLocationCenter;
     private readonly SKPicture _pictZoomIn;
@@ -793,8 +793,8 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         UpdateButtonPositions();
     }
 
-    private IconButtonWidget CreateButton(
-        float x, float y, SKPicture picture, Func<IconButtonWidget, WidgetEventArgs, bool> tapped) => new()
+    private ImageButtonWidget CreateButton(
+        float x, float y, SKPicture picture, Func<ImageButtonWidget, WidgetEventArgs, bool> tapped) => new()
         {
             //Picture = picture,
             HorizontalAlignment = Widgets.HorizontalAlignment.Absolute,

--- a/Mapsui/Styles/CalloutStyle.cs
+++ b/Mapsui/Styles/CalloutStyle.cs
@@ -92,7 +92,7 @@ public class CalloutStyle : SymbolStyle
     /// Type of Callout
     /// </summary>
     /// <remarks>
-    /// Could be Single, Detail or Custom. The last need a bitmap id in Content for an owner drawn image.
+    /// Could be Single, Detail or Image.
     /// </remarks>
     public CalloutType Type
     {

--- a/Mapsui/Styles/SymbolStyle.cs
+++ b/Mapsui/Styles/SymbolStyle.cs
@@ -93,13 +93,13 @@ public class SymbolStyle : VectorStyle
 
     /// <summary>
     /// Option to override the fill color of the SVG image. This is useful if you want to change the color of the SVG 
-    /// source image.
+    /// source image. Note that each different color used will add an new object to the image cache.
     /// </summary>
     public Color? SvgFillColor { get; set; }
 
     /// <summary>
     /// Option to override the stroke color of the SVG image. This is useful if you want to change the color of the SVG 
-    /// source image.
+    /// source image. Note that each different color used will add an new object to the image cache.
     /// </summary>
     public Color? SvgStrokeColor { get; set; }
 

--- a/Mapsui/Widgets/ButtonWidgets/IconButtonWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/IconButtonWidget.cs
@@ -50,37 +50,22 @@ public class IconButtonWidget : BoxWidget
         }
     }
 
-    private string? _svgImage;
+    private string? _imageSource;
 
     /// <summary>
-    /// SVG image to show for button
+    /// The image to show as button
     /// </summary>
-    public string? SvgImage
+    public string? ImageSource
     {
-        get => _svgImage;
+        get => _imageSource;
         set
         {
-            if (_svgImage == value)
+            if (_imageSource == value)
                 return;
 
-            _svgImage = value;
-            Picture = null;
-            Invalidate();
-        }
-    }
-
-    private object? _picture;
-
-    /// <summary>
-    /// Object for prerendered image. For internal use only.
-    /// </summary>
-    public object? Picture
-    {
-        get => _picture;
-        set
-        {
-            if (Equals(value, _picture)) return;
-            _picture = value;
+            if (!string.IsNullOrEmpty(value))
+                ImageSourceInitializer.Add(value);
+            _imageSource = value;
             Invalidate();
         }
     }

--- a/Mapsui/Widgets/ButtonWidgets/ImageButtonWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/ImageButtonWidget.cs
@@ -7,22 +7,9 @@ namespace Mapsui.Widgets.ButtonWidgets;
 /// <summary>
 /// Widget that shows a button with an icon
 /// </summary>
-/// <remarks>
-/// With this, the user could add buttons with SVG icons to the map.
-/// 
-/// Usage
-/// To show a IconButtonWidget, add a instance of the IconButtonWidget to Map.Widgets by
-/// 
-///   map.Widgets.Add(new IconButtonWidget(map, picture));
-///   
-/// Customize
-/// Picture: SVG image to display for button
-/// Rotation: Value for rotation in degrees
-/// Opacity: Opacity of button
-/// </remarks>
-public class IconButtonWidget : BoxWidget
+public class ImageButtonWidget : BoxWidget
 {
-    public IconButtonWidget() : base()
+    public ImageButtonWidget() : base()
     {
         BackColor = Color.Transparent;
     }
@@ -30,7 +17,7 @@ public class IconButtonWidget : BoxWidget
     /// <summary>
     /// Event handler which is called, when the button is touched
     /// </summary>
-    public Func<IconButtonWidget, WidgetEventArgs, bool> Tapped = (s, e) => false;
+    public Func<ImageButtonWidget, WidgetEventArgs, bool> Tapped = (s, e) => false;
 
     private MRect _padding = new(0);
 

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonSample.cs
@@ -31,7 +31,7 @@ public class ButtonSample : ISample
                 map.RefreshGraphics();
                 return false;
             }));
-        map.Widgets.Add(CreateButtonWithImage(VerticalAlignment.Top, HorizontalAlignment.Right));
+        map.Widgets.Add(CreateImageButtonWidget(VerticalAlignment.Top, HorizontalAlignment.Right));
         map.Widgets.Add(CreateButton("Hello!", VerticalAlignment.Bottom, HorizontalAlignment.Right, (s, a) =>
             {
                 s.Text = $"{s.Text}!";
@@ -64,7 +64,7 @@ public class ButtonSample : ISample
             Tapped = tapped
         };
 
-    private static IconButtonWidget CreateButtonWithImage(
+    private static ImageButtonWidget CreateImageButtonWidget(
         VerticalAlignment verticalAlignment, HorizontalAlignment horizontalAlignment) => new()
         {
             ImageSource = "embedded://Mapsui.Resources.Images.MyLocationStill.svg",

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonSample.cs
@@ -5,8 +5,6 @@ using Mapsui.Tiling;
 using Mapsui.Widgets;
 using Mapsui.Widgets.ButtonWidgets;
 using System;
-using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Mapsui.Samples.Common.Maps.Widgets;
@@ -69,7 +67,7 @@ public class ButtonSample : ISample
     private static IconButtonWidget CreateButtonWithImage(
         VerticalAlignment verticalAlignment, HorizontalAlignment horizontalAlignment) => new()
         {
-            SvgImage = LoadSomeSvgAsString(),
+            ImageSource = "embedded://Mapsui.Resources.Images.MyLocationStill.svg",
             VerticalAlignment = verticalAlignment,
             HorizontalAlignment = horizontalAlignment,
             Margin = new MRect(30),
@@ -77,13 +75,4 @@ public class ButtonSample : ISample
             CornerRadius = 8,
             Envelope = new MRect(0, 0, 64, 64)
         };
-
-    static string LoadSomeSvgAsString()
-    {
-        Assembly assembly = typeof(Map).Assembly ?? throw new ArgumentNullException("assembly");
-        using Stream stream = assembly.GetManifestResourceStream(assembly.GetFullName("Resources.Images.MyLocationStill.svg"))
-            ?? throw new Exception("Can not find embedded resource");
-        using StreamReader reader = new StreamReader(stream);
-        return reader.ReadToEnd();
-    }
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
@@ -1,4 +1,5 @@
 ﻿using Mapsui.Extensions;
+using Mapsui.Logging;
 using Mapsui.Manipulations;
 using Mapsui.Styles;
 using Mapsui.Tiling;
@@ -11,11 +12,12 @@ namespace Mapsui.Samples.Common.Maps.Widgets;
 
 public class ButtonWidgetSample : ISample
 {
-    public string Name => "Button";
-    public string Category => "Widgets";
-
     private int _tapCount;
     private int _doubleTapCount;
+    private int _imageTapCount;
+
+    public string Name => "Button";
+    public string Category => "Widgets";
 
     public Task<Map> CreateMapAsync()
     {
@@ -23,22 +25,27 @@ public class ButtonWidgetSample : ISample
 
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
 
-        map.Widgets.Add(CreateButton("Tap me", VerticalAlignment.Top, HorizontalAlignment.Left, (s, a) =>
-            {
-                if (a.TapType == TapType.Double)
-                    return false;
-                s.Text = $"Tapped {++_tapCount} times";
-                map.RefreshGraphics();
+        map.Widgets.Add(CreateButtonWidget("Tap me", VerticalAlignment.Top, HorizontalAlignment.Left, (s, a) =>
+        {
+            if (a.TapType == TapType.Double)
                 return false;
-            }));
-        map.Widgets.Add(CreateImageButtonWidget(VerticalAlignment.Top, HorizontalAlignment.Right));
-        map.Widgets.Add(CreateButton("Hello!", VerticalAlignment.Bottom, HorizontalAlignment.Right, (s, a) =>
-            {
-                s.Text = $"{s.Text}!";
-                map.RefreshGraphics();
-                return false;
-            }));
-        map.Widgets.Add(CreateButton("Double Tap me", VerticalAlignment.Bottom, HorizontalAlignment.Left, (s, a) =>
+            s.Text = $"Tapped {++_tapCount} times";
+            map.RefreshGraphics();
+            return false;
+        }));
+        map.Widgets.Add(CreateImageButtonWidget(VerticalAlignment.Top, HorizontalAlignment.Right, (s, a) =>
+        {
+            Logger.Log(LogLevel.Information, $"Image Tapped {++_imageTapCount} times");
+            map.RefreshGraphics();
+            return false;
+        }));
+        map.Widgets.Add(CreateButtonWidget("Hello!", VerticalAlignment.Bottom, HorizontalAlignment.Right, (s, a) =>
+        {
+            s.Text = $"{s.Text}!";
+            map.RefreshGraphics();
+            return false;
+        }));
+        map.Widgets.Add(CreateButtonWidget("Double Tap me", VerticalAlignment.Bottom, HorizontalAlignment.Left, (s, a) =>
         {
             if (a.TapType == TapType.Single)
                 return false;
@@ -50,7 +57,7 @@ public class ButtonWidgetSample : ISample
         return Task.FromResult(map);
     }
 
-    private static ButtonWidget CreateButton(string text, VerticalAlignment verticalAlignment,
+    private static ButtonWidget CreateButtonWidget(string text, VerticalAlignment verticalAlignment,
         HorizontalAlignment horizontalAlignment, Func<ButtonWidget, WidgetEventArgs, bool> tapped) => new()
         {
             Text = text,
@@ -64,8 +71,8 @@ public class ButtonWidgetSample : ISample
             Tapped = tapped
         };
 
-    private static ImageButtonWidget CreateImageButtonWidget(
-        VerticalAlignment verticalAlignment, HorizontalAlignment horizontalAlignment) => new()
+    private static ImageButtonWidget CreateImageButtonWidget(VerticalAlignment verticalAlignment,
+        HorizontalAlignment horizontalAlignment, Func<ImageButtonWidget, WidgetEventArgs, bool> tapped) => new()
         {
             ImageSource = "embedded://Mapsui.Resources.Images.MyLocationStill.svg",
             VerticalAlignment = verticalAlignment,
@@ -73,6 +80,7 @@ public class ButtonWidgetSample : ISample
             Margin = new MRect(30),
             Padding = new MRect(10, 8),
             CornerRadius = 8,
-            Envelope = new MRect(0, 0, 64, 64)
+            Envelope = new MRect(0, 0, 64, 64),
+            Tapped = tapped
         };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Mapsui.Samples.Common.Maps.Widgets;
 
-public class ButtonSample : ISample
+public class ButtonWidgetSample : ISample
 {
     public string Name => "Button";
     public string Category => "Widgets";

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
@@ -8,6 +8,7 @@ using SkiaSharp;
 using System;
 using System.Threading.Tasks;
 using Mapsui.Rendering.Skia.Extensions;
+using Mapsui.Rendering.Skia.Cache;
 
 namespace Mapsui.Samples.Common.Maps.Widgets;
 
@@ -66,7 +67,7 @@ public class CustomWidget : BaseWidget
 
 public class CustomWidgetSkiaRenderer : ISkiaWidgetRenderer
 {
-    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, float layerOpacity)
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity)
     {
         // Cast to custom widget to be able to access the specific CustomWidget fields
         var customWidget = (CustomWidget)widget;


### PR DESCRIPTION
### Context
Previously we worked with `object` pointers to skia objects in our core classes and then cast those back to `SKPicture` or `SKImage` in our renderers. So, we had an implicit dependency on skia which would not have worked for another renderer, and made the separation of concerns blurry. We are rewriting this to work with an ImageSource path. The skia objects can then be created within the skia renderer.

### Progress
We work(ed) with skia object in four places:
- [x] SymbolStyleRenderer
- [x] PolygonRenderer (brush texture)
- [x] **ImageButtonWidget.SvgPicture (previously IconButtonWidget).**
- [ ] CalloutStyle.ContentId

This PR replaced with ImageButtonWidget.SvgPicture with and ImageButtonWidget.ImageSource.