### PR TITLE
Dependencies: Remove upper Bounds from SkiaSharp

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,8 +32,8 @@
     <PackageVersion Include="Eto.Platform.XamMac2" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.Platform.Gtk" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.SkiaDraw" Version="[0.2.0,0.3.0)" />
-    <PackageVersion Include="HarfBuzzSharp" Version="[7.3.0.2,8.0.0.0)" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="[7.3.0.2,8.0.0.0)" />
+    <PackageVersion Include="HarfBuzzSharp" Version="7.3.0.2" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="7.3.0.2" />
     <PackageVersion Include="IDisposableAnalyzers" Version="[4.0.8,5.0.0)" />
     <PackageVersion Include="Mapsui.Android" Version="5.0.0-beta.1" />
     <PackageVersion Include="Mapsui.ArcGIS" Version="5.0.0-beta.1" />
@@ -64,20 +64,20 @@
     <PackageVersion Include="NetTopologySuite.IO.GeoJSON4STJ" Version="[4.0.0,5.0.0)" />
     <PackageVersion Include="NUnit" Version="[4.0.1,5.0.0)" />
     <PackageVersion Include="NUnit3TestAdapter" Version="[4.5.0,5.0.0)" />
-    <PackageVersion Include="SkiaSharp" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Skottie" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Views" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Views.Uno" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Views.WinUI" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Views.WPF" Version="[2.88.8,3.0.0)" />
-    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="[2.88.8,3.0.0)" />
+    <PackageVersion Include="SkiaSharp" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.Views" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.Views.Uno" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.Views.WinUI" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.Views.WPF" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="2.88.8" />
     <PackageVersion Include="sqlite-net-pcl" Version="[1.9.172,2.0.0)" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="[2.1.6,3.0.0)" />
     <PackageVersion Include="Svg.Skia" Version="1.0.0.17" />


### PR DESCRIPTION
Remove upper Bounds from SkiaSharp to make it easy upgradable to SkiaSharp 3.
Depends on this pull requests.
https://github.com/Mapsui/Mapsui/pull/2722
https://github.com/Mapsui/Mapsui/pull/2721
https://github.com/Mapsui/Mapsui/pull/2720