### PR TITLE
Build:  use partial clone for Builds (Reduces checkout duration)

### DIFF
--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -36,8 +36,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0 
-        fetch-tags: true
+        fetch-depth: 0         
         filter: tree:0 
     - name: Setup .NET 8 SDK
       uses: actions/setup-dotnet@v3

--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        fetch-depth: 1 
+        fetch-depth: 0 
         fetch-tags: true
         filter: tree:0 
     - name: Setup .NET 8 SDK

--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        fetch-depth: 0 
+        fetch-depth: 1 
     - name: Setup .NET 8 SDK
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -34,9 +34,10 @@ jobs:
 #End install mkdocs        
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1 
+        fetch-tags: true
     - name: Setup .NET 8 SDK
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -35,8 +35,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        filter: tree:0
+      with:                
+        filter: tree:0 
     - name: Setup .NET 8 SDK
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -35,8 +35,7 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0         
+      with:                
         filter: tree:0 
     - name: Setup .NET 8 SDK
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -38,6 +38,8 @@ jobs:
       with:
         fetch-depth: 1 
         fetch-tags: true
+    - name: Fetch Tags
+      run: git fetch --tags
     - name: Setup .NET 8 SDK
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -37,9 +37,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 1 
-        fetch-tags: true
-    - name: Fetch Tags
-      run: git fetch --tags
+        filter: tree:0 
     - name: Setup .NET 8 SDK
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -37,6 +37,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 1 
+        fetch-tags: true
         filter: tree:0 
     - name: Setup .NET 8 SDK
       uses: actions/setup-dotnet@v3

--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -35,8 +35,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
-      with:                
-        filter: tree:0 
+      with:
+        filter: tree:0
     - name: Setup .NET 8 SDK
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -35,7 +35,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
-      with:                
+      with:
+        fetch-depth: 0         
         filter: tree:0 
     - name: Setup .NET 8 SDK
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -18,8 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:        
-        filter: tree:0    
+      with:
+        filter: tree:0
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         filter: tree:0    
@@ -27,11 +27,11 @@ jobs:
         java-version: '17'
 
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.1.1
+      uses: NuGet/setup-nuget@v2
 
     # .Net 7 update     
     - name: Setup .NET 7 SDK
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
          dotnet-version: |
            8.0.x         
@@ -53,7 +53,7 @@ jobs:
       run: dotnet pack ${{ env.SOLUTION }} --configuration Release /p:Version=${{ env.VERSION_OF_RELEASE }} -o nugets
 
     - name: Upload nugets
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
       # Upload the 'nugets' folder as artifact
         name: packages

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0 # Prevent a shallow clone to allow git describe --tags
+        fetch-depth: 1
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
@@ -38,7 +38,7 @@ jobs:
     # The version tag needs to be set before the release. If not if will fail on nuget publish.
     - name: Set VERSION_OF_RELEASE to last tag
       run: |
-        echo ("VERSION_OF_RELEASE=" + $(git describe --tags --abbrev=0)) >> $env:GITHUB_ENV
+        echo ("VERSION_OF_RELEASE=" + $(git rev-parse --short HEAD --abbrev=0)) >> $env:GITHUB_ENV
         echo $VERSION_OF_RELEASE
 
     - name: install workloads

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -18,8 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      with:        
         filter: tree:0    
     - uses: actions/setup-java@v4
       with:

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -20,7 +20,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        fetch-tags: true
         filter: tree:0    
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -18,8 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        filter: tree:0
+      with:        
+        filter: tree:0    
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -17,9 +17,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        fetch-tags: true
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1
+        fetch-depth: 0
         fetch-tags: true
         filter: tree:0    
     - uses: actions/setup-java@v3

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -19,7 +19,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1          
+        fetch-depth: 1
+        fetch-tags: true
         filter: tree:0    
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -18,7 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:        
+      with:
+        fetch-depth: 0
         filter: tree:0    
     - uses: actions/setup-java@v4
       with:

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -38,7 +38,7 @@ jobs:
     # The version tag needs to be set before the release. If not if will fail on nuget publish.
     - name: Set VERSION_OF_RELEASE to last tag
       run: |
-        echo ("VERSION_OF_RELEASE=" + $(git rev-parse --short HEAD --abbrev=0)) >> $env:GITHUB_ENV
+        echo ("VERSION_OF_RELEASE=" + $(git describe --tags --abbrev=0)) >> $env:GITHUB_ENV
         echo $VERSION_OF_RELEASE
 
     - name: install workloads

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -19,10 +19,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1
-        fetch-tags: true
-    - name: Fetch Tags
-      run: git fetch --tags
+        fetch-depth: 1          
+        filter: tree:0    
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         fetch-depth: 1
         fetch-tags: true
+    - name: Fetch Tags
+      run: git fetch --tags
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1      
+        fetch-depth: 0      
         fetch-tags: true
         filter: tree:0    
     # Cache Nugets
@@ -84,7 +84,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1       
+        fetch-depth: 0       
         fetch-tags: true
         filter: tree:0
     # Cache Nugets
@@ -189,7 +189,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1  
+        fetch-depth: 0  
         fetch-tags: true
         filter: tree:0
     # Cache Nugets

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,8 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1          
+        fetch-depth: 1      
+        fetch-tags: true
         filter: tree:0    
     # Cache Nugets
     - uses: actions/cache@v3
@@ -83,7 +84,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1          
+        fetch-depth: 1       
+        fetch-tags: true
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v3
@@ -187,7 +189,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1          
+        fetch-depth: 1  
+        fetch-tags: true
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v3

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,9 +20,10 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
-        fetch-depth: 1   
+        fetch-depth: 1
+        fetch-tags: true
     # Cache Nugets
     - uses: actions/cache@v3
       with:
@@ -80,9 +81,10 @@ jobs:
     # macos-latest is currently macos-13
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        fetch-tags: true
     # Cache Nugets
     - uses: actions/cache@v3
       with:
@@ -183,9 +185,10 @@ jobs:
   winBuild:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        fetch-tags: true
     # Cache Nugets
     - uses: actions/cache@v3
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -69,7 +69,7 @@ jobs:
       run: dotnet test Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net8.0/Mapsui.Rendering.Skia.Tests.dll --blame-hang-timeout:60s
     # Release Build
     - name: Build Linux packages
-      run: dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD) Mapsui.Linux.slnf --output Artifacts
+      run: dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=$(git describe --tags) Mapsui.Linux.slnf --output Artifacts
     - name: Upload packages
       uses: actions/upload-artifact@v3
       with:
@@ -159,21 +159,21 @@ jobs:
       run: dotnet test Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net8.0/Mapsui.Rendering.Skia.Tests.dll --blame-hang-timeout:60s
     # Release Build
     - name: Build Mapsui
-      run: dotnet pack --no-restore --configuration Release Mapsui/Mapsui.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui/Mapsui.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
     - name: Build Mapsui.Rendering.Skia
-      run: dotnet pack --no-restore --configuration Release Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
     - name: Build Mapsui.Tiling
-      run: dotnet pack --no-restore --configuration Release Mapsui.Tiling/Mapsui.Tiling.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Tiling/Mapsui.Tiling.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
     - name: Build Mapsui.Nts
-      run: dotnet pack --no-restore --configuration Release Mapsui.Nts/Mapsui.Nts.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Nts/Mapsui.Nts.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
     - name: Build Mapsui.ArcGIS
-      run: dotnet pack --no-restore --configuration Release Mapsui.ArcGIS/Mapsui.ArcGIS.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.ArcGIS/Mapsui.ArcGIS.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
     - name: Build Mapsui.Extensions
-      run: dotnet pack --no-restore --configuration Release Mapsui.Extensions/Mapsui.Extensions.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Extensions/Mapsui.Extensions.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
     - name: Build Mapsui.UI.Android
-      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Android/Mapsui.UI.Android.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Android/Mapsui.UI.Android.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
     - name: Build Mapsui.UI.iOS
-      run: dotnet pack --no-restore --configuration Release Mapsui.UI.iOS/Mapsui.UI.iOS.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.UI.iOS/Mapsui.UI.iOS.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
     - name: Upload packages
       uses: actions/upload-artifact@v3
       with:
@@ -247,14 +247,14 @@ jobs:
       run: dotnet test Tests/Mapsui.UI.Maui.Tests/bin/Debug/net8.0-windows10.0.19041.0/Mapsui.UI.Maui.Tests.dll --blame-hang-timeout:60s
     # Release Build
     - name: Build nuget packages
-      run: dotnet pack Mapsui.sln --configuration Release /p:Version=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD) -o Artifacts
+      run: dotnet pack Mapsui.sln --configuration Release /p:Version=$(git describe --tags) -o Artifacts
     - name: Cleanup
       run: git clean -fx -d -e Artifacts
     # Change Project References to nuget package references in samples    
     - name: nuget ProjectReferences to PackageReferences
       shell: pwsh
       run: |
-       ./Scripts/SamplesMapsuiNugetReferences.ps1 $(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)       
+       ./Scripts/SamplesMapsuiNugetReferences.ps1 $(git describe --tags)       
     - name: Restore dependencies (dotnet)
       run: dotnet restore Mapsui.sln  
     # Samples Build 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,8 +21,7 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0              
+      with:              
         filter: tree:0    
     # Cache Nugets
     - uses: actions/cache@v4
@@ -82,8 +81,7 @@ jobs:
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0              
+      with:                
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v4
@@ -186,8 +184,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0          
+      with:        
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,8 +21,8 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: actions/checkout@v4
-      with:              
-        filter: tree:0    
+      with:
+        filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v4
       with:
@@ -81,7 +81,7 @@ jobs:
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
-      with:                
+      with:
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v4
@@ -184,7 +184,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-      with:        
+      with:
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,8 +22,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0      
-        fetch-tags: true
+        fetch-depth: 0              
         filter: tree:0    
     # Cache Nugets
     - uses: actions/cache@v3
@@ -84,8 +83,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0       
-        fetch-tags: true
+        fetch-depth: 0              
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v3
@@ -189,8 +187,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0  
-        fetch-tags: true
+        fetch-depth: 0          
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v3

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,8 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: actions/checkout@v4
-      with:              
+      with:
+        fetch-depth: 0              
         filter: tree:0    
     # Cache Nugets
     - uses: actions/cache@v4
@@ -81,7 +82,8 @@ jobs:
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
-      with:                
+      with:
+        fetch-depth: 0              
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v4
@@ -184,7 +186,8 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-      with:        
+      with:
+        fetch-depth: 0          
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,8 +21,8 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: actions/checkout@v4
-      with:
-        filter: tree:0
+      with:              
+        filter: tree:0    
     # Cache Nugets
     - uses: actions/cache@v4
       with:
@@ -81,7 +81,7 @@ jobs:
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
-      with:
+      with:                
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v4
@@ -184,7 +184,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-      with:
+      with:        
         filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,6 +24,8 @@ jobs:
       with:
         fetch-depth: 1
         fetch-tags: true
+    - name: Fetch Tags
+      run: git fetch --tags
     # Cache Nugets
     - uses: actions/cache@v3
       with:
@@ -85,6 +87,8 @@ jobs:
       with:
         fetch-depth: 1
         fetch-tags: true
+    - name: Fetch Tags
+      run: git fetch --tags
     # Cache Nugets
     - uses: actions/cache@v3
       with:
@@ -189,6 +193,8 @@ jobs:
       with:
         fetch-depth: 1
         fetch-tags: true
+    - name: Fetch Tags
+      run: git fetch --tags
     # Cache Nugets
     - uses: actions/cache@v3
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0   
+        fetch-depth: 1   
     # Cache Nugets
     - uses: actions/cache@v3
       with:
@@ -69,7 +69,7 @@ jobs:
       run: dotnet test Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net8.0/Mapsui.Rendering.Skia.Tests.dll --blame-hang-timeout:60s
     # Release Build
     - name: Build Linux packages
-      run: dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=$(git describe --tags) Mapsui.Linux.slnf --output Artifacts
+      run: dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=$(git rev-parse --short HEAD) Mapsui.Linux.slnf --output Artifacts
     - name: Upload packages
       uses: actions/upload-artifact@v3
       with:
@@ -82,7 +82,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     # Cache Nugets
     - uses: actions/cache@v3
       with:
@@ -159,21 +159,21 @@ jobs:
       run: dotnet test Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net8.0/Mapsui.Rendering.Skia.Tests.dll --blame-hang-timeout:60s
     # Release Build
     - name: Build Mapsui
-      run: dotnet pack --no-restore --configuration Release Mapsui/Mapsui.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui/Mapsui.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
     - name: Build Mapsui.Rendering.Skia
-      run: dotnet pack --no-restore --configuration Release Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
     - name: Build Mapsui.Tiling
-      run: dotnet pack --no-restore --configuration Release Mapsui.Tiling/Mapsui.Tiling.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Tiling/Mapsui.Tiling.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
     - name: Build Mapsui.Nts
-      run: dotnet pack --no-restore --configuration Release Mapsui.Nts/Mapsui.Nts.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Nts/Mapsui.Nts.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
     - name: Build Mapsui.ArcGIS
-      run: dotnet pack --no-restore --configuration Release Mapsui.ArcGIS/Mapsui.ArcGIS.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.ArcGIS/Mapsui.ArcGIS.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
     - name: Build Mapsui.Extensions
-      run: dotnet pack --no-restore --configuration Release Mapsui.Extensions/Mapsui.Extensions.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Extensions/Mapsui.Extensions.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
     - name: Build Mapsui.UI.Android
-      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Android/Mapsui.UI.Android.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Android/Mapsui.UI.Android.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
     - name: Build Mapsui.UI.iOS
-      run: dotnet pack --no-restore --configuration Release Mapsui.UI.iOS/Mapsui.UI.iOS.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.UI.iOS/Mapsui.UI.iOS.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
     - name: Upload packages
       uses: actions/upload-artifact@v3
       with:
@@ -185,7 +185,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     # Cache Nugets
     - uses: actions/cache@v3
       with:
@@ -247,14 +247,14 @@ jobs:
       run: dotnet test Tests/Mapsui.UI.Maui.Tests/bin/Debug/net8.0-windows10.0.19041.0/Mapsui.UI.Maui.Tests.dll --blame-hang-timeout:60s
     # Release Build
     - name: Build nuget packages
-      run: dotnet pack Mapsui.sln --configuration Release /p:Version=$(git describe --tags) -o Artifacts
+      run: dotnet pack Mapsui.sln --configuration Release /p:Version=$(git rev-parse --short HEAD) -o Artifacts
     - name: Cleanup
       run: git clean -fx -d -e Artifacts
     # Change Project References to nuget package references in samples    
     - name: nuget ProjectReferences to PackageReferences
       shell: pwsh
       run: |
-       ./Scripts/SamplesMapsuiNugetReferences.ps1 $(git describe --tags)       
+       ./Scripts/SamplesMapsuiNugetReferences.ps1 $(git rev-parse --short HEAD)       
     - name: Restore dependencies (dotnet)
       run: dotnet restore Mapsui.sln  
     # Samples Build 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -69,7 +69,7 @@ jobs:
       run: dotnet test Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net8.0/Mapsui.Rendering.Skia.Tests.dll --blame-hang-timeout:60s
     # Release Build
     - name: Build Linux packages
-      run: dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=$(git rev-parse --short HEAD) Mapsui.Linux.slnf --output Artifacts
+      run: dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD) Mapsui.Linux.slnf --output Artifacts
     - name: Upload packages
       uses: actions/upload-artifact@v3
       with:
@@ -159,21 +159,21 @@ jobs:
       run: dotnet test Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net8.0/Mapsui.Rendering.Skia.Tests.dll --blame-hang-timeout:60s
     # Release Build
     - name: Build Mapsui
-      run: dotnet pack --no-restore --configuration Release Mapsui/Mapsui.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui/Mapsui.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
     - name: Build Mapsui.Rendering.Skia
-      run: dotnet pack --no-restore --configuration Release Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
     - name: Build Mapsui.Tiling
-      run: dotnet pack --no-restore --configuration Release Mapsui.Tiling/Mapsui.Tiling.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Tiling/Mapsui.Tiling.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
     - name: Build Mapsui.Nts
-      run: dotnet pack --no-restore --configuration Release Mapsui.Nts/Mapsui.Nts.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Nts/Mapsui.Nts.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
     - name: Build Mapsui.ArcGIS
-      run: dotnet pack --no-restore --configuration Release Mapsui.ArcGIS/Mapsui.ArcGIS.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.ArcGIS/Mapsui.ArcGIS.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
     - name: Build Mapsui.Extensions
-      run: dotnet pack --no-restore --configuration Release Mapsui.Extensions/Mapsui.Extensions.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Extensions/Mapsui.Extensions.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
     - name: Build Mapsui.UI.Android
-      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Android/Mapsui.UI.Android.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Android/Mapsui.UI.Android.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
     - name: Build Mapsui.UI.iOS
-      run: dotnet pack --no-restore --configuration Release Mapsui.UI.iOS/Mapsui.UI.iOS.csproj -o Artifacts -p:PackageVersion=$(git rev-parse --short HEAD)
+      run: dotnet pack --no-restore --configuration Release Mapsui.UI.iOS/Mapsui.UI.iOS.csproj -o Artifacts -p:PackageVersion=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)
     - name: Upload packages
       uses: actions/upload-artifact@v3
       with:
@@ -247,14 +247,14 @@ jobs:
       run: dotnet test Tests/Mapsui.UI.Maui.Tests/bin/Debug/net8.0-windows10.0.19041.0/Mapsui.UI.Maui.Tests.dll --blame-hang-timeout:60s
     # Release Build
     - name: Build nuget packages
-      run: dotnet pack Mapsui.sln --configuration Release /p:Version=$(git rev-parse --short HEAD) -o Artifacts
+      run: dotnet pack Mapsui.sln --configuration Release /p:Version=$(git describe --tags --abbrev=0)$(git rev-parse --short HEAD) -o Artifacts
     - name: Cleanup
       run: git clean -fx -d -e Artifacts
     # Change Project References to nuget package references in samples    
     - name: nuget ProjectReferences to PackageReferences
       shell: pwsh
       run: |
-       ./Scripts/SamplesMapsuiNugetReferences.ps1 $(git rev-parse --short HEAD)       
+       ./Scripts/SamplesMapsuiNugetReferences.ps1 $(git describe --tags --abbrev=0)$(git rev-parse --short HEAD)       
     - name: Restore dependencies (dotnet)
       run: dotnet restore Mapsui.sln  
     # Samples Build 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,10 +22,8 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1
-        fetch-tags: true
-    - name: Fetch Tags
-      run: git fetch --tags
+        fetch-depth: 1          
+        filter: tree:0    
     # Cache Nugets
     - uses: actions/cache@v3
       with:
@@ -85,10 +83,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1
-        fetch-tags: true
-    - name: Fetch Tags
-      run: git fetch --tags
+        fetch-depth: 1          
+        filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v3
       with:
@@ -191,10 +187,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1
-        fetch-tags: true
-    - name: Fetch Tags
-      run: git fetch --tags
+        fetch-depth: 1          
+        filter: tree:0
     # Cache Nugets
     - uses: actions/cache@v3
       with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <Version>5.0.0-alpha.0</Version>
+    <Version>5.0.0-beta.1</Version>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Copyright>Copyright © Mapsui Developers 2018-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,21 +35,21 @@
     <PackageVersion Include="HarfBuzzSharp" Version="[7.3.0.2,8.0.0.0)" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="[7.3.0.2,8.0.0.0)" />
     <PackageVersion Include="IDisposableAnalyzers" Version="[4.0.7,5.0.0)" />
-    <PackageVersion Include="Mapsui.Android" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.ArcGIS" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.Avalonia" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.Blazor" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.Eto" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.Extensions" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.iOS" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.Maui" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.Nts" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.Rendering.Skia" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.Tiling" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.Uno.WinUI" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.WinUI" Version="5.0.0-alpha.0" />
-    <PackageVersion Include="Mapsui.Wpf" Version="5.0.0-alpha.0" />
+    <PackageVersion Include="Mapsui.Android" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.ArcGIS" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.Avalonia" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.Blazor" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.Eto" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.Extensions" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.iOS" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.Maui" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.Nts" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.Rendering.Skia" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.Tiling" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.Uno.WinUI" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.WinUI" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Mapsui.Wpf" Version="5.0.0-beta.1" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="[17.8.0,18.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[8.0.0,9.0.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.8.0, 18.0.0)" />


### PR DESCRIPTION
A partail cone with  fetch with tree:0 is around 3 seconds. For a whole checkout it can be sometimes be minutes. 
For example a linux build an checkout on linux can be 54 seconds to 6m 14 seconds

Theory behind it.
https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/