### PR TITLE
Improve husky so that the formatted files become part of the commit

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -12,19 +12,18 @@
         "--include",
         "${staged}"
       ]
+    },
+    {
+      "name": "re-add-the-staged-files-after-formatting-so-that-the-fix-becomes-part-of-the-commit",
+      "group": "pre-commit",
+      "output": "always",
+      "command": "bash",
+      "args": [ "-c", "git", "add", "${staged}" ],
+      "windows": {
+        "command": "cmd",
+        "args": [ "/c", "git", "add", "${staged}" ]
+      },
+      "include": [ "**/*.cs" ]
     }
-    // This adds the changed files back to the staging after formatting, but it sometimes fails
-    //,
-    //{
-    //  "name": "re-add-the-staged-files-after-formatting",
-    //  "group": "pre-commit",
-    //  "output": "always",
-    //  "command": "bash",
-    //  "args": [ "git", "add", "${staged}" ],
-    //  "windows": {
-    //    "command": "cmd",
-    //    "args": [ "git", "add", "${staged}" ]
-    //  }
-    //}
   ]
 }


### PR DESCRIPTION
Before running dotnet format the committed files are staged. The changes made by dotnet format need to be staged as well in order to make them part of the commit. I tried this before but the command had a flaw. This is fixed now.