### PR TITLE
Update: Uno to 5.3.31 (SkiaSharp 3 Compatible)

### DIFF
--- a/Samples/Mapsui.Samples.Uno.WinUI/Directory.Build.props
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Directory.Build.props
@@ -12,11 +12,4 @@
     -->
     <NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <UnoExtensionsVersion>4.1.24</UnoExtensionsVersion>
-    <UnoToolkitVersion>6.0.24</UnoToolkitVersion>
-    <UnoThemesVersion>5.0.13</UnoThemesVersion>
-    <UnoCSharpMarkupVersion>5.2.14</UnoCSharpMarkupVersion>
-  </PropertyGroup>
 </Project>

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/App.xaml.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/App.xaml.cs
@@ -1,5 +1,3 @@
-using System;
-using Microsoft.Extensions.Logging;
 using Uno.Resizetizer;
 
 namespace Mapsui.Samples.Uno.WinUI;

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/GlobalUsings.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/GlobalUsings.cs
@@ -1,4 +1,1 @@
-﻿global using System.Collections.Immutable;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using ApplicationExecutionState = Windows.ApplicationModel.Activation.ApplicationExecutionState;
+﻿global using Microsoft.Extensions.Logging;

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -1,13 +1,6 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>
-			net8.0-android;
-      net8.0-ios;
-      net8.0-maccatalyst;
-      net8.0-windows10.0.19041;
-      net8.0-desktop;
-      net8.0-browserwasm;
-		</TargetFrameworks>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Android/Main.Android.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Android/Main.Android.cs
@@ -1,15 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Android.App;
-using Android.Content;
-using Android.OS;
 using Android.Runtime;
-using Android.Views;
-using Android.Widget;
 using Com.Nostra13.Universalimageloader.Core;
-using Microsoft.UI.Xaml.Media;
 
 namespace Mapsui.Samples.Uno.WinUI.Droid;
 

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Android/MainActivity.Android.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Android/MainActivity.Android.cs
@@ -1,8 +1,5 @@
 using Android.App;
-using Android.Content.PM;
-using Android.OS;
 using Android.Views;
-using Android.Widget;
 
 namespace Mapsui.Samples.Uno.WinUI.Droid;
 

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {
-    "Uno.Sdk": "5.2.175"
+    "Uno.Sdk": "5.3.31"
   }
 }


### PR DESCRIPTION
Updates to Uno 5.3.31 (which is SkiaSharp 3 Compatible)
