### PR TITLE
Update: Svg.Skia to 2.0 (SkiaSharp 3 Compatible)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -80,7 +80,7 @@
     <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="[2.88.8,3.0.0)" />
     <PackageVersion Include="sqlite-net-pcl" Version="[1.9.172,2.0.0)" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="[2.1.6,3.0.0)" />
-    <PackageVersion Include="Svg.Skia" Version="1.0.0.17" />
+    <PackageVersion Include="Svg.Skia" Version="2.0.0" />
     <PackageVersion Include="Topten.RichTextKit" Version="0.4.167" />
     <PackageVersion Include="System.Text.Json" Version="[8.0.4,9.0.0)" />
   </ItemGroup>


### PR DESCRIPTION
Updates Skia.Svg to a Version that Works with SkiaSharp
