### PR TITLE
Improve logging in map

### DIFF
--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -69,6 +69,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 #pragma warning restore IDISP002
     private readonly TapGestureTracker _tapGestureTracker = new();
     private readonly FlingTracker _flingTracker = new();
+    private static bool _firstRender = true;
 
     /// <summary>
     /// The movement allowed between a touch down and touch up in a touch gestures in device independent pixels.
@@ -99,6 +100,12 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         if (Renderer is null) return;
         if (Map is null) return;
         if (!Map.Navigator.Viewport.HasSize()) return;
+
+        if (_firstRender)
+        {
+            _firstRender = false;
+            Logger.Log(LogLevel.Information, $"First call to the Mapsui renderer");
+        }
 
         // Start drawing
         _drawing = true;

--- a/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
@@ -8,9 +8,20 @@ namespace Mapsui.Widgets.InfoWidgets;
 
 public enum ShowLoggingInMap
 {
-    WhenLoggingWidgetIsEnabled,
-    WhenLoggingWidgetIsEnabledAndDebuggerIsAttached,
-    Never,
+    /// <summary>
+    /// Show logging in the map. Note, this only has effect if LoggingWidget.Enabled == true.
+    /// </summary>
+    Yes,
+    /// <summary>
+    /// Show logging in the map only if the debugger is attached. Note, this is independent of a debug build.
+    /// You can attach a debugger to a release build and it will show logging, or run a debug build without
+    /// a debugger attached and it won't show logging.
+    /// </summary>
+    ShowOnlyInDebugMode,
+    /// <summary>
+    /// Never show logging in the map.
+    /// </summary>
+    No,
 }
 
 /// <summary>
@@ -46,7 +57,7 @@ public class LoggingWidget : TextBoxWidget
     /// Enabled field of the logging widget is false.
     /// </summary>
     public static ShowLoggingInMap ShowLoggingInMap { get; set; }
-        = ShowLoggingInMap.WhenLoggingWidgetIsEnabledAndDebuggerIsAttached;
+        = ShowLoggingInMap.ShowOnlyInDebugMode;
 
     /// <summary>
     ///  Event handler for logging
@@ -168,9 +179,9 @@ public class LoggingWidget : TextBoxWidget
     private static bool ShouldLog(bool enabled, ShowLoggingInMap showLoggingInMap) =>
         enabled && showLoggingInMap switch
         {
-            ShowLoggingInMap.WhenLoggingWidgetIsEnabled => true,
-            ShowLoggingInMap.Never => false,
-            ShowLoggingInMap.WhenLoggingWidgetIsEnabledAndDebuggerIsAttached => System.Diagnostics.Debugger.IsAttached,
+            ShowLoggingInMap.Yes => true,
+            ShowLoggingInMap.No => false,
+            ShowLoggingInMap.ShowOnlyInDebugMode => System.Diagnostics.Debugger.IsAttached,
             _ => throw new NotSupportedException(nameof(InfoWidgets.ShowLoggingInMap))
         };
 }

--- a/Samples/Mapsui.Samples.Blazor/Pages/Index.razor.cs
+++ b/Samples/Mapsui.Samples.Blazor/Pages/Index.razor.cs
@@ -61,7 +61,7 @@ public partial class Index
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        LoggingWidget.ShowLoggingInMap = ShowLoggingInMap.WhenLoggingWidgetIsEnabled; // To show logging in release mode
+        LoggingWidget.ShowLoggingInMap = ShowLoggingInMap.Yes; // To show logging in release mode
         FillComboBoxWithCategories();
     }
 

--- a/Tests/Mapsui.Rendering.Skia.Tests/MapLiveTests.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/MapLiveTests.cs
@@ -59,7 +59,7 @@ public class MapLiveTests
             Logger.LogDelegate = ConsoleLog;
             // At the moment of writing this comment we do not have logging in the map. To compare
             // images we disable it for now. Perhaps we want logging to be part of the test image in some cases.
-            LoggingWidget.ShowLoggingInMap = ShowLoggingInMap.Never;
+            LoggingWidget.ShowLoggingInMap = ShowLoggingInMap.No;
             ConsoleLog(LogLevel.Debug, $"Start MapLiveTest {sample.GetType().Name}", null);
             await TestSampleAsync(sample).ConfigureAwait(false);
         }

--- a/Tests/Mapsui.Rendering.Skia.Tests/MapRegressionTests.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/MapRegressionTests.cs
@@ -69,7 +69,7 @@ public class MapRegressionTests
             Logger.LogDelegate = SampleHelper.ConsoleLog;
             // At the moment of writing this comment we do not have logging in the map. To compare
             // images we disable it for now. Perhaps we want logging to be part of the test image in some cases.
-            LoggingWidget.ShowLoggingInMap = ShowLoggingInMap.Never;
+            LoggingWidget.ShowLoggingInMap = ShowLoggingInMap.No;
             SampleHelper.ConsoleLog(LogLevel.Debug, $"Start MapRegressionTest {sample.GetType().Name}", null);
             await TestSampleAsync(sample, true).ConfigureAwait(false);
         }

--- a/docs/general/markdown/logging.md
+++ b/docs/general/markdown/logging.md
@@ -34,3 +34,14 @@ This is an example of how to forward Mapsui logging to the de facto standard ```
     }
 ```
 
+### Show logging in the map
+
+It is possible to show all Mapsui logging in the map. By default this shows only if the debugger is attached. In most 
+scenarios this is what you want and you don't have to change anything for a release of your app. You could change the 
+logging behavior by setting the static `LoggingWidget.ShowLoggingInMap` to `Yes`, `No` or `ShowOnlyInDebugMode` (the 
+default). 
+
+Logging in the map is implemented through the LoggingWidget which is added by default to the Map class. Usually you
+can just leave it there. If you remove or disable it no logging will be shown in the map.
+
+If you have two maps in your app both will show all Mapsui logging.


### PR DESCRIPTION
This PR was triggered by this issue: https://github.com/Mapsui/Mapsui/issues/2812

- It now shows a log line at the first rendering. I would like it to contain the version number but if I add this the version number should come from the version git tag, not the properties in directory.build.props.
- The fields of the enum we use in the static ShowLoggingInMap are changed to Yes, No, ShowOnlyInDebugMode.
- The api documentation of those fields was updated.
- The logging documentation page was updated for 'show logging in map'.
