### PR TITLE
Fix bug in snapping steps if the ZoomBounds have a wider range then the Resolutions.

### DIFF
--- a/Mapsui/Utilities/ZoomHelper.cs
+++ b/Mapsui/Utilities/ZoomHelper.cs
@@ -18,11 +18,12 @@ public static class ZoomHelper
 
         for (var i = 0; i < resolutions.Count; i++)
         {
-            // Is there a snap resolution smaller or equal?
-            if (resolutions[i] <= (newResolution - double.Epsilon))
-            {
+            if (resolutions[i] > (newResolution - double.Epsilon))
+                continue; // Ignore bigger snap resolutions
+
+            // The resolutions increase in multiples of two, so we need to take log2 for the difference comparison.
+            if (Math.Log2(newResolution) - Math.Log2(resolutions[i]) < 0.5)
                 return resolutions[i];
-            }
         }
 
         // No snapping, return as calculated.
@@ -38,11 +39,12 @@ public static class ZoomHelper
 
         for (var i = resolutions.Count - 1; i >= 0; i--)
         {
-            // Is there a snap resolution bigger or equal?
-            if (resolutions[i] >= (newResolution + double.Epsilon))
-            {
+            if (resolutions[i] < (newResolution + double.Epsilon))
+                continue; // Ignore smaller snap resolutions
+
+            // The resolutions increase in multiples of two, so we need to take log2 for the difference comparison.
+            if (Math.Log2(resolutions[i] - Math.Log2(newResolution)) < 0.5)
                 return resolutions[i];
-            }
         }
 
         // No snapping, return as calculated.
@@ -55,18 +57,13 @@ public static class ZoomHelper
         var widthResolution = worldWidth / screenWidth;
         var heightResolution = worldHeight / screenHeight;
 
-        switch (boxFit)
+        return boxFit switch
         {
-            case MBoxFit.FitHeight:
-                return heightResolution;
-            case MBoxFit.FitWidth:
-                return widthResolution;
-            case MBoxFit.Fill:
-                return Math.Min(widthResolution, heightResolution);
-            case MBoxFit.Fit:
-                return Math.Max(widthResolution, heightResolution);
-            default:
-                throw new Exception("BoxFit not supported");
-        }
+            MBoxFit.FitHeight => heightResolution,
+            MBoxFit.FitWidth => widthResolution,
+            MBoxFit.Fill => Math.Min(widthResolution, heightResolution),
+            MBoxFit.Fit => Math.Max(widthResolution, heightResolution),
+            _ => throw new Exception("BoxFit not supported"),
+        };
     }
 }

--- a/Mapsui/Utilities/ZoomHelper.cs
+++ b/Mapsui/Utilities/ZoomHelper.cs
@@ -11,30 +11,42 @@ public static class ZoomHelper
 {
     public static double GetResolutionToZoomIn(IReadOnlyList<double>? resolutions, double resolution)
     {
-        if (resolutions == null || resolutions.Count == 0) return resolution / 2.0;
+        var newResolution = resolution / 2.0;
 
-        foreach (var t in resolutions)
+        if (resolutions == null || resolutions.Count == 0)
+            return newResolution; // No snapping possible. Return as calculated.
+
+        for (var i = 0; i < resolutions.Count; i++)
         {
-            // If there is a smaller resolution in the array return it
-            if (t < resolution - double.Epsilon) return t;
+            // Is there a resolution higher are equal (taking into account a margin of epsilon)?
+            if (resolutions[i] <= (newResolution - double.Epsilon))
+            {
+                return resolutions[i];
+            }
         }
 
-        // Else return half of the current resolution
-        return resolution / 2.0;
+        // No snapping, return as calculated.
+        return newResolution;
     }
 
     public static double GetResolutionToZoomOut(IReadOnlyList<double>? resolutions, double resolution)
     {
-        if (resolutions == null || resolutions.Count == 0) return resolution * 2.0;
+        var newResolution = resolution * 2.0;
+
+        if (resolutions == null || resolutions.Count == 0)
+            return newResolution;  // No snapping possible. Return as calculated.
 
         for (var i = resolutions.Count - 1; i >= 0; i--)
         {
-            // If there is a bigger resolution in the array return it
-            if (resolutions[i] > (resolution + double.Epsilon)) return resolutions[i];
+            // Is there a resolution smaller are equal (taking into account a margin of epsilon)?
+            if (resolutions[i] >= (newResolution + double.Epsilon))
+            {
+                return resolutions[i];
+            }
         }
 
-        // Else return double the current resolution
-        return resolution * 2.0;
+        // No snapping, return as calculated.
+        return newResolution;
     }
 
     public static double CalculateResolutionForWorldSize(double worldWidth, double worldHeight, double screenWidth,

--- a/Mapsui/Utilities/ZoomHelper.cs
+++ b/Mapsui/Utilities/ZoomHelper.cs
@@ -18,7 +18,7 @@ public static class ZoomHelper
 
         for (var i = 0; i < resolutions.Count; i++)
         {
-            // Is there a resolution higher are equal (taking into account a margin of epsilon)?
+            // Is there a snap resolution smaller or equal?
             if (resolutions[i] <= (newResolution - double.Epsilon))
             {
                 return resolutions[i];
@@ -38,7 +38,7 @@ public static class ZoomHelper
 
         for (var i = resolutions.Count - 1; i >= 0; i--)
         {
-            // Is there a resolution smaller are equal (taking into account a margin of epsilon)?
+            // Is there a snap resolution bigger or equal?
             if (resolutions[i] >= (newResolution + double.Epsilon))
             {
                 return resolutions[i];

--- a/Tests/Mapsui.Tests/Utilities/ZoomHelperTests.cs
+++ b/Tests/Mapsui.Tests/Utilities/ZoomHelperTests.cs
@@ -1,0 +1,126 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using Mapsui.Utilities;
+
+namespace Mapsui.Tests.Utilities;
+
+[TestFixture]
+public class ZoomHelperTests
+{
+    [Test]
+    public void CalculateResolutionForWorldSize_FitWidth_ReturnsWidthResolution()
+    {
+        // Arrange
+        double worldWidth = 1000.0;
+        double worldHeight = 500.0;
+        double screenWidth = 100.0;
+        double screenHeight = 50.0;
+
+        // Act
+        double result = ZoomHelper.CalculateResolutionForWorldSize(worldWidth, worldHeight, screenWidth, screenHeight, MBoxFit.FitWidth);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(10.0));
+    }
+
+    [Test]
+    public void CalculateResolutionForWorldSize_FitHeight_ReturnsHeightResolution()
+    {
+        // Arrange
+        double worldWidth = 1000.0;
+        double worldHeight = 500.0;
+        double screenWidth = 100.0;
+        double screenHeight = 50.0;
+
+        // Act
+        double result = ZoomHelper.CalculateResolutionForWorldSize(worldWidth, worldHeight, screenWidth, screenHeight, MBoxFit.FitHeight);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(10.0));
+    }
+
+    [Test]
+    public void CalculateResolutionForWorldSize_Fill_ReturnsMinResolution()
+    {
+        // Arrange
+        double worldWidth = 1000.0;
+        double worldHeight = 500.0;
+        double screenWidth = 100.0;
+        double screenHeight = 50.0;
+
+        // Act
+        double result = ZoomHelper.CalculateResolutionForWorldSize(worldWidth, worldHeight, screenWidth, screenHeight, MBoxFit.Fill);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(10.0));
+    }
+
+    [Test]
+    public void CalculateResolutionForWorldSize_Fit_ReturnsMaxResolution()
+    {
+        // Arrange
+        double worldWidth = 1000.0;
+        double worldHeight = 500.0;
+        double screenWidth = 100.0;
+        double screenHeight = 50.0;
+
+        // Act
+        double result = ZoomHelper.CalculateResolutionForWorldSize(worldWidth, worldHeight, screenWidth, screenHeight, MBoxFit.Fit);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(10.0));
+    }
+
+    [Test]
+    public void GetResolutionToZoomIn_NoResolutions_ReturnsHalfResolution()
+    {
+        // Arrange
+        double resolution = 100.0;
+
+        // Act
+        double result = ZoomHelper.GetResolutionToZoomIn(null, resolution);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(50.0));
+    }
+
+    [Test]
+    public void GetResolutionToZoomOut_NoResolutions_ReturnsDoubleResolution()
+    {
+        // Arrange
+        double resolution = 100.0;
+
+        // Act
+        double result = ZoomHelper.GetResolutionToZoomOut(null, resolution);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(200.0));
+    }
+
+    [TestCase(100, 50)]
+    public void GetResolutionToZoomIn_WithResolutions_ReturnsSnappedResolution(double resolution, double expected)
+    {
+        // Arrange
+        var resolutions = new List<double> { 400.0, 200.0, 100.0 };
+
+        // Act
+        double result = ZoomHelper.GetResolutionToZoomIn(resolutions, resolution);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+
+    [TestCase(100, 200)]
+    public void GetResolutionToZoomOut_WithResolutions_ReturnsSnappedResolution(double resolution, double expected)
+    {
+        // Arrange
+        var resolutions = new List<double> { 400.0, 200.0, 100.0 };
+
+        // Act
+        double result = ZoomHelper.GetResolutionToZoomOut(resolutions, resolution);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(expected));
+    }
+}

--- a/Tests/Mapsui.Tests/Utilities/ZoomHelperTests.cs
+++ b/Tests/Mapsui.Tests/Utilities/ZoomHelperTests.cs
@@ -97,11 +97,16 @@ public class ZoomHelperTests
         Assert.That(result, Is.EqualTo(200.0));
     }
 
-    [TestCase(100, 50)]
+    [TestCase(6400, 3200)] // Zoom before list
+    [TestCase(3200, 1600)] // Zoom onto list
+    [TestCase(1600, 800)] // Zoom within list
+    [TestCase(800, 400)] // Zoom within list
+    [TestCase(400, 200)] // Zoom past list
+    [TestCase(200, 100)] // Zoom far past list
     public void GetResolutionToZoomIn_WithResolutions_ReturnsSnappedResolution(double resolution, double expected)
     {
         // Arrange
-        var resolutions = new List<double> { 400.0, 200.0, 100.0 };
+        var resolutions = new List<double> { 1600.0, 800, 400.0 };
 
         // Act
         double result = ZoomHelper.GetResolutionToZoomIn(resolutions, resolution);
@@ -110,12 +115,16 @@ public class ZoomHelperTests
         Assert.That(result, Is.EqualTo(expected));
     }
 
-
-    [TestCase(100, 200)]
+    [TestCase(100, 200)] // Zoom before list
+    [TestCase(200, 400)] // Zoom onto list
+    [TestCase(400, 800)] // Zoom within list
+    [TestCase(800, 1600)] // Zoom within list
+    [TestCase(1600, 3200)] // Zoom past list
+    [TestCase(3200, 6400)] // Zoom far past list
     public void GetResolutionToZoomOut_WithResolutions_ReturnsSnappedResolution(double resolution, double expected)
     {
         // Arrange
-        var resolutions = new List<double> { 400.0, 200.0, 100.0 };
+        var resolutions = new List<double> { 1600.0, 800, 400.0 };
 
         // Act
         double result = ZoomHelper.GetResolutionToZoomOut(resolutions, resolution);


### PR DESCRIPTION
This bug shows when the ZoomBounds are set to a wider range than the Resolutions to snap to. When you zoom in beyond the the snap resolutions it takes steps of x2 as expected. If you zoom out it immediately snaps back to the nearest resolution.

This is fixed by doing an log2 distance compare in the ZoomHelper. 

Unit tests are added for the failing cases.