### PR TITLE
Fix: Mapsui Maui ios 17.5 rendering (Disable GPU rendering for now)

### DIFF
--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -28,7 +28,8 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
         DeviceInfo.Platform != DevicePlatform.WinUI &&
         DeviceInfo.Platform != DevicePlatform.macOS &&
         DeviceInfo.Platform != DevicePlatform.MacCatalyst &&
-        DeviceInfo.Platform != DevicePlatform.Android;
+        DeviceInfo.Platform != DevicePlatform.Android &&
+        DeviceInfo.Platform != DevicePlatform.iOS; // 3d rendering does not work on ios 17.5 with 2.88.8 skiasharp.
 
     private readonly SKGLView? _glView;
     private readonly SKCanvasView? _canvasView;


### PR DESCRIPTION
Disable 3d accelerated rendering for iOS because it doesn't work currently on iOS 17.5
Fixes this https://github.com/Mapsui/Mapsui/issues/2669