### PR TITLE
[4.1] MapControl: Reset widget cache

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
          dotnet-version: |
-           8.0.x
+           8.0.3xx
          include-prerelease: false
     # Android SDK Install
     - name: Set up Android SDK
@@ -92,7 +92,7 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
          dotnet-version: |
-           8.0.x
+           8.0.3xx
          include-prerelease: false
     - name: Setup Xcode version 14.2
       uses: maxim-lobanov/setup-xcode@v1.5.1
@@ -158,7 +158,7 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
          dotnet-version: |
-           8.0.x
+           8.0.3xx
          include-prerelease: false
     - name: install maui macos android ios maccatalyst wasm-tools
       run: dotnet workload install maui macos android ios maccatalyst wasm-tools
@@ -235,7 +235,7 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
          dotnet-version: |
-           8.0.x
+           8.0.3xx
          include-prerelease: false
     - name: Set up JDK 11
       uses: actions/setup-java@v4

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -709,14 +709,22 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         return _extendedWidgets.Where(w => w.Enabled).ToList();
     }
 
+    /// <summary>
+    /// Reset the widget cache. It may be necessary to call this explicitly after the widgets have changed.
+    /// </summary>
+    protected void ResetWidgetCache()
+    {
+        // reset widgets
+        _extendedWidgets = null;
+        _touchableWidgets = null;
+        _widgetCollection = Map.Widgets;
+    }
+
     private void AssureWidgets()
     {
         if (_widgetCollection != Map.Widgets)
         {
-            // reset widgets
-            _extendedWidgets = null;
-            _touchableWidgets = null;
-            _widgetCollection = Map.Widgets;
+            ResetWidgetCache();
         }
     }
 

--- a/global.json
+++ b/global.json
@@ -2,11 +2,11 @@
   "sdk": {
     "allowPrerelease": false,
     "version": "8.0.300",
-    "rollForward": "latestMajor"
+    "rollForward": "latestPatch"
   },
   "tools": {
     "allowPrerelease": false,
     "dotnet": "8.0.300",
-    "rollForward": "latestMajor"
-  }  
+    "rollForward": "latestPatch"
+  }
 }


### PR DESCRIPTION
This is my attempt to fix #2599. I'm adding a method that triggers the re-caching of widgets in `MapControl`. The method is protected, so that it can be called in all classes derived from MapControl (including MapView etc). This should be enough to fix the problem (for me).