### PR TITLE
Windows app sdk cleanup.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,8 @@
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+    <!-- Windows App Sdk 1.6 Workaround-->
+    <WindowsSdkPackageVersion>10.0.19041.41</WindowsSdkPackageVersion>
   </PropertyGroup>
 
 	<!--Package Icon Include -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,8 +21,6 @@
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
-    <!-- Windows App Sdk 1.6 Workaround-->
-    <WindowsSdkPackageVersion>10.0.19041.41</WindowsSdkPackageVersion>
   </PropertyGroup>
 
 	<!--Package Icon Include -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,10 +55,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="[6.2.14,7.0.0)" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="[2.6.2,3.0.0)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="[17.10.48,18.0.0)" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.106" />
-    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.1.3" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26031-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="[17.10.48,18.0.0)" />       
     <PackageVersion Include="NetTopologySuite" Version="[2.5.0,3.0.0)" />
     <PackageVersion Include="NetTopologySuite.IO.GeoJSON4STJ" Version="[4.0.0,5.0.0)" />
     <PackageVersion Include="NUnit" Version="4.2.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,16 +51,14 @@
     <PackageVersion Include="Mapsui.WinUI" Version="5.0.0-beta.1" />
     <PackageVersion Include="Mapsui.Wpf" Version="5.0.0-beta.1" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.11.1" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.106" />
-    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.1.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[8.0.0,9.0.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="[6.2.14,7.0.0)" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="[2.6.2,3.0.0)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="[17.10.48,18.0.0)" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="[0.3.106,1.0.0)" />
-    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="[2.0.0,3.0.0)" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.106" />
+    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.1.3" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26031-preview" />
     <PackageVersion Include="NetTopologySuite" Version="[2.5.0,3.0.0)" />
     <PackageVersion Include="NetTopologySuite.IO.GeoJSON4STJ" Version="[4.0.0,5.0.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,7 +56,6 @@
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="[6.2.14,7.0.0)" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="[2.6.2,3.0.0)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="[17.10.48,18.0.0)" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.106" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.1.3" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26031-preview" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,6 +51,7 @@
     <PackageVersion Include="Mapsui.WinUI" Version="5.0.0-beta.1" />
     <PackageVersion Include="Mapsui.Wpf" Version="5.0.0-beta.1" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="[17.8.0,18.0.0)" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.106" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[8.0.0,9.0.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.8.0, 18.0.0)" />
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="[6.2.14,7.0.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,9 +56,7 @@
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="[6.2.14,7.0.0)" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="[2.6.2,3.0.0)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="[17.10.48,18.0.0)" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="[1.5.240607001,2.0.0)" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="[0.3.106,1.0.0)" />
-    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="[2.0.0,3.0.0)" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26031-preview" />
     <PackageVersion Include="NetTopologySuite" Version="[2.5.0,3.0.0)" />
     <PackageVersion Include="NetTopologySuite.IO.GeoJSON4STJ" Version="[4.0.0,5.0.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,6 +52,7 @@
     <PackageVersion Include="Mapsui.Wpf" Version="5.0.0-beta.1" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="[17.8.0,18.0.0)" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.106" />
+    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.1.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[8.0.0,9.0.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.8.0, 18.0.0)" />
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="[6.2.14,7.0.0)" />

--- a/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
+++ b/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
@@ -18,7 +18,6 @@
       UnoFeatures let's you quickly add and manage implicit package references based on the features you want to use.
       https://aka.platform.uno/singleproject-features
     -->
-    
     <UnoFeatures>
     </UnoFeatures>
   </PropertyGroup>
@@ -36,11 +35,6 @@
     -->
     <!-- <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" /> -->
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.Contains('windows'))">
-    <PackageReference Include="Microsoft.WindowsAppSDK" />
-    <!--<PackageReference Include="SkiaSharp.Views.WinUI" />-->
   </ItemGroup>
 
   <!--Harfbuzz Sharp references Workaround for this issue-->

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFrameworks>net6.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <RootNamespace>Mapsui.UI.WinUI</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -14,7 +14,7 @@
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
-		<UseRidGraph>true</UseRidGraph>    
+		<UseRidGraph>true</UseRidGraph>
   </PropertyGroup>	
 
   <ItemGroup>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -14,8 +14,7 @@
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
-		<UseRidGraph>true</UseRidGraph>
-    <WindowsSdkPackageVersion>10.0.19041.41</WindowsSdkPackageVersion>
+		<UseRidGraph>true</UseRidGraph>    
   </PropertyGroup>	
 
   <ItemGroup>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>	
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" VersionOverride="1.6.240829007" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" VersionOverride="1.5.240627000" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
   </ItemGroup>
 

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -15,10 +15,11 @@
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
 		<UseRidGraph>true</UseRidGraph>
+    <WindowsSdkPackageVersion>10.0.19041.41</WindowsSdkPackageVersion>
   </PropertyGroup>	
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" VersionOverride="1.6.240829007" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
   </ItemGroup>
 

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <RootNamespace>Mapsui.UI.WinUI</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
@@ -12,7 +12,6 @@
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
 		<RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
 		<UseRidGraph>true</UseRidGraph>
-    <WindowsSdkPackageVersion>10.0.19041.41</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
@@ -18,10 +18,6 @@
   <ItemGroup>
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" >
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
@@ -18,6 +18,10 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" >
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
@@ -12,10 +12,10 @@
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
 		<RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
 		<UseRidGraph>true</UseRidGraph>
+    <WindowsSdkPackageVersion>10.0.19041.41</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
     <PackageReference Include="Microsoft.Windows.CsWin32" >


### PR DESCRIPTION
Things done:
1) Removed unused nuget packages.
2) Only set the WindowsAppSdk Version on Mapsui.WinUI project. 
3) When this is merged only the Version Number of WindowsAppSdk needs to change and a SkiaSharp Updated is needed.

https://github.com/Mapsui/Mapsui/pull/2747
