### PR TITLE
Update Uno Sdk 5.3.108 (Recommanded Version)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="BitMiracle.LibTiff.NET" Version="[2.4.649,3.0.0)" />
     <PackageVersion Include="BruTile" Version="[6.0.0-beta.3,7.0)" />
     <PackageVersion Include="BruTile.MbTiles" Version="[6.0.0-beta.3,7.0)" />
-    <PackageVersion Include="coverlet.collector" Version="[3.0.2,4.0.0)" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="DotSpatial.Projections" Version="[4.0.656,5.0.0)" />
     <PackageVersion Include="CommunityToolkit.Maui.Markup" Version="[1.0.0,2.0.0)" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="[7.1.2,8.0.0)" />
@@ -50,20 +50,20 @@
     <PackageVersion Include="Mapsui.Uno.WinUI" Version="5.0.0-beta.1" />
     <PackageVersion Include="Mapsui.WinUI" Version="5.0.0-beta.1" />
     <PackageVersion Include="Mapsui.Wpf" Version="5.0.0-beta.1" />
-    <PackageVersion Include="Microsoft.CodeCoverage" Version="[17.8.0,18.0.0)" />
+    <PackageVersion Include="Microsoft.CodeCoverage" Version="17.11.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[8.0.0,9.0.0)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.8.0, 18.0.0)" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="[6.2.14,7.0.0)" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="[2.6.2,3.0.0)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="[17.10.48,18.0.0)" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="[1.5.240607001,2.0.0)" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.5.240627000" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="[0.3.106,1.0.0)" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="[2.0.0,3.0.0)" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26031-preview" />
     <PackageVersion Include="NetTopologySuite" Version="[2.5.0,3.0.0)" />
     <PackageVersion Include="NetTopologySuite.IO.GeoJSON4STJ" Version="[4.0.0,5.0.0)" />
-    <PackageVersion Include="NUnit" Version="[4.0.1,5.0.0)" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="[4.5.0,5.0.0)" />
+    <PackageVersion Include="NUnit" Version="4.2.2" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="SkiaSharp" Version="2.88.8" />
     <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.8" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.8" />

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {
-    "Uno.Sdk": "5.3.96"
+    "Uno.Sdk": "5.3.108"
   }
 }


### PR DESCRIPTION
Updates the Uno.Sdk Version to the Recommanded Version 5.3.108
