### PR TITLE
Blazor: Update vulnerable Microsoft.AspNetCore.Components.Web 6.0.0 to 8.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,6 +50,7 @@
     <PackageVersion Include="Mapsui.Uno.WinUI" Version="5.0.0-beta.1" />
     <PackageVersion Include="Mapsui.WinUI" Version="5.0.0-beta.1" />
     <PackageVersion Include="Mapsui.Wpf" Version="5.0.0-beta.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.11.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[8.0.0,9.0.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj
+++ b/Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj
@@ -17,6 +17,7 @@
 
 	<ItemGroup>
     <PackageReference Include="SkiaSharp.Views.Blazor" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
     <PackageReference Include="DotNext.Threading" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />

--- a/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
+++ b/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="SkiaSharp.Views.Blazor" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" VersionOverride="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" VersionOverride="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" VersionOverride="8.0.0" PrivateAssets="all" />
 		<!--still needed for direct project reference the nuget package of blazor doesn't need this anymore-->


### PR DESCRIPTION
Microsoft.AspNetCore.Components.Web in version 6.0.0 is a dependency of SkiaSharp.Views.Blazor So explicilty referencing Version 8.0.0 to avoid the warning