### PR TITLE
Update: Use Release Version of Microsoft.Windows.CsWin32

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,7 +57,7 @@
     <PackageVersion Include="Microsoft.UI.Xaml" Version="[2.6.2,3.0.0)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="[17.6.40,18.0.0)" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="[1.5.240311000,2.0.0)" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="[0.1.588-beta,1.0.0)" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="[0.3.106,1.0.0)" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="[2.0.0,3.0.0)" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26031-preview" />
     <PackageVersion Include="NetTopologySuite" Version="[2.5.0,3.0.0)" />


### PR DESCRIPTION
Microsoft.Windows.CsWin32 has now a non beta version use this now (is only used in the samples)
