### PR TITLE
Multi targeting improvements (Removed Version Numbers when they are not necessary)

### DIFF
--- a/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
+++ b/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
@@ -35,9 +35,9 @@
     <PackageReference Include="SkiaSharp.Views.Maui.Controls" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
-    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="[$(MauiVersion),9.0.0)" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="[$(MauiVersion),9.0.0)" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="$(MauiVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
+++ b/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
@@ -45,16 +45,16 @@
 
   <!--Harfbuzz Sharp references Workaround for this issue-->
   <!--https://github.com/mono/SkiaSharp/issues/1725-->
-  <ItemGroup Condition="'$(TargetFramework)'=='net8.0-browserwasm'">
+  <ItemGroup Condition="$(TargetFramework.Contains('browserwasm'))">
     <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
   </ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'!='net8.0-windows10.0.19041'">
+  <ItemGroup Condition="!$(TargetFramework.Contains('windows'))">
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net8.0-windows10.0.19041'">
+  <ItemGroup Condition="$(TargetFramework.Contains('windows'))">
     <PackageReference Include="SkiaSharp.Views.WinUI"/>
   </ItemGroup>
 


### PR DESCRIPTION
Improvements in Maui and Uno for easier adding a new .NET 8 Target.
Taken from here.
https://github.com/Mapsui/Mapsui/pull/2744/files
