### PR TITLE
Update to Uno Sdk 5.4.10 

### DIFF
--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {
-    "Uno.Sdk": "5.3.108"
+    "Uno.Sdk": "5.4.10"
   }
 }


### PR DESCRIPTION
(Is needed in the .NET 9 and SkiaSharp 3 pull requests)