### PR TITLE
Update: Uno to 5.2.161

### DIFF
--- a/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
+++ b/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
@@ -1,14 +1,6 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>
-      net8.0;
-      net8.0-ios;
-      net8.0-maccatalyst;
-      net8.0-android;
-      net8.0-windows10.0.19041;
-      net8.0-browserwasm;
-      net8.0-desktop
-    </TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop</TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
+++ b/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
@@ -1,6 +1,14 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop</TargetFrameworks>
+    <TargetFrameworks>
+      net8.0;
+      net8.0-ios;
+      net8.0-maccatalyst;
+      net8.0-android;
+      net8.0-windows10.0.19041;
+      net8.0-browserwasm;
+      net8.0-desktop
+    </TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
@@ -20,7 +28,6 @@
     -->
     
     <UnoFeatures>
-      Skia;
     </UnoFeatures>
   </PropertyGroup>
 
@@ -46,9 +53,17 @@
 
   <!--Harfbuzz Sharp references Workaround for this issue-->
   <!--https://github.com/mono/SkiaSharp/issues/1725-->
-  <ItemGroup Condition="'$(TargetFramework)'=='net7.0' or '$(TargetFramework)'=='net8.0-browserwasm'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0-browserwasm'">
     <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
+  </ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'!='net8.0-windows10.0.19041'">
+    <PackageReference Include="SkiaSharp.Views.Uno.WinUI"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0-windows10.0.19041'">
+    <PackageReference Include="SkiaSharp.Views.WinUI"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.Uno.WinUI/Directory.Build.props
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Directory.Build.props
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <UnoExtensionsVersion>4.1.14</UnoExtensionsVersion>
+    <UnoExtensionsVersion>4.1.23</UnoExtensionsVersion>
     <UnoToolkitVersion>6.0.18</UnoToolkitVersion>
     <UnoThemesVersion>5.0.13</UnoThemesVersion>
-    <UnoCSharpMarkupVersion>5.2.13</UnoCSharpMarkupVersion>
+    <UnoCSharpMarkupVersion>5.2.14</UnoCSharpMarkupVersion>
   </PropertyGroup>
 </Project>

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <TargetFrameworks>
-      net8.0-android;
-      net8.0-browserwasm;
+			net8.0-android;
       net8.0-ios;
       net8.0-maccatalyst;
       net8.0-windows10.0.19041;
       net8.0-desktop;
-    </TargetFrameworks>
+      net8.0-browserwasm;
+		</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>
@@ -36,7 +36,6 @@
       https://aka.platform.uno/singleproject-features
     -->
     <UnoFeatures>
-      Skia;
     </UnoFeatures>
   </PropertyGroup>
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {
-    "Uno.Sdk": "5.2.121"
+    "Uno.Sdk": "5.2.161"
   }
 }


### PR DESCRIPTION
Things done:
1. Update Uno to 5.2.161
2. Handle Skia explictlity instead of using UnoFeature. 
    This is needed to be able to select a different SkiaSharp Version. (For example Version 3.0)
3. I'm doing this to reduce the changes in https://github.com/Mapsui/Mapsui/pull/2603