### PR TITLE
Fix: WinUI Targets (Maui,Uno,WinUI)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,8 +32,8 @@
     <PackageVersion Include="Eto.Platform.XamMac2" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.Platform.Gtk" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.SkiaDraw" Version="[0.2.0,0.3.0)" />
-    <PackageVersion Include="HarfBuzzSharp" Version="7.3.0.2" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="7.3.0.2" />
+    <PackageVersion Include="HarfBuzzSharp" Version="7.3.0.3-preview.2.2" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="7.3.0.3-preview.2.2" />
     <PackageVersion Include="IDisposableAnalyzers" Version="[4.0.8,5.0.0)" />
     <PackageVersion Include="Mapsui.Android" Version="5.0.0-beta.1" />
     <PackageVersion Include="Mapsui.ArcGIS" Version="5.0.0-beta.1" />
@@ -60,20 +60,20 @@
     <PackageVersion Include="NetTopologySuite.IO.GeoJSON4STJ" Version="[4.0.0,5.0.0)" />
     <PackageVersion Include="NUnit" Version="4.2.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageVersion Include="SkiaSharp" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.Views" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.Views.Uno" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.Views.WinUI" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.Views.WPF" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="2.88.8" />
+    <PackageVersion Include="SkiaSharp" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.Views" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.Views.Uno" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.Views.WinUI" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.Views.WPF" Version="2.88.9-preview.2.2" />
+    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="2.88.9-preview.2.2" />
     <PackageVersion Include="sqlite-net-pcl" Version="[1.9.172,2.0.0)" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="[2.1.6,3.0.0)" />
     <PackageVersion Include="Svg.Skia" Version="2.0.0" />

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -32,6 +32,7 @@
     </UnoFeatures>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="SkiaSharp.Views.Uno.WinUI"/>
     <ProjectReference Include="..\..\..\Mapsui.UI.Uno.WinUI\Mapsui.UI.Uno.WinUI.csproj" />
     <ProjectReference Include="..\..\..\Tests\Mapsui.Tests.Common\Mapsui.Tests.Common.csproj" />
     <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />


### PR DESCRIPTION
With newer Visual Studio Versions the Default WindowsSdk that is used is per default higher or equal to 10.0.19041.38 which causes SkiaSharp to stop working on WinUI Targets, Like Mapsui.WinUI, Mapsui.Maui (Windows), Mapsui.Uno (WinUI)
This fixes this issue too. 

https://github.com/Mapsui/Mapsui/issues/2758

This happens too when the .NET 8 SDK is updated beyond Version 8.0.403 and greater. As an added Bonus Mapsui works now on .NET 9 Wasm targets too.
