### PR TITLE
Add way to add Pin with Callout through the MapBuilder

### DIFF
--- a/Mapsui.Tiling/Extensions/MapBuilderExtensions.cs
+++ b/Mapsui.Tiling/Extensions/MapBuilderExtensions.cs
@@ -7,9 +7,9 @@ public static class MapBuilderExtensions
 {
     public static MapBuilder WithOpenStreetMapLayer(this MapBuilder mapBuilder, ConfigureLayer configureLayer)
     {
-        return mapBuilder.WithLayer((map) => OpenStreetMap.CreateTileLayer(), (l) =>
+        return mapBuilder.WithLayer((map) => OpenStreetMap.CreateTileLayer(), (l, m) =>
         {
-            configureLayer(l);
+            configureLayer(l, m);
         });
     }
 

--- a/Mapsui.Tiling/Extensions/MapBuilderExtensions.cs
+++ b/Mapsui.Tiling/Extensions/MapBuilderExtensions.cs
@@ -7,7 +7,7 @@ public static class MapBuilderExtensions
 {
     public static MapBuilder WithOpenStreetMapLayer(this MapBuilder mapBuilder, ConfigureLayer configureLayer)
     {
-        return mapBuilder.WithLayer(() => OpenStreetMap.CreateTileLayer(), (l) =>
+        return mapBuilder.WithLayer((map) => OpenStreetMap.CreateTileLayer(), (l) =>
         {
             configureLayer(l);
         });

--- a/Mapsui/MapBuilder.cs
+++ b/Mapsui/MapBuilder.cs
@@ -1,7 +1,5 @@
 ﻿using Mapsui.Extensions;
 using Mapsui.Layers;
-using Mapsui.Styles;
-using Mapsui.Styles.Thematics;
 using Mapsui.Widgets;
 using Mapsui.Widgets.ButtonWidgets;
 using System;
@@ -34,22 +32,16 @@ public class MapBuilder
         return this;
     }
 
-    public MapBuilder WithLayer(AddLayer layerFactory, ConfigureLayer configureLayer)
+    public MapBuilder WithLayer(AddLayer layerFactory, ConfigureLayer? configureLayer = null)
     {
         _layerFactories.Add((m) =>
         {
             var layer = layerFactory(m);
-            configureLayer(layer);
+            configureLayer?.Invoke(layer);
             return layer;
         });
         return this;
     }
-
-    public MapBuilder WithLayer(AddLayer layerFactory)
-        => WithLayer(layerFactory, (l) => { });
-
-    public MapBuilder WithPinWithCalloutLayer(IEnumerable<IFeature>? features = null)
-        => WithLayer(m => CreateLayerWithPinWithCallout(m, features ?? []), (l) => { });
 
     public MapBuilder WithMapCRS(string crs)
     {
@@ -93,50 +85,4 @@ public class MapBuilder
     public delegate void ConfigureLayer(ILayer layer);
     public delegate void ConfigureWidget(IWidget widget);
     public delegate void TapFeature(Action<IFeature> tapFeature);
-
-    private static MemoryLayer CreateLayerWithPinWithCallout(Map map, IEnumerable<IFeature> features)
-    {
-        map.Info += (sender, args) =>
-        {
-            var feature = args.MapInfo.Feature;
-            if (feature is null)
-                return;
-
-            var enabled = feature["enabled"]?.ToString() == "True";
-            feature["enabled"] = (!enabled).ToString();
-        };
-
-        return new()
-        {
-            IsMapInfoLayer = true,
-            Features = features,
-            Style = new StyleCollection
-            {
-                Styles =
-                {
-                    new SymbolStyle
-                    {
-                        ImageSource = "embedded://Mapsui.Resources.Images.Pin.svg",
-                        SymbolOffset = new RelativeOffset(0.0, 0.5), // The point at the bottom should be at the location
-                        SvgFillColor = Color.CornflowerBlue,
-                        SvgStrokeColor = Color.Black,
-                        SymbolScale = 1,
-                    },
-                    new ThemeStyle(f =>
-                    {
-                        return new CalloutStyle()
-                        {
-                            Enabled = f["enabled"]?.ToString() == "True",
-                            SymbolOffset = new Offset(0, 52),
-                            TitleFont = { FontFamily = null, Size = 24, Italic = false, Bold = true },
-                            TitleFontColor = Color.Black,
-                            Type = CalloutType.Single,
-                            MaxWidth = 120,
-                            Title = f["Name"]!.ToString()
-                        };
-                    })
-                }
-            }
-        };
-    }
 }

--- a/Mapsui/MapBuilder.cs
+++ b/Mapsui/MapBuilder.cs
@@ -1,8 +1,10 @@
 ﻿using Mapsui.Extensions;
 using Mapsui.Layers;
 using Mapsui.Styles;
+using Mapsui.Styles.Thematics;
 using Mapsui.Widgets;
 using Mapsui.Widgets.ButtonWidgets;
+using System;
 using System.Collections.Generic;
 
 namespace Mapsui;
@@ -34,9 +36,9 @@ public class MapBuilder
 
     public MapBuilder WithLayer(AddLayer layerFactory, ConfigureLayer configureLayer)
     {
-        _layerFactories.Add(() =>
+        _layerFactories.Add((m) =>
         {
-            var layer = layerFactory();
+            var layer = layerFactory(m);
             configureLayer(layer);
             return layer;
         });
@@ -46,8 +48,8 @@ public class MapBuilder
     public MapBuilder WithLayer(AddLayer layerFactory)
         => WithLayer(layerFactory, (l) => { });
 
-    public MapBuilder WithPinWithCalloutLayer()
-        => WithLayer(CreatePinWithCalloutLayer, (l) => { });
+    public MapBuilder WithPinWithCalloutLayer(IEnumerable<IFeature>? features = null)
+        => WithLayer(m => CreateLayerWithPinWithCallout(m, features ?? []), (l) => { });
 
     public MapBuilder WithMapCRS(string crs)
     {
@@ -74,7 +76,7 @@ public class MapBuilder
         var map = new Map();
 
         foreach (var layerFactory in _layerFactories)
-            map.Layers.Add(layerFactory());
+            map.Layers.Add(layerFactory(map));
 
         foreach (var widgetFactory in _widgetFactories)
             map.Widgets.Add(widgetFactory(map));
@@ -85,21 +87,56 @@ public class MapBuilder
         return map;
     }
 
-    public delegate ILayer AddLayer();
+    public delegate ILayer AddLayer(Map map);
     public delegate void ConfigureMap(Map map);
     public delegate IWidget AddWidget(Map map);
     public delegate void ConfigureLayer(ILayer layer);
     public delegate void ConfigureWidget(IWidget widget);
+    public delegate void TapFeature(Action<IFeature> tapFeature);
 
-    private MemoryLayer CreatePinWithCalloutLayer() => new()
+    private static MemoryLayer CreateLayerWithPinWithCallout(Map map, IEnumerable<IFeature> features)
     {
-        Style = new SymbolStyle
+        map.Info += (sender, args) =>
         {
-            ImageSource = $"embedded://Mapsui.Samples.Common.Images.arrow.svg",
-            SymbolOffset = new RelativeOffset(0.0, 0.5), // The point at the bottom should be at the location
-            SvgFillColor = Color.AliceBlue,
-            SvgStrokeColor = Color.Black,
-            SymbolScale = 0.5,
-        }
-    };
+            var feature = args.MapInfo.Feature;
+            if (feature is null)
+                return;
+
+            var enabled = feature["enabled"]?.ToString() == "True";
+            feature["enabled"] = (!enabled).ToString();
+        };
+
+        return new()
+        {
+            IsMapInfoLayer = true,
+            Features = features,
+            Style = new StyleCollection
+            {
+                Styles =
+                {
+                    new SymbolStyle
+                    {
+                        ImageSource = "embedded://Mapsui.Resources.Images.Pin.svg",
+                        SymbolOffset = new RelativeOffset(0.0, 0.5), // The point at the bottom should be at the location
+                        SvgFillColor = Color.CornflowerBlue,
+                        SvgStrokeColor = Color.Black,
+                        SymbolScale = 1,
+                    },
+                    new ThemeStyle(f =>
+                    {
+                        return new CalloutStyle()
+                        {
+                            Enabled = f["enabled"]?.ToString() == "True",
+                            SymbolOffset = new Offset(0, 52),
+                            TitleFont = { FontFamily = null, Size = 24, Italic = false, Bold = true },
+                            TitleFontColor = Color.Black,
+                            Type = CalloutType.Single,
+                            MaxWidth = 120,
+                            Title = f["Name"]!.ToString()
+                        };
+                    })
+                }
+            }
+        };
+    }
 }

--- a/Mapsui/MapBuilder.cs
+++ b/Mapsui/MapBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using Mapsui.Extensions;
 using Mapsui.Layers;
+using Mapsui.Styles;
 using Mapsui.Widgets;
 using Mapsui.Widgets.ButtonWidgets;
 using System.Collections.Generic;
@@ -45,6 +46,8 @@ public class MapBuilder
     public MapBuilder WithLayer(AddLayer layerFactory)
         => WithLayer(layerFactory, (l) => { });
 
+    public MapBuilder WithPinWithCalloutLayer()
+        => WithLayer(CreatePinWithCalloutLayer, (l) => { });
 
     public MapBuilder WithMapCRS(string crs)
     {
@@ -87,4 +90,16 @@ public class MapBuilder
     public delegate IWidget AddWidget(Map map);
     public delegate void ConfigureLayer(ILayer layer);
     public delegate void ConfigureWidget(IWidget widget);
+
+    private MemoryLayer CreatePinWithCalloutLayer() => new()
+    {
+        Style = new SymbolStyle
+        {
+            ImageSource = $"embedded://Mapsui.Samples.Common.Images.arrow.svg",
+            SymbolOffset = new RelativeOffset(0.0, 0.5), // The point at the bottom should be at the location
+            SvgFillColor = Color.AliceBlue,
+            SvgStrokeColor = Color.Black,
+            SymbolScale = 0.5,
+        }
+    };
 }

--- a/Mapsui/MapBuilder.cs
+++ b/Mapsui/MapBuilder.cs
@@ -37,7 +37,7 @@ public class MapBuilder
         _layerFactories.Add((m) =>
         {
             var layer = layerFactory(m);
-            configureLayer?.Invoke(layer);
+            configureLayer?.Invoke(layer, m);
             return layer;
         });
         return this;
@@ -82,7 +82,7 @@ public class MapBuilder
     public delegate ILayer AddLayer(Map map);
     public delegate void ConfigureMap(Map map);
     public delegate IWidget AddWidget(Map map);
-    public delegate void ConfigureLayer(ILayer layer);
+    public delegate void ConfigureLayer(ILayer layer, Map map);
     public delegate void ConfigureWidget(IWidget widget);
     public delegate void TapFeature(Action<IFeature> tapFeature);
 }

--- a/Mapsui/Styles/CalloutStyle.cs
+++ b/Mapsui/Styles/CalloutStyle.cs
@@ -69,6 +69,9 @@ public class CalloutStyle : SymbolStyle
     private double _maxWidth;
     private Color? _titleFontColor;
     private Color? _subtitleFontColor;
+    private Font _titleFont = new();
+    private Font _subtitleFont = new();
+    private CalloutBalloonDefinition _balloonDefinition = new();
 
     public string ImageIdOfCallout { get; private set; } = Guid.NewGuid().ToString();
     public string ImageIdOfCalloutContent { get; private set; } = Guid.NewGuid().ToString();
@@ -232,10 +235,6 @@ public class CalloutStyle : SymbolStyle
             }
         }
     }
-
-    private Font _titleFont = new();
-    private Font _subtitleFont = new();
-    private CalloutBalloonDefinition _balloonDefinition = new();
 
     public Font TitleFont
     {

--- a/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
@@ -27,5 +27,6 @@ public class MapBuilderSample : ISample
             .WithMapCRS("EPSG:3857") // Should we have such specific methods or should the configure method be enough?
             .WithMapConfiguration(map => map.CRS = "EPSG:3857") // Does the same thing as the line above.
             .WithMapConfiguration(map => map.Navigator.CenterOnAndZoomTo(_sphericalMercatorCoordinate, 1222.99)) // Navigation is complex, because the Map is passed as argument the navigation methods could be called. Better to have specific builder methods for navigation.
+            .WithPinWithCalloutLayer()
             .Build());
 }

--- a/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
@@ -17,7 +17,8 @@ public class MapBuilderSample : ISample
     public Task<Map> CreateMapAsync()
         => Task.FromResult(new MapBuilder()
             .WithOpenStreetMapLayer((l) => l.Name = "OpenStreetMap")
-            .WithLayer(() => new MemoryLayer("Pin Layer") { Features = [new PointFeature(_sphericalMercatorCoordinate)], Style = SymbolStyles.CreatePinStyle() })
+            .WithLayer((map) => new MemoryLayer("Pin Layer") { Features = [new PointFeature(_sphericalMercatorCoordinate)], Style = SymbolStyles.CreatePinStyle() })
+            .WithPinWithCalloutLayer([new PointFeature(_sphericalMercatorCoordinate) { ["Name"] = "Hello!" }])
             .WithZoomButtons()
             .WithScaleBarWidget(w =>
                 {
@@ -27,6 +28,5 @@ public class MapBuilderSample : ISample
             .WithMapCRS("EPSG:3857") // Should we have such specific methods or should the configure method be enough?
             .WithMapConfiguration(map => map.CRS = "EPSG:3857") // Does the same thing as the line above.
             .WithMapConfiguration(map => map.Navigator.CenterOnAndZoomTo(_sphericalMercatorCoordinate, 1222.99)) // Navigation is complex, because the Map is passed as argument the navigation methods could be called. Better to have specific builder methods for navigation.
-            .WithPinWithCalloutLayer()
             .Build());
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Navigation/MyLocationLayerSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Navigation/MyLocationLayerSample.cs
@@ -11,7 +11,6 @@ public class MyLocationLayerSample : ISample, IDisposable
 {
     private MyLocationLayer? _myLocationLayer;
     private bool _disposed;
-    private (MPoint, double, double, double, bool, bool, bool)[] _points = new (MPoint, double, double, double, bool, bool, bool)[0];
     private int _count = 0;
 
     public string Name => "MyLocationLayer";
@@ -33,7 +32,7 @@ public class MyLocationLayerSample : ISample, IDisposable
 
         // Get the lon lat coordinates from somewhere (Mapsui can not help you there)
         var centerOfLondonOntario = new MPoint(-81.2497, 42.9837);
-        // OSM uses spherical mercator coordinates. So transform the lon lat coordinates to spherical mercator
+        // OSM uses spherical Mercator coordinates. So transform the lon lat coordinates to spherical Mercator
         var sphericalMercatorCoordinate = SphericalMercator.FromLonLat(centerOfLondonOntario.X, centerOfLondonOntario.Y).ToMPoint();
         // Set the center of the viewport to the coordinate. The UI will refresh automatically
         // Additionally you might want to set the resolution, this could depend on your specific purpose
@@ -41,19 +40,19 @@ public class MyLocationLayerSample : ISample, IDisposable
 
         _myLocationLayer.UpdateMyLocation(sphericalMercatorCoordinate, true);
 
-        _points = CreatePoints(centerOfLondonOntario);
+        var points = CreatePoints(centerOfLondonOntario);
 
         map.Info += (s, e) =>
         {
             if (_count >= 20)
                 _count = 0;
 
-            _myLocationLayer.IsCentered = _points[_count].Item5;
-            _myLocationLayer.IsMoving = _points[_count].Item6;
-            _myLocationLayer.UpdateMyLocation(_points[_count].Item1, _points[_count].Item7);
-            _myLocationLayer.UpdateMyDirection(_points[_count].Item2, map.Navigator.Viewport.Rotation, _points[_count].Item7);
-            _myLocationLayer.UpdateMyViewDirection(_points[_count].Item3, map.Navigator.Viewport.Rotation, _points[_count].Item7);
-            _myLocationLayer.UpdateMySpeed(_points[_count].Item4);
+            _myLocationLayer.IsCentered = points[_count].Item5;
+            _myLocationLayer.IsMoving = points[_count].Item6;
+            _myLocationLayer.UpdateMyLocation(points[_count].Item1, points[_count].Item7);
+            _myLocationLayer.UpdateMyDirection(points[_count].Item2, map.Navigator.Viewport.Rotation, points[_count].Item7);
+            _myLocationLayer.UpdateMyViewDirection(points[_count].Item3, map.Navigator.Viewport.Rotation, points[_count].Item7);
+            _myLocationLayer.UpdateMySpeed(points[_count].Item4);
 
             _count++;
         };
@@ -61,7 +60,7 @@ public class MyLocationLayerSample : ISample, IDisposable
         return Task.FromResult(map);
     }
 
-    private (MPoint, double, double, double, bool, bool, bool)[] CreatePoints(MPoint center)
+    private static (MPoint, double, double, double, bool, bool, bool)[] CreatePoints(MPoint center)
     {
         var result = new (MPoint, double, double, double, bool, bool, bool)[20];
         var rand = new Random();


### PR DESCRIPTION
Investigating to allow a simpler way to add callout through the builder. Several questions and related issues come up while working on this:

- The IsInfoLayer field is annoying. Let's investigate to fetch the layer info actively in the Info event. So, it is the users call which determines which layers are fetched in MapInfo.
- The string indexer on IFeature to get data (`["bla"]`) becomes clumsy when building more advanced functionality like this. Perhaps it is time to look into the idea to add a Data field of type object which could be cast to a specific type in user code.
- We have to pass the Map object along several method calls because we need the (Map)Info event. I am thinking of an easier way. Perhaps we need some tap event on Style. Or pass in a style tap event in the builder methods.
- A callout's purpose is to shows feature specific information. The text if different for different features, that is why you want to see it. This is why you almost always need to nest the CalloutStyle in ThemeStyle. Perhaps the CalloutStyle (or a variant of the callout style) should have ThemeStyle method built in.
- A layer should have Styles instead of a Style so that you do not have to use a StyleCollection all the time. This is a big change.
- An alternative would be composed styles, with the CalloutStyle as a child style of the SymbolStyle. So, any feature would become a StyleCollection. We should make sure the VisualFeatureIterator works correctly with this. 
- The CalloutStyle defaults could be better so less fields need initialization (the title font color is white on a white background).