### PR TITLE
Update: Avalonia to 11.1.0 (SkiaSharp 3 Compatible)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,16 +6,16 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="[11.0.10,12.0.0)" />
-    <PackageVersion Include="Avalonia.Skia" Version="[11.0.10,12.0.0)" />
-    <PackageVersion Include="Avalonia.Desktop" Version="[11.0.10,12.0.0)" />
-    <PackageVersion Include="Avalonia.Browser" Version="[11.0.10,12.0.0)" />
-    <PackageVersion Include="Avalonia.Android" Version="[11.0.10,12.0.0)" />
-    <PackageVersion Include="Avalonia.iOS" Version="[11.0.10,12.0.0)" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="[11.0.10,12.0.0)" />
-    <PackageVersion Include="Avalonia.ReactiveUI" Version="[11.0.10,12.0.0)" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="[11.0.10,12.0.0)" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="[11.0.10,12.0.0)" />
+    <PackageVersion Include="Avalonia" Version="[11.1.0,12.0.0)" />
+    <PackageVersion Include="Avalonia.Skia" Version="[11.1.0,12.0.0)" />
+    <PackageVersion Include="Avalonia.Desktop" Version="[11.1.0,12.0.0)" />
+    <PackageVersion Include="Avalonia.Browser" Version="[11.1.0,12.0.0)" />
+    <PackageVersion Include="Avalonia.Android" Version="[11.1.0,12.0.0)" />
+    <PackageVersion Include="Avalonia.iOS" Version="[11.1.0,12.0.0)" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="[11.1.0,12.0.0)" />
+    <PackageVersion Include="Avalonia.ReactiveUI" Version="[11.1.0,12.0.0)" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="[11.1.0,12.0.0)" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="[11.1.0,12.0.0)" />
     <PackageVersion Include="BenchmarkDotNet" Version="[0.13.9,1.0.0)" />
     <PackageVersion Include="BitMiracle.LibTiff.NET" Version="[2.4.649,3.0.0)" />
     <PackageVersion Include="BruTile" Version="[6.0.0-beta.3,7.0)" />

--- a/Samples/Avalonia/Directory.Build.props
+++ b/Samples/Avalonia/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <AvaloniaVersion>11.0.0</AvaloniaVersion>
+    <AvaloniaVersion>11.1.0</AvaloniaVersion>
 	<IsPackable>false</IsPackable> <!--Default to not packable and override in projects that do need to be packed.-->
 	<Nullable>enable</Nullable> <!--This is in the root Directory.Build.props but apparently needs repeating. Probably a bug in the tooling. -->
   </PropertyGroup>

--- a/Samples/Avalonia/Mapsui.Samples.Avalonia.Browser/Program.cs
+++ b/Samples/Avalonia/Mapsui.Samples.Avalonia.Browser/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Avalonia;
-using Avalonia.Browser;
 using Avalonia.ReactiveUI;
 using Mapsui.Samples.Avalonia;
 
@@ -9,10 +8,9 @@ using Mapsui.Samples.Avalonia;
 
 internal partial class Program
 {
-    private static async Task Main(string[] args) => await BuildAvaloniaApp()
-            .WithInterFont()
-            .UseReactiveUI()
-            .StartBrowserAppAsync("out");
+    private static async Task Main(string[] args) => BuildAvaloniaApp()
+        .WithInterFont()
+        .UseReactiveUI();
 
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>();


### PR DESCRIPTION
Updates Avalonia to a Version that works with SkiaSharp 3
