### PR TITLE
Add groups to the LayerCollection

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -12,17 +12,19 @@
         "--include",
         "${staged}"
       ]
-    },
-    {
-      "name": "re-add-the-staged-files-after-formatting",
-      "group": "pre-commit",
-      "output": "always",
-      "command": "bash",
-      "args": [ "git", "add", "${staged}" ],
-      "windows": {
-        "command": "cmd",
-        "args": [ "git", "add", "${staged}" ]
-      }
     }
+    // This adds the changed files back to the staging after formatting, but it sometimes fails
+    //,
+    //{
+    //  "name": "re-add-the-staged-files-after-formatting",
+    //  "group": "pre-commit",
+    //  "output": "always",
+    //  "command": "bash",
+    //  "args": [ "git", "add", "${staged}" ],
+    //  "windows": {
+    //    "command": "cmd",
+    //    "args": [ "git", "add", "${staged}" ]
+    //  }
+    //}
   ]
 }

--- a/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToBitmapPerformance.cs
+++ b/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToBitmapPerformance.cs
@@ -99,7 +99,7 @@ public class RenderToBitmapPerformance
 
         map.Layers.Add(layer);
 
-        var extent = map.Layers[0].Extent!;
+        var extent = map.Layers.Get(0).Extent!;
         map.Navigator.ZoomToBox(extent);
 
         return map;

--- a/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToCpuPerformance.cs
+++ b/Benchmarks/Mapsui.Rendering.Benchmarks/RenderToCpuPerformance.cs
@@ -121,7 +121,7 @@ public class RenderToCpuPerformance : IDisposable
 
         map.Layers.Add(layer);
 
-        var extent = map.Layers[0].Extent!;
+        var extent = map.Layers.Get(0).Extent!;
         map.Navigator.ZoomToBox(extent);
 
         return map;

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -700,7 +700,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     private void AddLayers()
     {
         // Add MapView layers
-        Map?.Layers.Add(_mapDrawableLayer, _mapPinLayer, _mapCalloutLayer, MyLocationLayer);
+        Map?.Layers.Add([_mapDrawableLayer, _mapPinLayer, _mapCalloutLayer, MyLocationLayer]);
     }
 
     /// <summary>
@@ -709,7 +709,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     private void RemoveLayers()
     {
         // Remove MapView layers
-        Map?.Layers.Remove(MyLocationLayer, _mapCalloutLayer, _mapPinLayer, _mapDrawableLayer);
+        Map?.Layers.Remove([MyLocationLayer, _mapCalloutLayer, _mapPinLayer, _mapDrawableLayer]);
     }
 
     private void UpdateButtonPositions()

--- a/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
+++ b/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
@@ -20,7 +20,7 @@
     -->
     <UnoFeatures>
     </UnoFeatures>
-  </PropertyGroup>
+	</PropertyGroup>
 
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
     <!--

--- a/Mapsui.sln
+++ b/Mapsui.sln
@@ -196,7 +196,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapsui.Samples.WindowsForms
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapsui.UI.WindowsForms", "Mapsui.UI.WindowsForms\Mapsui.UI.WindowsForms.csproj", "{563CAE64-573F-4D0F-9DFF-D037E2FE114F}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".husky", ".husky", "{1192D94C-B051-403B-91BE-D0C218238175}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "husky", "husky", "{1192D94C-B051-403B-91BE-D0C218238175}"
 	ProjectSection(SolutionItems) = preProject
 		.husky\pre-commit = .husky\pre-commit
 		.husky\task-runner.json = .husky\task-runner.json

--- a/Mapsui/Layers/LayerCollection.cs
+++ b/Mapsui/Layers/LayerCollection.cs
@@ -177,6 +177,24 @@ public class LayerCollection : IEnumerable<ILayer>
         OnChanged([], [], [layer]);
     }
 
+    public void MoveDown(ILayer layer)
+    {
+        var index = GetLayerIndex(layer);
+        if (index <= 0)
+            return;
+        MoveInternal(--index, layer);
+        OnChanged([], [], [layer]);
+    }
+
+    public void MoveUp(ILayer layer)
+    {
+        var index = GetLayerIndex(layer);
+        if (index >= _entries.Count - 1)
+            return;
+        MoveInternal(++index, layer);
+        OnChanged([], [], [layer]);
+    }
+
     /// <summary>
     /// Inserts a layer at a specific index in a group.
     /// </summary>
@@ -387,6 +405,9 @@ public class LayerCollection : IEnumerable<ILayer>
     {
         Changed?.Invoke(this, new LayerCollectionChangedEventArgs(added, removed, moved));
     }
+
+    private int GetLayerIndex(ILayer layer) =>
+        _entries.First(e => e.Layer == layer).Index;
 
     private class LayerEntry(ILayer layer, int index, int group = 0)
     {

--- a/Mapsui/Layers/LayerCollection.cs
+++ b/Mapsui/Layers/LayerCollection.cs
@@ -201,64 +201,6 @@ public class LayerCollection : IEnumerable<ILayer>
         OnChanged(layers, [], []);
     }
 
-    private void MoveInternal(int index, ILayer layer)
-    {
-        var entryToMove = _entries.First(e => e.Layer == layer);
-
-        entryToMove.Index = index;
-
-        var counter = 0;
-        foreach (var entry in GetEntriesOfGroup(entryToMove.Group))
-        {
-            if (entryToMove == entry) // Skip the entry we are moving
-                continue;
-
-            if (counter < index)
-                entry.Index = counter;
-            else
-                entry.Index = counter + 1;
-
-            counter++;
-        };
-    }
-
-    private LayerEntry[] GetEntriesOfGroup(int group)
-    {
-        return _entries.Where(e => e.Group == group).OrderBy(e => e.Index).ToArray();
-    }
-
-    private void InsertInternal(int index, IEnumerable<ILayer> layers, int group)
-    {
-        if (layers == null || layers.Count() == 0)
-            throw new ArgumentException("Layers cannot be null or empty");
-
-        foreach (var layer in layers)
-        {
-            InsertInternal(layer, index, group);
-            index++;
-        }
-    }
-
-    private void InsertInternal(ILayer layer, int index, int group)
-    {
-        var entryToInsert = new LayerEntry(layer, index, group);
-        var counter = 0;
-        foreach (var entry in GetEntriesOfGroup(entryToInsert.Group))
-        {
-            if (entry.Group != entryToInsert.Group) // Skip entries in other groups
-                continue;
-
-            if (counter < index)
-                entry.Index = counter;
-            else
-                entry.Index = counter + 1;
-
-            counter++;
-        };
-        _entries.Enqueue(entryToInsert);
-    }
-
-
     /// <summary>
     /// Removes multiple layers from the collection.
     /// </summary>
@@ -322,6 +264,63 @@ public class LayerCollection : IEnumerable<ILayer>
     public IEnumerable<ILayer> FindLayer(string layerName)
     {
         return _entries.Where(e => e.Layer.Name == layerName).Select(e => e.Layer).ToArray();
+    }
+
+    private void MoveInternal(int index, ILayer layer)
+    {
+        var entryToMove = _entries.First(e => e.Layer == layer);
+
+        entryToMove.Index = index;
+
+        var counter = 0;
+        foreach (var entry in GetEntriesOfGroup(entryToMove.Group))
+        {
+            if (entryToMove == entry) // Skip the entry we are moving
+                continue;
+
+            if (counter < index)
+                entry.Index = counter;
+            else
+                entry.Index = counter + 1;
+
+            counter++;
+        };
+    }
+
+    private LayerEntry[] GetEntriesOfGroup(int group)
+    {
+        return _entries.Where(e => e.Group == group).OrderBy(e => e.Index).ToArray();
+    }
+
+    private void InsertInternal(int index, IEnumerable<ILayer> layers, int group)
+    {
+        if (layers == null || layers.Count() == 0)
+            throw new ArgumentException("Layers cannot be null or empty");
+
+        foreach (var layer in layers)
+        {
+            InsertInternal(layer, index, group);
+            index++;
+        }
+    }
+
+    private void InsertInternal(ILayer layer, int index, int group)
+    {
+        var entryToInsert = new LayerEntry(layer, index, group);
+        var counter = 0;
+        foreach (var entry in GetEntriesOfGroup(entryToInsert.Group))
+        {
+            if (entry.Group != entryToInsert.Group) // Skip entries in other groups
+                continue;
+
+            if (counter < index)
+                entry.Index = counter;
+            else
+                entry.Index = counter + 1;
+
+            counter++;
+        };
+        _entries.Enqueue(entryToInsert);
     }
 
     private void AddInternal(IEnumerable<ILayer> layers, int group = 0)

--- a/Mapsui/Layers/LayerCollection.cs
+++ b/Mapsui/Layers/LayerCollection.cs
@@ -11,15 +11,7 @@ public class LayerCollection : IEnumerable<ILayer>
 {
     private ConcurrentQueue<LayerEntry> _entries = new();
 
-    public delegate void LayerRemovedEventHandler(ILayer layer);
-    public delegate void LayerAddedEventHandler(ILayer layer);
-    public delegate void LayerMovedEventHandler(ILayer layer);
-
     public delegate void LayerCollectionChangedEventHandler(object sender, LayerCollectionChangedEventArgs args);
-
-    public event LayerRemovedEventHandler? LayerRemoved;
-    public event LayerAddedEventHandler? LayerAdded;
-    public event LayerMovedEventHandler? LayerMoved;
 
     public event LayerCollectionChangedEventHandler? Changed;
 
@@ -67,7 +59,6 @@ public class LayerCollection : IEnumerable<ILayer>
                 asyncLayer.AbortFetch();
                 asyncLayer.ClearCache();
             }
-            OnLayerRemoved(entry.Layer);
         }
 
         _entries = entries;
@@ -134,7 +125,6 @@ public class LayerCollection : IEnumerable<ILayer>
             counter++;
         };
 
-        OnLayerMoved(layer);
         OnChanged([], [], [layer]);
     }
 
@@ -163,9 +153,6 @@ public class LayerCollection : IEnumerable<ILayer>
             InsertLayer(layer, index, group);
             index++;
         }
-
-        foreach (var layer in layers)
-            OnLayerAdded(layer);
 
         OnChanged(layers, [], []);
     }
@@ -252,7 +239,6 @@ public class LayerCollection : IEnumerable<ILayer>
         {
             var index = _entries.Count(e => e.Group == group);
             _entries.Enqueue(new LayerEntry(layer, index, group));
-            OnLayerAdded(layer);
         }
     }
 
@@ -285,25 +271,8 @@ public class LayerCollection : IEnumerable<ILayer>
         }
 
         _entries = new ConcurrentQueue<LayerEntry>(copy);
-        foreach (var layer in layers)
-            OnLayerRemoved(layer);
 
         return success;
-    }
-
-    private void OnLayerRemoved(ILayer layer)
-    {
-        LayerRemoved?.Invoke(layer);
-    }
-
-    private void OnLayerAdded(ILayer layer)
-    {
-        LayerAdded?.Invoke(layer);
-    }
-
-    private void OnLayerMoved(ILayer layer)
-    {
-        LayerMoved?.Invoke(layer);
     }
 
     private void OnChanged(IEnumerable<ILayer> added, IEnumerable<ILayer> removed, IEnumerable<ILayer> moved)

--- a/Mapsui/Layers/LayerCollection.cs
+++ b/Mapsui/Layers/LayerCollection.cs
@@ -9,7 +9,7 @@ namespace Mapsui.Layers;
 
 public class LayerCollection : IEnumerable<ILayer>
 {
-    private ConcurrentQueue<ILayer> _layers = new();
+    private ConcurrentQueue<LayerEntry> _entries = new();
 
     public delegate void LayerRemovedEventHandler(ILayer layer);
     public delegate void LayerAddedEventHandler(ILayer layer);
@@ -23,52 +23,64 @@ public class LayerCollection : IEnumerable<ILayer>
 
     public event LayerCollectionChangedEventHandler? Changed;
 
-    public int Count => _layers.Count;
+    public int Count => _entries.Count;
 
     public IEnumerator<ILayer> GetEnumerator()
     {
-        return _layers.GetEnumerator();
+        return (IEnumerator<ILayer>)_entries.OrderBy(l => l.Group).Select(l => l.Layer).ToList().GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return _layers.GetEnumerator();
+        return _entries.OrderBy(l => l.Group).Select(l => l.Layer).ToList().GetEnumerator();
+    }
+
+    public void ClearGroup(int group)
+    {
+        var copy = _entries.ToArray().ToList();
+
+        var entries = copy.Where(e => e.Group != group).Select(e => e.Layer).ToArray();
+
+        RemoveLayers(entries);
     }
 
     public void Clear()
     {
-        var copy = _layers.ToArray().ToList();
+        var copy = _entries.ToArray().ToList();
 
-        _layers = new ConcurrentQueue<ILayer>();
+        var entries = new ConcurrentQueue<LayerEntry>();
 
-        foreach (var layer in copy)
+        foreach (var entry in copy)
         {
-            if (layer is IAsyncDataFetcher asyncLayer)
+            if (entry is IAsyncDataFetcher asyncLayer)
             {
                 asyncLayer.AbortFetch();
                 asyncLayer.ClearCache();
             }
-            OnLayerRemoved(layer);
+            OnLayerRemoved(entry.Layer);
         }
+
+        _entries = entries;
     }
 
     public bool Contains(ILayer item)
     {
-        return _layers.Contains(item);
+        return _entries.Any(l => l.Layer == item);
     }
 
     public void CopyTo(ILayer[] array, int arrayIndex)
     {
-        var copy = _layers.ToArray().ToList();
+        var copy = _entries.ToArray().ToList();
 
         var maxCount = Math.Min(array.Length, copy.Count);
         var count = maxCount - arrayIndex;
-        copy.CopyTo(0, array, arrayIndex, count);
+        var entries = new ConcurrentQueue<LayerEntry>(array.Select(l => new LayerEntry(l))).ToArray();
+        copy.CopyTo(0, entries, arrayIndex, count);
 
-        _layers = new ConcurrentQueue<ILayer>(copy);
+        _entries = new ConcurrentQueue<LayerEntry>(copy);
     }
 
-    public ILayer this[int index] => _layers.ToArray()[index];
+    public ILayer this[int index] => _entries.ToArray()[index].Layer;
 
     public void Add(params ILayer[] layers)
     {
@@ -76,33 +88,85 @@ public class LayerCollection : IEnumerable<ILayer>
         OnChanged(layers, null);
     }
 
+    public void Add(ILayer[] layers, int group = 0)
+    {
+        AddLayers(layers, group);
+        OnChanged(layers, null);
+    }
+
+    public void Add(ILayer layer, int group = 0)
+    {
+        AddLayers([layer], group);
+        OnChanged([layer], null);
+    }
+
+    public void AddOnTop(ILayer layer, int group = 0)
+    {
+        Add(layer, group);
+    }
+
+    public void AddOnBottom(ILayer layer, int group = 0)
+    {
+        Insert(0, layer, group);
+    }
+
     public void Move(int index, ILayer layer)
     {
-        var copy = _layers.ToArray().ToList();
-        copy.Remove(layer);
+        MoveLayer(index, layer);
+    }
+
+    public void MoveToBottom(int index, ILayer layer)
+    {
+        MoveLayer(0, layer);
+    }
+
+    public void MoveToTop(int index, ILayer layer)
+    {
+        MoveLayer(_entries.Count - 1, layer);
+    }
+
+    private void MoveLayer(int index, ILayer layer)
+    {
+        var copy = _entries.ToArray().ToList();
+        copy.Remove(copy.First(e => e.Layer == layer));
 
         if (copy.Count > index)
-            copy.Insert(index, layer);
+            copy.Insert(index, new LayerEntry(layer));
         else
-            copy.Add(layer);
+            copy.Add(new LayerEntry(layer));
 
-        _layers = new ConcurrentQueue<ILayer>(copy);
+        _entries = new ConcurrentQueue<LayerEntry>(copy);
         OnLayerMoved(layer);
         OnChanged(null, null, [layer]);
     }
 
     public void Insert(int index, params ILayer[] layers)
     {
+        InsertLayers(index, layers, 0);
+    }
+    public void Insert(int index, ILayer[] layers, int group)
+    {
+        InsertLayers(index, layers, group);
+    }
+
+    public void Insert(int index, ILayer layer, int group)
+    {
+        InsertLayers(index, [layer], group);
+    }
+
+    private void InsertLayers(int index, ILayer[] layers, int group)
+    {
         if (layers == null || layers.Length == 0)
             throw new ArgumentException("Layers cannot be null or empty");
 
-        var copy = _layers.ToArray().ToList();
+        var entries = layers.Select(l => new LayerEntry(l, group)).ToArray();
+        var copy = _entries.ToArray().ToList();
         if (copy.Count > index)
-            copy.InsertRange(index, layers);
+            copy.InsertRange(index, entries);
         else
-            copy.AddRange(layers);
+            copy.AddRange(entries);
 
-        _layers = new ConcurrentQueue<ILayer>(copy);
+        _entries = new ConcurrentQueue<LayerEntry>(copy);
         foreach (var layer in layers)
             OnLayerAdded(layer);
 
@@ -119,7 +183,7 @@ public class LayerCollection : IEnumerable<ILayer>
 
     public bool Remove(Func<ILayer, bool> predicate)
     {
-        var copyLayers = _layers.ToArray().Where(predicate).ToArray();
+        var copyLayers = _entries.Select(e => e.Layer).ToArray().Where(predicate).ToArray();
         var success = RemoveLayers(copyLayers);
 
         OnChanged(null, copyLayers);
@@ -139,7 +203,7 @@ public class LayerCollection : IEnumerable<ILayer>
 
     public void Modify(Func<ILayer, bool> removePredicate, IEnumerable<ILayer> layersToAdd)
     {
-        var copyLayersToRemove = _layers.ToArray().Where(removePredicate).ToArray();
+        var copyLayersToRemove = _entries.Select(e => e.Layer).ToArray().Where(removePredicate).ToArray();
         var copyLayersToAdd = layersToAdd.ToArray();
 
         RemoveLayers(copyLayersToRemove);
@@ -148,26 +212,26 @@ public class LayerCollection : IEnumerable<ILayer>
         OnChanged(copyLayersToAdd, copyLayersToRemove);
     }
 
-    private void AddLayers(ILayer[] layers)
+    private void AddLayers(ILayer[] layers, int group = 0)
     {
         if (layers == null || layers.Length == 0)
             throw new ArgumentException("Layers cannot be null or empty");
 
         foreach (var layer in layers)
         {
-            _layers.Enqueue(layer);
+            _entries.Enqueue(new LayerEntry(layer, group));
             OnLayerAdded(layer);
         }
     }
 
     private bool RemoveLayers(ILayer[] layers)
     {
-        var copy = _layers.ToArray().ToList();
+        var copy = _entries.ToArray().ToList();
         var success = true;
 
         foreach (var layer in layers)
         {
-            if (!copy.Remove(layer))
+            if (!copy.Remove(new LayerEntry(layer)))
                 success = false;
 
             if (layer is IAsyncDataFetcher asyncLayer)
@@ -177,7 +241,7 @@ public class LayerCollection : IEnumerable<ILayer>
             }
         }
 
-        _layers = new ConcurrentQueue<ILayer>(copy);
+        _entries = new ConcurrentQueue<LayerEntry>(copy);
         foreach (var layer in layers)
             OnLayerRemoved(layer);
 
@@ -206,6 +270,12 @@ public class LayerCollection : IEnumerable<ILayer>
 
     public IEnumerable<ILayer> FindLayer(string layerName)
     {
-        return _layers.Where(layer => layer.Name.Contains(layerName));
+        return _entries.Where(e => e.Layer.Name == layerName).Select(e => e.Layer).ToArray();
+    }
+
+    private class LayerEntry(ILayer layer, int group = 0)
+    {
+        public ILayer Layer { get; set; } = layer;
+        public int Group { get; set; } = group;
     }
 }

--- a/Mapsui/Layers/LayerCollection.cs
+++ b/Mapsui/Layers/LayerCollection.cs
@@ -239,6 +239,11 @@ public class LayerCollection : IEnumerable<ILayer>
         return success;
     }
 
+    /// <summary>
+    /// Modifies the layer collection by removing specified layers and adding new layers.
+    /// </summary>
+    /// <param name="layersToRemove">The layers to remove from the collection.</param>
+    /// <param name="layersToAdd">The layers to add to the collection.</param>
     public void Modify(IEnumerable<ILayer> layersToRemove, IEnumerable<ILayer> layersToAdd)
     {
         var copyLayersToRemove = layersToRemove.ToArray();
@@ -250,6 +255,11 @@ public class LayerCollection : IEnumerable<ILayer>
         OnChanged(copyLayersToAdd, copyLayersToRemove, []);
     }
 
+    /// <summary>
+    /// Modifies the layer collection by removing layers that match a specified predicate and adding new layers.
+    /// </summary>
+    /// <param name="removePredicate">The predicate to determine which layers to remove from the collection.</param>
+    /// <param name="layersToAdd">The layers to add to the collection.</param>
     public void Modify(Func<ILayer, bool> removePredicate, IEnumerable<ILayer> layersToAdd)
     {
         var copyLayersToRemove = _entries.Select(e => e.Layer).ToArray().Where(removePredicate).ToArray();
@@ -261,6 +271,11 @@ public class LayerCollection : IEnumerable<ILayer>
         OnChanged(copyLayersToAdd, copyLayersToRemove, []);
     }
 
+    /// <summary>
+    /// Finds layers in the collection by their name.
+    /// </summary>
+    /// <param name="layerName">The name of the layer to find.</param>
+    /// <returns>The layers with the specified name.</returns>
     public IEnumerable<ILayer> FindLayer(string layerName)
     {
         return _entries.Where(e => e.Layer.Name == layerName).Select(e => e.Layer).ToArray();

--- a/Mapsui/Layers/LayerCollection.cs
+++ b/Mapsui/Layers/LayerCollection.cs
@@ -44,7 +44,7 @@ public class LayerCollection : IEnumerable<ILayer>
     /// Retrieves all layers in a specific group.
     /// </summary>
     /// <param name="group">The group identifier (default is 0).</param>
-    /// <returns>An enumerable of layers in the specified group.</returns>
+    /// <returns>All the layers in the specified group.</returns>
     public IEnumerable<ILayer> GetLayers(int group = 0)
     {
         return _entries.Where(e => e.Group == group).OrderBy(e => e.Index).Select(e => e.Layer).ToArray();
@@ -53,7 +53,7 @@ public class LayerCollection : IEnumerable<ILayer>
     /// <summary>
     /// Retrieves all layers from all groups.
     /// </summary>
-    /// <returns>An enumerable of all layers.</returns>
+    /// <returns>All the layers of all groups.</returns>
     public IEnumerable<ILayer> GetLayersOfAllGroups()
     {
         return _entries.OrderBy(e => e.Index).Select(e => e.Layer).ToArray();
@@ -158,7 +158,7 @@ public class LayerCollection : IEnumerable<ILayer>
     }
 
     /// <summary>
-    /// Moves a layer to the bottom of the collection.
+    /// Moves a layer to the bottom of it's current group. This means the other layers will be drawn on top of it.
     /// </summary>
     /// <param name="layer">The layer to move.</param>
     public void MoveToBottom(ILayer layer)
@@ -168,7 +168,7 @@ public class LayerCollection : IEnumerable<ILayer>
     }
 
     /// <summary>
-    /// Moves a layer to the top of the collection.
+    /// Moves a layer to the top of it's current group. This means this layer will be drawn on top of the other layers.
     /// </summary>
     /// <param name="layer">The layer to move.</param>
     public void MoveToTop(ILayer layer)

--- a/Mapsui/Layers/LayerCollectionChangedEventArgs.cs
+++ b/Mapsui/Layers/LayerCollectionChangedEventArgs.cs
@@ -3,16 +3,9 @@ using System.Collections.Generic;
 
 namespace Mapsui.Layers;
 
-public class LayerCollectionChangedEventArgs : EventArgs
+public class LayerCollectionChangedEventArgs(IEnumerable<ILayer> added, IEnumerable<ILayer> removed, IEnumerable<ILayer> moved) : EventArgs
 {
-    public IEnumerable<ILayer>? AddedLayers { get; }
-    public IEnumerable<ILayer>? RemovedLayers { get; }
-    public IEnumerable<ILayer>? MovedLayers { get; }
-
-    public LayerCollectionChangedEventArgs(IEnumerable<ILayer>? added = null, IEnumerable<ILayer>? removed = null, IEnumerable<ILayer>? moved = null)
-    {
-        AddedLayers = added;
-        RemovedLayers = removed;
-        MovedLayers = moved;
-    }
+    public IEnumerable<ILayer> AddedLayers { get; } = added;
+    public IEnumerable<ILayer> RemovedLayers { get; } = removed;
+    public IEnumerable<ILayer> MovedLayers { get; } = moved;
 }

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -371,7 +371,7 @@ public class Map : INotifyPropertyChanged, IDisposable
         {
             foreach (var layer in Layers)
                 LayerRemoved(layer); // Remove Event so that no memory leaks occur
-            Layers.Clear();
+            Layers.ClearAllGroups();
         }
     }
 

--- a/Samples/Avalonia/Mapsui.Samples.Avalonia/Views/MainView.axaml.cs
+++ b/Samples/Avalonia/Mapsui.Samples.Avalonia/Views/MainView.axaml.cs
@@ -80,7 +80,7 @@ public partial class MainView : UserControl
         {
             Catch.Exceptions(async () =>
             {
-                MapControl.Map?.Layers.Clear();
+                MapControl.Map?.Layers.ClearAllGroups();
                 await sample.SetupAsync(MapControl);
                 MapControl.Refresh();
             });

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
@@ -28,7 +28,7 @@ public class PointsSample : ISample
 
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Layers.Add(CreatePointLayer());
-        map.Navigator.CenterOnAndZoomTo(map.Layers[1].Extent!.Centroid, map.Navigator.Resolutions[5]);
+        map.Navigator.CenterOnAndZoomTo(map.Layers.Get(1).Extent!.Centroid, map.Navigator.Resolutions[5]);
 
         map.Widgets.Add(new MapInfoWidget(map));
 

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
@@ -13,7 +13,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
-// ReSharper disable UnusedAutoPropertyAccessor.Local
+#pragma warning disable IDISP004 // Don't ignore created IDisposable
 
 namespace Mapsui.Samples.Common.Maps.Geometries;
 

--- a/Samples/Mapsui.Samples.Common/Maps/Info/ImageCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/ImageCalloutSample.cs
@@ -15,7 +15,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
-#pragma warning disable IDISP001 // Dispose created
+#pragma warning disable IDISP004 // Don't ignore created IDisposable
 
 namespace Mapsui.Samples.Common.Maps.Info;
 

--- a/Samples/Mapsui.Samples.Common/Maps/Info/ImageCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/ImageCalloutSample.cs
@@ -32,7 +32,7 @@ public class ImageCalloutSample : ISample
 
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Layers.Add(CreatePointLayer());
-        map.Navigator.CenterOnAndZoomTo(map.Layers[1].Extent!.Centroid, map.Navigator.Resolutions[5]);
+        map.Navigator.CenterOnAndZoomTo(map.Layers.Get(1).Extent!.Centroid, map.Navigator.Resolutions[5]);
 
         map.Widgets.Add(new MapInfoWidget(map));
         map.Info += MapOnInfo;

--- a/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
@@ -14,8 +14,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
-// ReSharper disable UnusedAutoPropertyAccessor.Local
-// ReSharper disable once ClassNeverInstantiated.Local
+#pragma warning disable IDISP004 // Don't ignore created IDisposable
 
 namespace Mapsui.Samples.Common.Maps.Info;
 

--- a/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
@@ -30,7 +30,7 @@ public class SingleCalloutSample : ISample
 
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Layers.Add(CreatePointLayer());
-        map.Navigator.CenterOnAndZoomTo(map.Layers[1].Extent!.Centroid, map.Navigator.Resolutions[5]);
+        map.Navigator.CenterOnAndZoomTo(map.Layers.Get(1).Extent!.Centroid, map.Navigator.Resolutions[5]);
         map.Info += MapOnInfo;
 
         map.Widgets.Add(new MapInfoWidget(map));

--- a/Samples/Mapsui.Samples.Common/Maps/Performance/ManyMutatingLayersSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Performance/ManyMutatingLayersSample.cs
@@ -11,6 +11,8 @@ using System.Threading.Tasks;
 using System.Timers;
 using Mapsui.Tiling;
 
+#pragma warning disable IDISP004 // Don't ignore created IDisposable
+
 namespace Mapsui.Samples.Common.Maps.Geometries;
 
 public sealed class ManyMutatingLayersSample : ISample, IDisposable

--- a/Samples/Mapsui.Samples.Common/Maps/Performance/ManyMutatingLayersSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Performance/ManyMutatingLayersSample.cs
@@ -38,7 +38,7 @@ public sealed class ManyMutatingLayersSample : ISample, IDisposable
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         var features = RandomPointsBuilder.CreateRandomFeatures(new MRect(-_c, -_c, _c, _c), _featureCount, _random);
         map.Layers.Add(CreatePointLayers(_random, features).ToArray());
-        map.Navigator.ZoomToBox(map.Layers[0].Extent);
+        map.Navigator.ZoomToBox(map.Layers.Get(0).Extent);
 
         map.Widgets.Add(new MapInfoWidget(map));
 

--- a/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingLayerWithLineStringSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingLayerWithLineStringSample.cs
@@ -30,7 +30,7 @@ public class RasterizingLayerWithLineStringSample : IMapControlSample
 
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Layers.Add(new RasterizingLayer(CreateLineStringLayer(), pixelDensity: pixelDensity));
-        var extent = map.Layers[1].Extent!.Grow(map.Layers[1].Extent!.Width * 0.25);
+        var extent = map.Layers.Get(1).Extent!.Grow(map.Layers.Get(1).Extent!.Width * 0.25);
         map.Navigator.ZoomToBox(extent);
 
         map.Widgets.Add(new MapInfoWidget(map));

--- a/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingLayerWithPointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingLayerWithPointsSample.cs
@@ -24,7 +24,7 @@ public class RasterizingLayerWithPointsSample : IMapControlSample
         var map = new Map();
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Layers.Add(new RasterizingLayer(CreateRandomPointLayer(), pixelDensity: pixelDensity));
-        var extent = map.Layers[1].Extent!.Grow(map.Layers[1].Extent!.Width * 0.1);
+        var extent = map.Layers.Get(1).Extent!.Grow(map.Layers.Get(1).Extent!.Width * 0.1);
         map.Navigator.ZoomToBox(extent);
         return map;
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithDynamicPointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithDynamicPointsSample.cs
@@ -26,7 +26,7 @@ public class RasterizingTileLayerWithDynamicPointsSample : IMapControlSample
         var map = new Map();
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Layers.Add(new RasterizingTileLayer(CreateRandomPointLayer(), pixelDensity: pixelDensity));
-        var extent = map.Layers[1].Extent!.Grow(map.Layers[1].Extent!.Width * 0.1);
+        var extent = map.Layers.Get(1).Extent!.Grow(map.Layers.Get(1).Extent!.Width * 0.1);
         map.Navigator.ZoomToBox(extent);
         return map;
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithPointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithPointsSample.cs
@@ -20,7 +20,7 @@ public class RasterizingTileLayerWithPointsSample : ISample
         var map = new Map();
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Layers.Add(new RasterizingTileLayer(CreateRandomPointLayer()));
-        var extent = map.Layers[1].Extent!.Grow(map.Layers[1].Extent!.Width * 0.1);
+        var extent = map.Layers.Get(1).Extent!.Grow(map.Layers.Get(1).Extent!.Width * 0.1);
         map.Navigator.ZoomToBox(extent);
         return Task.FromResult(map);
     }

--- a/Samples/Mapsui.Samples.Droid/MainActivity.cs
+++ b/Samples/Mapsui.Samples.Droid/MainActivity.cs
@@ -36,7 +36,7 @@ public class MainActivity : AppCompatActivity
         _mapControl.Renderer.WidgetRenders[typeof(CustomWidget)] = new CustomWidgetSkiaRenderer();
 
         var relativeLayout = FindViewById<RelativeLayout>(Resource.Id.mainLayout) ?? throw new NullReferenceException(); ;
-        _mapControl.Map.Layers.Clear();
+        _mapControl.Map.Layers.ClearAllGroups();
         var sample = new OsmSample();
 
         Catch.Exceptions(async () =>
@@ -106,7 +106,7 @@ public class MainActivity : AppCompatActivity
             var sample = AllSamples.GetSamples()?.FirstOrDefault(s => s.Name == item.TitleFormatted?.ToString());
             if (sample != null)
             {
-                _mapControl?.Map?.Layers.Clear();
+                _mapControl?.Map?.Layers.ClearAllGroups();
 
                 Catch.Exceptions(async () =>
                 {

--- a/Samples/Mapsui.Samples.Eto/MainForm.cs
+++ b/Samples/Mapsui.Samples.Eto/MainForm.cs
@@ -106,7 +106,7 @@ public class MainForm : Form
         {
             Catch.Exceptions(async () =>
             {
-                MapControl.Map?.Layers.Clear();
+                MapControl.Map?.Layers.ClearAllGroups();
 
                 await sample.SetupAsync(MapControl);
 

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/MainPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/MainPage.xaml.cs
@@ -79,7 +79,7 @@ public sealed partial class MainPage : Page
         {
             Catch.Exceptions(async () =>
             {
-                MapControl.Map!.Layers.Clear();
+                MapControl.Map!.Layers.ClearAllGroups();
                 await sample.SetupAsync(MapControl);
                 MapControl.Refresh();
             });

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/MainWindow.xaml.cs
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/MainWindow.xaml.cs
@@ -81,7 +81,7 @@ public sealed partial class MainWindow : Window
         {
             Catch.Exceptions(async () =>
             {
-                MapControl.Map!.Layers.Clear();
+                MapControl.Map!.Layers.ClearAllGroups();
                 await sample.SetupAsync(MapControl);
                 MapControl.Refresh();
             });

--- a/Samples/Mapsui.Samples.WindowsForms/SampleWindow.cs
+++ b/Samples/Mapsui.Samples.WindowsForms/SampleWindow.cs
@@ -102,7 +102,7 @@ public partial class SampleWindow : Form
 
     private void ItemCheck(object? sender, ItemCheckEventArgs e)
     {
-        _mapControl.Map.Layers[e.Index].Enabled = e.NewValue == CheckState.Checked;
+        _mapControl.Map.Layers.Get(e.Index).Enabled = e.NewValue == CheckState.Checked;
         _mapControl.Map.Refresh();
     }
 
@@ -169,7 +169,7 @@ public partial class SampleWindow : Form
             Catch.Exceptions(async () =>
             {
                 _mapControl.Map.Navigator.ViewportChanged -= ViewportChanged;
-                _mapControl.Map.Layers.Clear();
+                _mapControl.Map.Layers.ClearAllGroups();
                 await sample.SetupAsync(_mapControl);
                 _mapControl.Refresh();
                 _mapControl.Map.Navigator.ViewportChanged += ViewportChanged;

--- a/Tests/Mapsui.Tests/Layers/LayerCollectionTests.cs
+++ b/Tests/Mapsui.Tests/Layers/LayerCollectionTests.cs
@@ -54,7 +54,7 @@ public class LayerCollectionTests
         layerCollection.Insert(1, layer3);
 
         // Assert
-        var list = layerCollection.GetLayersOfGroup(0);
+        var list = layerCollection.GetLayers(0).ToArray();
         Assert.That(list.Length, Is.EqualTo(2));
         Assert.That(list[0], Is.Not.Null);
         Assert.That(list[0].Name, Is.EqualTo("Layer2"));

--- a/Tests/Mapsui.Tests/Layers/LayerCollectionTests.cs
+++ b/Tests/Mapsui.Tests/Layers/LayerCollectionTests.cs
@@ -156,4 +156,78 @@ public class LayerCollectionTests
         ClassicAssert.NotNull(list[2]);
         ClassicAssert.AreEqual("Layer1", list[2].Name);
     }
+
+    [Test]
+    public void AddToGroup()
+    {
+        // Arrange
+        var layerCollection = new LayerCollection();
+
+        using var layer1 = new MemoryLayer() { Name = "Layer1" };
+        using var layer2 = new MemoryLayer() { Name = "Layer2" };
+        using var layer3 = new MemoryLayer() { Name = "Layer3" };
+        using var layer4 = new MemoryLayer() { Name = "Layer4" };
+        using var layer5 = new MemoryLayer() { Name = "Layer5" };
+        using var layer6 = new MemoryLayer() { Name = "Layer6" };
+
+        var groupOnTop = -1;
+        var groupOnMiddle = 0;
+        var groupOnBottom = 1;
+
+        // Act
+        layerCollection.Add(layer1, groupOnTop);
+        layerCollection.Add(layer2, groupOnMiddle);
+        layerCollection.Add(layer3, groupOnBottom);
+        layerCollection.Add(layer4, groupOnTop);
+        layerCollection.Add(layer5, groupOnMiddle);
+        layerCollection.Add(layer6, groupOnBottom);
+
+        // Assert
+        var list = layerCollection.ToList();
+        Assert.That(list.Count, Is.EqualTo(6));
+
+        Assert.That(list[0].Name, Is.EqualTo("Layer1"));
+        Assert.That(list[1].Name, Is.EqualTo("Layer4"));
+        Assert.That(list[2].Name, Is.EqualTo("Layer2"));
+        Assert.That(list[3].Name, Is.EqualTo("Layer5"));
+        Assert.That(list[4].Name, Is.EqualTo("Layer3"));
+        Assert.That(list[5].Name, Is.EqualTo("Layer6"));
+    }
+
+    [Test]
+    public void InsertToGroup()
+    {
+        // Arrange
+        var layerCollection = new LayerCollection();
+
+        using var layer1 = new MemoryLayer() { Name = "Layer1" };
+        using var layer2 = new MemoryLayer() { Name = "Layer2" };
+        using var layer3 = new MemoryLayer() { Name = "Layer3" };
+        using var layer4 = new MemoryLayer() { Name = "Layer4" };
+        using var layer5 = new MemoryLayer() { Name = "Layer5" };
+        using var layer6 = new MemoryLayer() { Name = "Layer6" };
+
+        var groupOnTop = -1;
+        var groupOnMiddle = 0;
+        var groupOnBottom = 1;
+
+        // Act
+        layerCollection.Insert(0, layer1, groupOnTop);
+        layerCollection.Insert(0, layer2, groupOnMiddle);
+        layerCollection.Insert(0, layer3, groupOnBottom);
+        layerCollection.Insert(1, layer4, groupOnTop);
+        layerCollection.Insert(1, layer5, groupOnMiddle);
+        layerCollection.Insert(1, layer6, groupOnBottom);
+
+        // Assert
+        var list = layerCollection.ToList();
+        Assert.That(list.Count, Is.EqualTo(6));
+
+        Assert.That(list[0].Name, Is.EqualTo("Layer1"));
+        Assert.That(list[1].Name, Is.EqualTo("Layer4"));
+        Assert.That(list[2].Name, Is.EqualTo("Layer2"));
+        Assert.That(list[3].Name, Is.EqualTo("Layer5"));
+        Assert.That(list[4].Name, Is.EqualTo("Layer3"));
+        Assert.That(list[5].Name, Is.EqualTo("Layer6"));
+    }
 }

--- a/Tests/Mapsui.Tests/Layers/LayerCollectionTests.cs
+++ b/Tests/Mapsui.Tests/Layers/LayerCollectionTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Mapsui.Layers;
 using NUnit.Framework;
 
@@ -183,5 +184,67 @@ public class LayerCollectionTests
         Assert.That(list[3].Name, Is.EqualTo("Layer5"));
         Assert.That(list[4].Name, Is.EqualTo("Layer3"));
         Assert.That(list[5].Name, Is.EqualTo("Layer6"));
+    }
+
+    [TestCase(2, -1)]
+    [TestCase(1, -1)]
+    [TestCase(0, -1)]
+    [TestCase(2, 0)]
+    [TestCase(1, 0)]
+    [TestCase(0, 0)]
+    [TestCase(2, 1)]
+    [TestCase(1, 1)]
+    [TestCase(0, 1)]
+
+    public void MoveDown(int index, int group)
+    {
+        // Arrange
+        var layerCollection = BuildLayerCollection();
+        var layer = layerCollection.Get(index, group);
+
+        // Act
+        layerCollection.MoveDown(layer);
+
+        // Assert
+        var indexAfterMove = Math.Max(index - 1, 0);
+        Assert.That(layer.Name, Is.EqualTo(layerCollection.Get(indexAfterMove, group).Name));
+    }
+
+    [TestCase(2, -1)]
+    [TestCase(1, -1)]
+    [TestCase(0, -1)]
+    [TestCase(2, 0)]
+    [TestCase(1, 0)]
+    [TestCase(0, 0)]
+    [TestCase(2, 1)]
+    [TestCase(1, 1)]
+    [TestCase(0, 1)]
+    public void MoveUp(int index, int group)
+    {
+        // Arrange
+        var layerCollection = BuildLayerCollection();
+        var layer = layerCollection.Get(index, group);
+
+        // Act
+        layerCollection.MoveUp(layer);
+
+        // Assert
+        var indexAfterMove = Math.Min(index + 1, 2);
+        Assert.That(layer.Name, Is.EqualTo(layerCollection.Get(indexAfterMove, group).Name));
+    }
+
+    private static LayerCollection BuildLayerCollection()
+    {
+        var layerCollection = new LayerCollection();
+
+        for (var i = -1; i < 3; i++) // Start with group -1
+        {
+            for (var j = 0; j < 3; j++)
+            {
+                layerCollection.Add(new MemoryLayer() { Name = $"Layer{i}{j}" }, i);
+            }
+        }
+
+        return layerCollection;
     }
 }

--- a/Tests/Mapsui.Tests/Layers/LayerCollectionTests.cs
+++ b/Tests/Mapsui.Tests/Layers/LayerCollectionTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq;
 using Mapsui.Layers;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace Mapsui.Tests.Layers;
 
@@ -9,56 +8,9 @@ namespace Mapsui.Tests.Layers;
 public class LayerCollectionTests
 {
     [Test]
-    public void CopyToWithNormalConditions()
-    {
-        // arrange
-        var layerCollection = new LayerCollection();
-        using var layer1 = new MemoryLayer();
-        using var layer2 = new MemoryLayer();
-        layerCollection.Add(layer1);
-        layerCollection.Add(layer2);
-
-        var size = layerCollection.Count();
-        var array = new ILayer[size];
-
-        // act
-        layerCollection.CopyTo(array, 0);
-
-        // assert
-        ClassicAssert.AreEqual(2, array.Length);
-        ClassicAssert.NotNull(array[0]);
-        ClassicAssert.NotNull(array[1]);
-    }
-
-    [Test]
-    public void CopyToAfterRemovingItem()
-    {
-        // arrange
-        var layerCollection = new LayerCollection();
-        using var layer1 = new MemoryLayer();
-        using var layer2 = new MemoryLayer();
-        layerCollection.Add(layer1);
-        layerCollection.Add(layer2);
-
-        var size = layerCollection.Count();
-        var array = new ILayer[size];
-        layerCollection.Remove(layer1);
-
-        // act
-        layerCollection.CopyTo(array, 0);
-
-        // assert
-        ClassicAssert.AreEqual(2, array.Length);
-        ClassicAssert.NotNull(array[0], "first element not null");
-        // We have no crash but the seconds element is null.
-        // This might have unpleasant consequences.
-        ClassicAssert.Null(array[1], "second element IS null");
-    }
-
-    [Test]
     public void InsertWithNormalConditions()
     {
-        // arrange
+        // Arrange
         var layerCollection = new LayerCollection();
         using var layer1 = new MemoryLayer() { Name = "Layer1" };
         using var layer2 = new MemoryLayer() { Name = "Layer2" };
@@ -66,49 +18,54 @@ public class LayerCollectionTests
         layerCollection.Add(layer1);
         layerCollection.Add(layer2);
 
-        // act
+        // Act
         layerCollection.Insert(1, layer3);
 
-        // assert
+        // Assert
         var list = layerCollection.ToList();
-        ClassicAssert.AreEqual(3, list.Count);
-        ClassicAssert.NotNull(list[0]);
-        ClassicAssert.AreEqual("Layer1", list[0].Name);
-        ClassicAssert.NotNull(list[1]);
-        ClassicAssert.AreEqual("Layer3", list[1].Name);
-        ClassicAssert.NotNull(list[2]);
-        ClassicAssert.AreEqual("Layer2", list[2].Name);
+        Assert.That(list.Count, Is.EqualTo(3));
+        Assert.That(list[0], Is.Not.Null);
+        Assert.That(list[0].Name, Is.EqualTo("Layer1"));
+        Assert.That(list[1], Is.Not.Null);
+        Assert.That(list[1].Name, Is.EqualTo("Layer3"));
+        Assert.That(list[2], Is.Not.Null);
+        Assert.That(list[2].Name, Is.EqualTo("Layer2"));
     }
 
     [Test]
     public void InsertAfterRemoving()
     {
-        // arrange
+        // Arrange
         var layerCollection = new LayerCollection();
         using var layer1 = new MemoryLayer() { Name = "Layer1" };
         using var layer2 = new MemoryLayer() { Name = "Layer2" };
         using var layer3 = new MemoryLayer() { Name = "Layer3" };
+        using var layer1Group2 = new MemoryLayer() { Name = "Layer1Group2" };
+        using var layer2Group2 = new MemoryLayer() { Name = "Layer2Group2" };
+
+        layerCollection.Add(layer1Group2, 1);
         layerCollection.Add(layer1);
+        layerCollection.Add(layer2Group2, 1);
         layerCollection.Add(layer2);
 
         layerCollection.Remove(layer1);
 
-        // act
+        // Act
         layerCollection.Insert(1, layer3);
 
-        // assert
-        var list = layerCollection.ToList();
-        ClassicAssert.AreEqual(2, list.Count);
-        ClassicAssert.NotNull(list[0]);
-        ClassicAssert.AreEqual("Layer2", list[0].Name);
-        ClassicAssert.NotNull(list[1]);
-        ClassicAssert.AreEqual("Layer3", list[1].Name);
+        // Assert
+        var list = layerCollection.GetLayersOfGroup(0);
+        Assert.That(list.Length, Is.EqualTo(2));
+        Assert.That(list[0], Is.Not.Null);
+        Assert.That(list[0].Name, Is.EqualTo("Layer2"));
+        Assert.That(list[1], Is.Not.Null);
+        Assert.That(list[1].Name, Is.EqualTo("Layer3"));
     }
 
     [Test]
     public void MoveWithNormalConditions()
     {
-        // arrange
+        // Arrange
         var layerCollection = new LayerCollection();
         using var layer1 = new MemoryLayer() { Name = "Layer1" };
         using var layer2 = new MemoryLayer() { Name = "Layer2" };
@@ -117,24 +74,24 @@ public class LayerCollectionTests
         layerCollection.Add(layer2);
         layerCollection.Add(layer3);
 
-        // act
+        // Act
         layerCollection.Move(1, layer3);
 
-        // assert
+        // Assert
         var list = layerCollection.ToList();
-        ClassicAssert.AreEqual(3, list.Count);
-        ClassicAssert.NotNull(list[0]);
-        ClassicAssert.AreEqual("Layer1", list[0].Name);
-        ClassicAssert.NotNull(list[1]);
-        ClassicAssert.AreEqual("Layer3", list[1].Name);
-        ClassicAssert.NotNull(list[2]);
-        ClassicAssert.AreEqual("Layer2", list[2].Name);
+        Assert.That(list.Count, Is.EqualTo(3));
+        Assert.That(list[0], Is.Not.Null);
+        Assert.That(list[0].Name, Is.EqualTo("Layer1"));
+        Assert.That(list[1], Is.Not.Null);
+        Assert.That(list[1].Name, Is.EqualTo("Layer3"));
+        Assert.That(list[2], Is.Not.Null);
+        Assert.That(list[2].Name, Is.EqualTo("Layer2"));
     }
 
     [Test]
     public void MoveAfterIndex()
     {
-        // arrange
+        // Arrange
         var layerCollection = new LayerCollection();
         using var layer1 = new MemoryLayer() { Name = "Layer1" };
         using var layer2 = new MemoryLayer() { Name = "Layer2" };
@@ -143,18 +100,15 @@ public class LayerCollectionTests
         layerCollection.Add(layer2);
         layerCollection.Add(layer3);
 
-        // act
+        // Act
         layerCollection.Move(3, layer1);
 
-        // assert
+        // Assert
         var list = layerCollection.ToList();
-        ClassicAssert.AreEqual(3, list.Count);
-        ClassicAssert.NotNull(list[0]);
-        ClassicAssert.AreEqual("Layer2", list[0].Name);
-        ClassicAssert.NotNull(list[1]);
-        ClassicAssert.AreEqual("Layer3", list[1].Name);
-        ClassicAssert.NotNull(list[2]);
-        ClassicAssert.AreEqual("Layer1", list[2].Name);
+        Assert.That(list.Count, Is.EqualTo(3));
+        Assert.That(list[0].Name, Is.EqualTo("Layer2"));
+        Assert.That(list[1].Name, Is.EqualTo("Layer3"));
+        Assert.That(list[2].Name, Is.EqualTo("Layer1"));
     }
 
     [Test]

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "version": "8.0.403",
+    "version": "8.0.400",
     "rollForward": "latestMajor"
   },
   "tools": {
     "allowPrerelease": false,
-    "dotnet": "8.0.403",
+    "dotnet": "8.0.400",
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
Add groups to LayerCollection. This was done with a LayerEntry private class with Layer, Order and Group fields. This way the ILayer did not have to be altered. The order of the layers in the internal class does not matter anymore because we always sort on Order and Group when requesting the list.

~Open~ issues:

- [x] There was a Clear method that removed all. Now I added ClearGroup(). Perhaps it should be ClearAllGroups and Clear(int group = 0) instead.
- [x] GetLayersOfGroup is like the above. Perhaps it should be GetLayers(int group) and GetLayersOfAllGroups().
- [x] The group parameter is often optional. This is good because group 0 should be the default most of the time. For some methods a default may cause confusion. UPDATE: For all public methods it is now optional
- [x] I use Span on one method. IEnumerable on the other. The problem with IEnumerable is the 'possible multiple enumerations' which makes you need to convert to List. I prefer Span for that reason. I need to figure out if it is possible to use that everywhere. UPDATE: Can not use it that much because we are dealing with field members here, and mostly input parameters.
- [x] We use the params keyword in some cases, but the group parameter can not be added after it because that is never allowed after a params keyword. Now I added overload. Perhaps the params keyword should be removed altogether because this way it is only confusing. UPDATE: The params have some added value because you can add a list of parameters as separate parameters, like this: Method(layer1, layer2, layer3, layer4). Because collection initializers are now a good alternative I prefer to keep the interface simpler and remove the params.
- [x] I don't like the 'keepWithinGroup boolean that I suggested [here](https://github.com/Mapsui/Mapsui/issues/1491). I think it should be about moving within a group. Moving between groups may need a some other method.
- [x] Removed the CopyTo method. I don't remember what it was for.
- [x] Perhaps Group should be called OrderGroup. Update: Keep Order for now
- [x] The main iterator operates directly on the collection. The becomes confusing now there are several ways to request layers (all, or grouped). UPDATE: I kept this one for now because it will not be clear with which to replace it.
- [x] The same problem for the this[int index]. I think this should be a method. UPDATE: There is a Get(index) now, and the [index] was removed
- [x] The public methods call private methods and at some point the event handlers are called. It is not very clear which method is responsible for calling the event handlers. UPDATE: Removed the individual change events, now only using OnChanged (which posts in bulk). Calling OnChanged on all public method. Renamed all private counter parts to <MethodName>Internal. Never call OnChanged in the internal methods.
- [x] MoveUp(ILayer layerToMove); // Move one up within the group (increasing index)
- [x] MoveDown(ILayer layerToMove); // Move one down within the group (lowering the index)
- [x] Add api documentation.