### PR TITLE
Dependency: Update Avalonia to 11.2.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,16 +6,16 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.2.1" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.2.1" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.2.1" />
-    <PackageVersion Include="Avalonia.Browser" Version="11.2.1" />
-    <PackageVersion Include="Avalonia.Android" Version="11.2.1" />
-    <PackageVersion Include="Avalonia.iOS" Version="11.2.1" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.1" />
-    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.2.1" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.1" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.1" />
+    <PackageVersion Include="Avalonia" Version="11.2.2" />
+    <PackageVersion Include="Avalonia.Skia" Version="11.2.2" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.2.2" />
+    <PackageVersion Include="Avalonia.Browser" Version="11.2.2" />
+    <PackageVersion Include="Avalonia.Android" Version="11.2.2" />
+    <PackageVersion Include="Avalonia.iOS" Version="11.2.2" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.2" />
+    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.2.2" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.2" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="[0.13.9,1.0.0)" />
     <PackageVersion Include="BitMiracle.LibTiff.NET" Version="[2.4.649,3.0.0)" />
     <PackageVersion Include="BruTile" Version="[6.0.0-beta.3,7.0)" />


### PR DESCRIPTION
Update Avalonia because SkiaSharp Dependency was updated to a newer version 2.88.9