### PR TITLE
Cleanup: Some more .net7.0 Target removals (net7 is end of life)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <!--Disable Run Api Compat Task causes Build failure on github actions with visual studio 2022 17.5 and .net Compilers Toolset 4.6-->
     <RunApiCompat>false</RunApiCompat>
 	<Nullable>enable</Nullable>
-    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
   </PropertyGroup>

--- a/Mapsui.ArcGIS/Mapsui.ArcGIS.csproj
+++ b/Mapsui.ArcGIS/Mapsui.ArcGIS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Description>
       Mapsui components to access an ArcGIS dynamic layer and image layer.
     </Description>

--- a/Mapsui.Extensions/Mapsui.Extensions.csproj
+++ b/Mapsui.Extensions/Mapsui.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <description>Mapsui - Library for mapping Extensions</description>
     <PackageTags>$(PackageTags) arcgis geotiff cache projection</PackageTags>
 		<IsPackable>true</IsPackable>

--- a/Mapsui.Nts/Mapsui.Nts.csproj
+++ b/Mapsui.Nts/Mapsui.Nts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 		<Description>Mapsui - Library for mapping</Description>
 		<PackageTags>$(PackageTags) nts</PackageTags>
 		<IsPackable>true</IsPackable>

--- a/Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj
+++ b/Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Description>Mapsui - Library for mapping</Description>
     <PackageTags>$(PackageTags) rendering skia</PackageTags>
 		<IsPackable>true</IsPackable>

--- a/Mapsui.UI.Blazor/Mapsui.Blazor.targets
+++ b/Mapsui.UI.Blazor/Mapsui.Blazor.targets
@@ -1,9 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup Condition="'$(TargetFramework)'=='net7.0'">
-        <WasmExtraFilesToDeploy Include="$(MSBuildThisFileDirectory)/wwwroot/**/*.*" />
-        <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.7\libHarfBuzzSharp.a" />
-        <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.7\libSkiaSharp.a" />
-    </ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
 		<WasmExtraFilesToDeploy Include="$(MSBuildThisFileDirectory)/wwwroot/**/*.*" />
 		<NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.34\simd,mt\libHarfBuzzSharp.a" />


### PR DESCRIPTION
 Some more .net7.0 Target removals (net7 is end of life) I missed in this pull request.
https://github.com/Mapsui/Mapsui/pull/2689
