### PR TITLE
Update: Uno.Sdk to 5.5.49 for .NET 9 support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="DotSpatial.Projections" Version="[4.0.656,5.0.0)" />
     <PackageVersion Include="CommunityToolkit.Maui.Markup" Version="[1.0.0,2.0.0)" />
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="[7.1.2,8.0.0)" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.3.2" />
     <PackageVersion Include="DotNext.Threading" Version="[4.9.0,5.0.0)" />
     <PackageVersion Include="Eto.Forms" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.Platform.Wpf" Version="[2.8.0,3.0.0)" />

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -31,6 +31,15 @@
     <UnoFeatures>
     </UnoFeatures>
   </PropertyGroup>
+
+  <!--workaround for Uno.Resizetizer uses a newer skiasharp version then maui resizetizer -->
+  <ItemGroup>
+    <PackageReference Include="Uno.Resizetizer" VersionOverride="1.5.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI"/>
     <ProjectReference Include="..\..\..\Mapsui.UI.Uno.WinUI\Mapsui.UI.Uno.WinUI.csproj" />

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -35,11 +35,6 @@
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI"/>
     <ProjectReference Include="..\..\..\Mapsui.UI.Uno.WinUI\Mapsui.UI.Uno.WinUI.csproj" />
     <ProjectReference Include="..\..\..\Tests\Mapsui.Tests.Common\Mapsui.Tests.Common.csproj" />
-    <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(TargetFramework.Contains('windows'))">
-    <PackageReference Include="System.IO.Packaging" VersionOverride="9.0.0" />
-  </ItemGroup>
+    <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" /></ItemGroup>
 
 </Project>

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI"/>
     <ProjectReference Include="..\..\..\Mapsui.UI.Uno.WinUI\Mapsui.UI.Uno.WinUI.csproj" />
     <ProjectReference Include="..\..\..\Tests\Mapsui.Tests.Common\Mapsui.Tests.Common.csproj" />
-    <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" /></ItemGroup>
+    <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
-    "Uno.Sdk": "5.3.108"
+    "Uno.Sdk": "5.5.49"
   }
 }


### PR DESCRIPTION
Updated Uno.sdk to 5.5.49 
Updated CommunityToolkit.Mvvm to 8.3.2 (Dependency)