### PR TITLE
Cleanup: Remove .net7 Because it is End Of Life

### DIFF
--- a/Mapsui.Tiling/Mapsui.Tiling.csproj
+++ b/Mapsui.Tiling/Mapsui.Tiling.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Description>Mapsui - Library for mapping</Description>
     <PackageTags>$(PackageTags) brutile tiling</PackageTags>
 		<IsPackable>true</IsPackable>

--- a/Mapsui.UI.Android/Mapsui.UI.Android.csproj
+++ b/Mapsui.UI.Android/Mapsui.UI.Android.csproj
@@ -4,7 +4,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworks>net7.0-android33.0;net8.0-android34.0</TargetFrameworks>    
+    <TargetFrameworks>net8.0-android34.0</TargetFrameworks>    
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>Mapsui.Android</PackageId>

--- a/Mapsui.UI.Avalonia/Mapsui.UI.Avalonia.csproj
+++ b/Mapsui.UI.Avalonia/Mapsui.UI.Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <PackageId>Mapsui.Avalonia</PackageId>
     <Description>Avalonia map components based on the Mapsui library</Description>
     <PackageTags>$(PackageTags) avalonia</PackageTags>

--- a/Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj
+++ b/Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
 	  <ImplicitUsings>enable</ImplicitUsings>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <DefineConstants>__BLAZOR__</DefineConstants>

--- a/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
+++ b/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <DefineConstants>__MAUI__</DefineConstants>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <RootNamespace>Mapsui.UI.WinUI</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>

--- a/Mapsui.UI.iOS/Mapsui.UI.iOS.csproj
+++ b/Mapsui.UI.iOS/Mapsui.UI.iOS.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <TargetFrameworks>net7.0-ios16.0;net8.0-ios</TargetFrameworks>
+    <TargetFrameworks>net8.0-ios</TargetFrameworks>
     <ImplicitUsings>true</ImplicitUsings>
     <PackageId>Mapsui.iOS</PackageId>
     <!--<RuntimeIdentifiers>iossimulator-x64</RuntimeIdentifiers>-->

--- a/Mapsui/Mapsui.csproj
+++ b/Mapsui/Mapsui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Description>Mapsui - Library for mapping</Description>
 		<IsPackable>true</IsPackable>


### PR DESCRIPTION
I saw that there are still some .net 7 Targets. I remove them here because .net 7 is end of life since quite some time.
