### PR TITLE
Fixing: Maui Samples Build (Specify SkiaSharp PackageReferences)

### DIFF
--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>	
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" VersionOverride="1.6.240923002" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" VersionOverride="1.5.240627000" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
   </ItemGroup>
 

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>	
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" VersionOverride="1.5.240627000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" VersionOverride="1.6.240923002" />
     <PackageReference Include="SkiaSharp.Views.WinUI" />
   </ItemGroup>
 

--- a/Samples/Mapsui.Samples.Maui/Mapsui.Samples.Maui.csproj
+++ b/Samples/Mapsui.Samples.Maui/Mapsui.Samples.Maui.csproj
@@ -52,6 +52,9 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Maui.Markup" />
 		<PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.StartsWith('net8.0'))">

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "version": "8.0.403",
+    "version": "8.0.400",
     "rollForward": "latestMajor"
   },
   "tools": {
     "allowPrerelease": false,
-    "dotnet": "8.0.403",
+    "dotnet": "8.0.400",
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "version": "8.0.400",
+    "version": "8.0.403",
     "rollForward": "latestMajor"
   },
   "tools": {
     "allowPrerelease": false,
-    "dotnet": "8.0.400",
+    "dotnet": "8.0.403",
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {
-    "Uno.Sdk": "5.3.112"
+    "Uno.Sdk": "5.3.108"
   }
 }

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {
-    "Uno.Sdk": "5.4.10"
+    "Uno.Sdk": "5.3.112"
   }
 }


### PR DESCRIPTION
Things done: 
1.) Added SkiaSharp references to Mapsui.Samples.Maui so that it compiles (Rasterizer has SkiaSharp Dependencies and therefere I have to specifiy it explicitly so that it takes the 2.89 preview versions).
2. Revert Uno.sdk to 5.0.108 later uno versions Seen to have Problems

