### PR TITLE
Update: Uno to 5.2.175

### DIFF
--- a/Samples/Mapsui.Samples.Uno.WinUI/Directory.Build.props
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Directory.Build.props
@@ -1,22 +1,22 @@
 <Project>
-  <PropertyGroup>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	<PropertyGroup>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
-    <!--
+		<!--
       Adding NoWarn to remove build warnings
       NU1507: Warning when there are multiple package sources when using CPM with no source mapping
       NETSDK1201: Warning that specifying RID won't create self containing app
       PRI257: Ignore default language (en) not being one of the included resources (eg en-us, en-uk)
     -->
-    <NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
-  </PropertyGroup>
+		<NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <UnoExtensionsVersion>4.1.23</UnoExtensionsVersion>
-    <UnoToolkitVersion>6.0.18</UnoToolkitVersion>
-    <UnoThemesVersion>5.0.13</UnoThemesVersion>
-    <UnoCSharpMarkupVersion>5.2.14</UnoCSharpMarkupVersion>
-  </PropertyGroup>
+	<PropertyGroup>
+		<UnoExtensionsVersion>4.1.24</UnoExtensionsVersion>
+		<UnoToolkitVersion>6.0.24</UnoToolkitVersion>
+		<UnoThemesVersion>5.0.13</UnoThemesVersion>
+		<UnoCSharpMarkupVersion>5.2.14</UnoCSharpMarkupVersion>
+	</PropertyGroup>
 </Project>

--- a/Samples/Mapsui.Samples.Uno.WinUI/Directory.Build.props
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Directory.Build.props
@@ -1,22 +1,22 @@
 <Project>
-	<PropertyGroup>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
-		<!--
+    <!--
       Adding NoWarn to remove build warnings
       NU1507: Warning when there are multiple package sources when using CPM with no source mapping
       NETSDK1201: Warning that specifying RID won't create self containing app
       PRI257: Ignore default language (en) not being one of the included resources (eg en-us, en-uk)
     -->
-		<NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
-	</PropertyGroup>
+    <NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
+  </PropertyGroup>
 
-	<PropertyGroup>
-		<UnoExtensionsVersion>4.1.24</UnoExtensionsVersion>
-		<UnoToolkitVersion>6.0.24</UnoToolkitVersion>
-		<UnoThemesVersion>5.0.13</UnoThemesVersion>
-		<UnoCSharpMarkupVersion>5.2.14</UnoCSharpMarkupVersion>
-	</PropertyGroup>
+  <PropertyGroup>
+    <UnoExtensionsVersion>4.1.24</UnoExtensionsVersion>
+    <UnoToolkitVersion>6.0.24</UnoToolkitVersion>
+    <UnoThemesVersion>5.0.13</UnoThemesVersion>
+    <UnoCSharpMarkupVersion>5.2.14</UnoCSharpMarkupVersion>
+  </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {
-    "Uno.Sdk": "5.2.161"
+    "Uno.Sdk": "5.2.175"
   }
 }


### PR DESCRIPTION
1) Update Uno to 5.2.175 (Uno.Check suggestet that 5.2.175 is the recommanded uno.sdk version)
2) reduces diffs to https://github.com/Mapsui/Mapsui/pull/2603/ (SkiaSharp 3.0) Update