### PR TITLE
Fixed Obsolete SKFilterQuality

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaStyles/BitmapRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/BitmapRenderer.cs
@@ -8,12 +8,13 @@ internal class BitmapRenderer
 {
     // The field below is static for performance. Effect has not been measured.
     // Note that the default FilterQuality is None. Setting it explicitly to Low increases the quality.
-    private static readonly SKPaint DefaultPaint = new() { FilterQuality = SKFilterQuality.Low };
+    private static readonly SKPaint DefaultPaint = new();
+    private static readonly SKSamplingOptions DefaultSamplingOptions = new(SKFilterMode.Linear, SKMipmapMode.None);
 
     public static void Draw(SKCanvas canvas, SKImage bitmap, SKRect rect, float layerOpacity = 1f)
     {
         var skPaint = GetPaint(layerOpacity, out var dispose);
-        canvas.DrawImage(bitmap, rect, skPaint);
+        canvas.DrawImage(bitmap, rect, DefaultSamplingOptions, skPaint);
         if (dispose)
             skPaint.Dispose();
     }
@@ -76,7 +77,6 @@ internal class BitmapRenderer
             dispose = true;
             return new SKPaint
             {
-                FilterQuality = SKFilterQuality.Low,
                 Color = new SKColor(255, 255, 255, (byte)(255 * layerOpacity))
             };
         }

--- a/Mapsui.Rendering.Skia/SkiaStyles/PictureRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/PictureRenderer.cs
@@ -10,7 +10,7 @@ internal class PictureRenderer
 {
     // The field below is static for performance. Effect has not been measured.
     // Note that setting the FilterQuality to Low increases the quality because the default is None.
-    private static readonly SKPaint DefaultPaint = new() { FilterQuality = SKFilterQuality.Low };
+    private static readonly SKPaint DefaultPaint = new();
 
     [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP001:Dispose created")]
     public static void Draw(SKCanvas canvas, SKPicture picture, SKRect rect, float layerOpacity = 1f, Color? blendModeColor = null)


### PR DESCRIPTION
Fixed Obsoletion of SkFilterQuality.Low

Logic for correct settings i found here

```
public static partial class SkiaExtensions
{
	[Obsolete ($"Use {nameof (SKSamplingOptions)} instead.")]
	public static SKSamplingOptions ToSamplingOptions (this SKFilterQuality quality) =>
		quality switch {
			SKFilterQuality.None => new SKSamplingOptions (SKFilterMode.Nearest, SKMipmapMode.None),
			SKFilterQuality.Low => new SKSamplingOptions (SKFilterMode.Linear, SKMipmapMode.None),
			SKFilterQuality.Medium => new SKSamplingOptions (SKFilterMode.Linear, SKMipmapMode.Linear),
			SKFilterQuality.High => new SKSamplingOptions (SKCubicResampler.Mitchell),
			_ => throw new ArgumentOutOfRangeException (nameof (quality), $"Unknown filter quality: '{quality}'"),
		};
}
```