### PR TITLE
Fix: GeoTiffProvider avoid TagExtender recursion.

### DIFF
--- a/Mapsui.Extensions/Provider/GeoTiffProvider.cs
+++ b/Mapsui.Extensions/Provider/GeoTiffProvider.cs
@@ -131,6 +131,8 @@ public class GeoTiffProvider : IProvider, IDisposable
         // Register the custom tag handler
         Tiff.TiffExtendProc extender = TagExtender;
         _parentExtender = Tiff.SetTagExtender(extender);
+        if (_parentExtender == extender)
+            _parentExtender = null; // avoid recursion;
 
         using var tif = Tiff.Open(location, "r4") ?? Tiff.Open(location, "r8"); // read big tiff if normal tiff fails.
 

--- a/Mapsui.Extensions/Provider/GeoTiffProvider.cs
+++ b/Mapsui.Extensions/Provider/GeoTiffProvider.cs
@@ -108,9 +108,9 @@ public class GeoTiffProvider : IProvider, IDisposable
     private const TiffTag TIFFTAG_ModelPixelScaleTag = (TiffTag)33550;
     private const TiffTag TIFFTAG_ModelTiepointTag = (TiffTag)33922;
 
-    private Tiff.TiffExtendProc? _parentExtender;
+    private static Tiff.TiffExtendProc? _parentExtender;
 
-    public void TagExtender(Tiff tif)
+    public static void TagExtender(Tiff tif)
     {
         TiffFieldInfo[] tiffFieldInfo =
         {
@@ -124,7 +124,7 @@ public class GeoTiffProvider : IProvider, IDisposable
             _parentExtender(tif);
     }
 
-    private TiffProperties LoadTiff(string location)
+    private static TiffProperties LoadTiff(string location)
     {
         TiffProperties tiffFileProperties;
 

--- a/Mapsui.Extensions/Provider/GeoTiffProvider.cs
+++ b/Mapsui.Extensions/Provider/GeoTiffProvider.cs
@@ -130,9 +130,9 @@ public class GeoTiffProvider : IProvider, IDisposable
 
         // Register the custom tag handler
         Tiff.TiffExtendProc extender = TagExtender;
-        _parentExtender = Tiff.SetTagExtender(extender);
-        if (_parentExtender == extender)
-            _parentExtender = null; // avoid recursion;
+        var previousExtender = Tiff.SetTagExtender(extender);
+        if (previousExtender != extender) // avoid recursion;
+            _parentExtender = previousExtender;
 
         using var tif = Tiff.Open(location, "r4") ?? Tiff.Open(location, "r8"); // read big tiff if normal tiff fails.
 

--- a/Mapsui.Extensions/Provider/GeoTiffProvider.cs
+++ b/Mapsui.Extensions/Provider/GeoTiffProvider.cs
@@ -108,9 +108,9 @@ public class GeoTiffProvider : IProvider, IDisposable
     private const TiffTag TIFFTAG_ModelPixelScaleTag = (TiffTag)33550;
     private const TiffTag TIFFTAG_ModelTiepointTag = (TiffTag)33922;
 
-    private static Tiff.TiffExtendProc? _parentExtender;
+    private Tiff.TiffExtendProc? _parentExtender;
 
-    public static void TagExtender(Tiff tif)
+    public void TagExtender(Tiff tif)
     {
         TiffFieldInfo[] tiffFieldInfo =
         {
@@ -124,7 +124,7 @@ public class GeoTiffProvider : IProvider, IDisposable
             _parentExtender(tif);
     }
 
-    private static TiffProperties LoadTiff(string location)
+    private TiffProperties LoadTiff(string location)
     {
         TiffProperties tiffFileProperties;
 

--- a/Mapsui.Linux.slnf
+++ b/Mapsui.Linux.slnf
@@ -22,6 +22,7 @@
       "Samples\\Mapsui.Samples.Eto\\Mapsui.Samples.Eto.csproj",
       "Samples\\Mapsui.Samples.Maui.MapView\\Mapsui.Samples.Maui.MapView.csproj",
       "Samples\\Mapsui.Samples.Maui\\Mapsui.Samples.Maui.csproj",
+      "Samples\\Mapsui.Samples.Uno.WinUI\\Mapsui.Samples.Uno.WinUI\\Mapsui.Samples.Uno.WinUI.csproj",
       "SourceGenerators\\Mapsui.Sample.SourceGenerator\\Mapsui.Sample.SourceGenerator.csproj",
       "Tests\\Mapsui.Nts.Tests\\Mapsui.Nts.Tests.csproj",
       "Tests\\Mapsui.Rendering.Skia.Tests\\Mapsui.Rendering.Skia.Tests.csproj",

--- a/Mapsui.Linux.slnf
+++ b/Mapsui.Linux.slnf
@@ -22,7 +22,6 @@
       "Samples\\Mapsui.Samples.Eto\\Mapsui.Samples.Eto.csproj",
       "Samples\\Mapsui.Samples.Maui.MapView\\Mapsui.Samples.Maui.MapView.csproj",
       "Samples\\Mapsui.Samples.Maui\\Mapsui.Samples.Maui.csproj",
-      "Samples\\Mapsui.Samples.Uno.WinUI\\Mapsui.Samples.Uno.WinUI\\Mapsui.Samples.Uno.WinUI.csproj",
       "SourceGenerators\\Mapsui.Sample.SourceGenerator\\Mapsui.Sample.SourceGenerator.csproj",
       "Tests\\Mapsui.Nts.Tests\\Mapsui.Nts.Tests.csproj",
       "Tests\\Mapsui.Rendering.Skia.Tests\\Mapsui.Rendering.Skia.Tests.csproj",

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {
-    "Uno.Sdk": "5.2.121"
+    "Uno.Sdk": "5.3.0-dev.1916"
   }
 }


### PR DESCRIPTION
In this pull request it is visible that the TagExtender recursively calls it self  
https://github.com/Mapsui/Mapsui/actions/runs/9618748477/job/26533287346?pr=2603
By setting the _parentExtender to null if it is the TagExtender I avoid this recursion
