### PR TITLE
[4.1] Fix enabling widgets after app start

### DIFF
--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -709,18 +709,6 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         return _extendedWidgets.Where(w => w.Enabled).ToList();
     }
 
-    /// <summary>
-    /// Gets the enabled and disabled widgets of the map and layers. We need the disable ones because the result
-    /// is cached.
-    /// </summary>
-    private List<IWidget> GetWidgetsOfMapAndLayers()
-    {
-        var list = new List<IWidget>();
-        list.AddRange(Map.Widgets);
-        list.AddRange(Map.Layers.Select(l => l.Attribution).Where(a => a != null));
-        return list;
-    }
-
     private void AssureWidgets()
     {
         if (_widgetCollection != Map.Widgets)
@@ -749,5 +737,17 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         }
 
         return _touchableWidgets.Where(w => w.Enabled).ToList();
+    }
+
+    /// <summary>
+    /// Gets the enabled and disabled widgets of the map and layers. The result is cached so we need disabled
+    /// ones as well because they could be enabled later.
+    /// </summary>
+    private List<IWidget> GetWidgetsOfMapAndLayers()
+    {
+        var list = new List<IWidget>();
+        list.AddRange(Map.Widgets);
+        list.AddRange(Map.Layers.Select(l => l.Attribution).Where(a => a != null));
+        return list;
     }
 }

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -739,7 +739,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         {
             _updateTouchableWidget = Map.Widgets.Count;
             _touchableWidgets = new List<IWidget>();
-            var touchableWidgets = Map.GetWidgetsOfMapAndLayers().ToList();
+            var touchableWidgets = GetWidgetsOfMapAndLayers();
             foreach (var widget in touchableWidgets)
             {
                 if (widget is IWidgetTouchable { Touchable: false }) continue;
@@ -748,6 +748,6 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             }
         }
 
-        return _touchableWidgets;
+        return _touchableWidgets.Where(w => w.Enabled).ToList();
     }
 }

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -696,7 +696,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         {
             _updateWidget = Map.Widgets.Count;
             _extendedWidgets = new List<IWidgetExtended>();
-            var widgetsOfMapAndLayers = Map.GetWidgetsOfMapAndLayers().ToList();
+            var widgetsOfMapAndLayers = GetWidgetsOfMapAndLayers();
             foreach (var widget in widgetsOfMapAndLayers)
             {
                 if (widget is IWidgetExtended extendedWidget)
@@ -706,7 +706,19 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             }
         }
 
-        return _extendedWidgets;
+        return _extendedWidgets.Where(w => w.Enabled).ToList();
+    }
+
+    /// <summary>
+    /// Gets the enabled and disabled widgets of the map and layers. We need the disable ones because the result
+    /// is cached.
+    /// </summary>
+    private List<IWidget> GetWidgetsOfMapAndLayers()
+    {
+        var list = new List<IWidget>();
+        list.AddRange(Map.Widgets);
+        list.AddRange(Map.Layers.Select(l => l.Attribution).Where(a => a != null));
+        return list;
     }
 
     private void AssureWidgets()


### PR DESCRIPTION
The extended widgets are cached. However, only the enabled widgets are cached. If later an extended widget is enabled this will not be in the cached list and its events will never be triggered.