### PR TITLE
Make styleRenderers and widgetRenderers static 

### DIFF
--- a/Mapsui.Tiling/Provider/RasterizingTileSource.cs
+++ b/Mapsui.Tiling/Provider/RasterizingTileSource.cs
@@ -8,6 +8,7 @@ using BruTile.Cache;
 using BruTile.Predefined;
 using Mapsui.Extensions;
 using Mapsui.Layers;
+using Mapsui.Logging;
 using Mapsui.Manipulations;
 using Mapsui.Projections;
 using Mapsui.Providers;
@@ -161,7 +162,7 @@ public class RasterizingTileSource : ILocalTileSource, ILayerFeatureInfo
             var layerStyles = _layer.Style.GetStylesToApply(section.Resolution);
             foreach (var style in layerStyles)
             {
-                if (renderer.StyleRenderers.TryGetValue(style.GetType(), out var styleRenderer))
+                if (renderer.TryGetStyleRenderer(style.GetType(), out var styleRenderer))
                 {
                     if (styleRenderer is IFeatureSize featureSize)
                     {
@@ -178,6 +179,8 @@ public class RasterizingTileSource : ILocalTileSource, ILayerFeatureInfo
                             tempSize = featureSize.FeatureSize(style, renderer.RenderService, null);
                         }
                     }
+                    else
+                        Logger.Log(LogLevel.Warning, $"No StyleRenderer found for {style.GetType()}");
                 }
             }
 

--- a/Mapsui/Rendering/IRenderer.cs
+++ b/Mapsui/Rendering/IRenderer.cs
@@ -14,8 +14,8 @@ public interface IRenderer : IDisposable
     MemoryStream RenderToBitmapStream(Viewport viewport, IEnumerable<ILayer> layers,
         Color? background = null, float pixelDensity = 1, IEnumerable<IWidget>? widgets = null, RenderFormat renderFormat = RenderFormat.Png, int quality = 100);
     IRenderService RenderService { get; }
-    IDictionary<Type, IWidgetRenderer> WidgetRenders { get; }
-    IDictionary<Type, IStyleRenderer> StyleRenderers { get; }
+    bool TryGetWidgetRenderer(Type widgetType, out IWidgetRenderer? widgetRenderer);
+    bool TryGetStyleRenderer(Type widgetType, out IStyleRenderer? widgetRenderer);
     ImageSourceCache ImageSourceCache { get; }
     MapInfo GetMapInfo(ScreenPosition screenPosition, Viewport viewport, IEnumerable<ILayer> layers, int margin = 0);
 

--- a/Samples/Avalonia/Mapsui.Samples.Avalonia/Views/MainView.axaml.cs
+++ b/Samples/Avalonia/Mapsui.Samples.Avalonia/Views/MainView.axaml.cs
@@ -1,13 +1,11 @@
-using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Mapsui.Extensions;
 using Mapsui.Samples.Common;
 using Mapsui.Samples.Common.Extensions;
-
 using Mapsui.Tiling;
-using Mapsui.Samples.Common.Maps.Widgets;
+using System.Linq;
 
 namespace Mapsui.Samples.Avalonia.Views;
 
@@ -30,7 +28,6 @@ public partial class MainView : UserControl
 
         MapControl.Map.Layers.Add(OpenStreetMap.CreateTileLayer());
         MapControl.Map.Navigator.RotationLock = false;
-        MapControl.Renderer.WidgetRenders[typeof(CustomWidget)] = new CustomWidgetSkiaRenderer();
 
         RotationSlider.PointerMoved += RotationSliderOnPointerMoved;
 

--- a/Samples/Mapsui.Samples.Blazor/Pages/Index.razor.cs
+++ b/Samples/Mapsui.Samples.Blazor/Pages/Index.razor.cs
@@ -2,7 +2,6 @@
 using Mapsui.Extensions;
 using Mapsui.Samples.Common;
 using Mapsui.Samples.Common.Extensions;
-using Mapsui.Samples.Common.Maps.Widgets;
 using Mapsui.UI.Blazor;
 using Mapsui.Widgets.InfoWidgets;
 using Microsoft.AspNetCore.Components;
@@ -72,8 +71,6 @@ public partial class Index
         {
             _render = false;
             FillMap();
-            if (_mapControl != null)
-                _mapControl.Renderer.WidgetRenders[typeof(CustomWidget)] = new CustomWidgetSkiaRenderer();
         }
     }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
@@ -27,13 +27,12 @@ public class CustomCalloutStyleSample : IMapControlSample
     public void Setup(IMapControl mapControl)
     {
         mapControl.Map = CreateMap();
-
-        if (mapControl.Renderer is MapRenderer && !mapControl.Renderer.StyleRenderers.ContainsKey(typeof(CustomCalloutStyle)))
-            mapControl.Renderer.StyleRenderers.Add(typeof(CustomCalloutStyle), new CustomCalloutStyleRenderer());
     }
 
     public static Map CreateMap()
     {
+        MapRenderer.RegisterStyleRenderer(typeof(CustomCalloutStyle), new CustomCalloutStyleRenderer());
+
         var map = new Map();
 
         map.Layers.Add(OpenStreetMap.CreateTileLayer());

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/CustomStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/CustomStyleSample.cs
@@ -1,5 +1,6 @@
 ﻿using Mapsui.Extensions;
 using Mapsui.Layers;
+using Mapsui.Rendering.Skia;
 using Mapsui.Rendering.Skia.Cache;
 using Mapsui.Rendering.Skia.SkiaStyles;
 using Mapsui.Samples.Common.DataBuilders;
@@ -60,13 +61,12 @@ public class CustomStyleSample : IMapControlSample
     public void Setup(IMapControl mapControl)
     {
         mapControl.Map = CreateMap();
-
-        if (mapControl.Renderer is Rendering.Skia.MapRenderer && !mapControl.Renderer.StyleRenderers.ContainsKey(typeof(CustomStyle)))
-            mapControl.Renderer.StyleRenderers.Add(typeof(CustomStyle), new SkiaCustomStyleRenderer());
     }
 
     public static Map CreateMap()
     {
+        MapRenderer.RegisterStyleRenderer(typeof(CustomStyle), new SkiaCustomStyleRenderer());
+
         var map = new Map();
 
         map.Layers.Add(OpenStreetMap.CreateTileLayer());

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
@@ -9,6 +9,7 @@ using System;
 using System.Threading.Tasks;
 using Mapsui.Rendering.Skia.Extensions;
 using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Rendering.Skia;
 
 namespace Mapsui.Samples.Common.Maps.Widgets;
 
@@ -20,6 +21,8 @@ public class CustomWidgetSample : ISample
 
     public Task<Map> CreateMapAsync()
     {
+        MapRenderer.RegisterWidgetRenderer(typeof(CustomWidget), new CustomWidgetSkiaRenderer());
+
         var map = new Map();
 
         map.Layers.Add(OpenStreetMap.CreateTileLayer());

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/PerformanceWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/PerformanceWidgetSample.cs
@@ -1,5 +1,6 @@
 ﻿using BruTile.Predefined;
 using Mapsui.Extensions;
+using Mapsui.Rendering.Skia;
 using Mapsui.Rendering.Skia.SkiaWidgets;
 using Mapsui.Samples.Common.PersistentCaches;
 using Mapsui.Styles;
@@ -27,9 +28,8 @@ public class PerformanceWidgetSample : IMapControlSample
         var widget = CreatePerformanceWidget();
         mapControl.Map.Widgets.Add(widget);
         mapControl.Performance = _performance;
-        mapControl.Renderer.WidgetRenders[typeof(PerformanceWidget)] = new PerformanceWidgetRenderer();
+        MapRenderer.RegisterWidgetRenderer(typeof(PerformanceWidget), new PerformanceWidgetRenderer());
     }
-
 
     public static Map CreateMap()
     {

--- a/Samples/Mapsui.Samples.Droid/MainActivity.cs
+++ b/Samples/Mapsui.Samples.Droid/MainActivity.cs
@@ -6,7 +6,6 @@ using Mapsui.Samples.Common.Extensions;
 using Mapsui.UI.Android;
 using Mapsui.Samples.Common.Maps.DataFormats;
 using Mapsui.Samples.Common.Maps.Demo;
-using Mapsui.Samples.Common.Maps.Widgets;
 
 namespace Mapsui.Samples.Droid;
 
@@ -33,7 +32,6 @@ public class MainActivity : AppCompatActivity
         _mapControl = FindViewById<MapControl>(Resource.Id.mapcontrol) ?? throw new NullReferenceException();
         _mapControl.Map = MbTilesSample.CreateMap();
         _mapControl.Map.Navigator.RotationLock = true;
-        _mapControl.Renderer.WidgetRenders[typeof(CustomWidget)] = new CustomWidgetSkiaRenderer();
 
         var relativeLayout = FindViewById<RelativeLayout>(Resource.Id.mainLayout) ?? throw new NullReferenceException(); ;
         _mapControl.Map.Layers.ClearAllGroups();

--- a/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
+++ b/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
@@ -1,5 +1,6 @@
 ﻿using Mapsui.Extensions;
 using Mapsui.Manipulations;
+using Mapsui.Rendering.Skia;
 using Mapsui.Samples.Common;
 using Mapsui.Samples.Common.Maps.Demo;
 using Mapsui.Styles;
@@ -103,7 +104,7 @@ public class ManyPinsSample : IMapViewSample
             mapControl.Performance = new Performance();
 
         mapControl.Map.Widgets.Add(CreatePerformanceWidget(mapControl));
-        mapControl.Renderer.WidgetRenders[typeof(PerformanceWidget)] = new Rendering.Skia.SkiaWidgets.PerformanceWidgetRenderer();
+        MapRenderer.RegisterWidgetRenderer(typeof(PerformanceWidget), new Rendering.Skia.SkiaWidgets.PerformanceWidgetRenderer());
 
         ((UI.Maui.MapView)mapControl).UniqueCallout = true;
 

--- a/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
@@ -6,7 +6,6 @@ using Mapsui.Samples.Common.Extensions;
 using Mapsui.Styles;
 using Mapsui.UI.Maui;
 using Mapsui.Manipulations;
-using Mapsui.Samples.Common.Maps.Widgets;
 
 namespace Mapsui.Samples.Maui;
 
@@ -51,7 +50,6 @@ public sealed partial class MainPageLarge : ContentPage, IDisposable
         mapView.IsNorthingButtonVisible = true;
 
         mapView.Info += MapView_Info;
-        mapView.Renderer.WidgetRenders[typeof(CustomWidget)] = new CustomWidgetSkiaRenderer();
 
         StartGPS();
     }

--- a/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
@@ -7,7 +7,6 @@ using Mapsui.Styles;
 using Mapsui.UI.Maui;
 using Compass = Microsoft.Maui.Devices.Sensors.Compass;
 using Mapsui.Manipulations;
-using Mapsui.Samples.Common.Maps.Widgets;
 
 namespace Mapsui.Samples.Maui;
 
@@ -42,7 +41,6 @@ public sealed partial class MapPage : ContentPage, IDisposable
         mapView.MyLocationLayer.UpdateMyLocation(new Position());
 
         mapView.Info += MapView_Info;
-        mapView.Renderer.WidgetRenders[typeof(CustomWidget)] = new CustomWidgetSkiaRenderer();
 
         Catch.TaskRun(StartGPS);
 

--- a/Samples/Mapsui.Samples.Maui/View/MainPage.cs
+++ b/Samples/Mapsui.Samples.Maui/View/MainPage.cs
@@ -1,6 +1,5 @@
 using CommunityToolkit.Maui.Markup;
 using Mapsui.Samples.Common;
-using Mapsui.Samples.Common.Maps.Widgets;
 using Mapsui.Samples.Maui.ViewModel;
 using Mapsui.UI.Maui;
 
@@ -25,10 +24,6 @@ public sealed class MainPage : ContentPage, IDisposable
 
         // Workaround. Samples need the MapControl in the current setup.
         mainViewModel.MapControl = mapControl;
-
-        // The CustomWidgetSkiaRenderer needs to be registered to make the CustomWidget sample work.
-        // Perhaps it is possible to let the sample itself do this so we do not have to do this for each platform.
-        mapControl.Renderer.WidgetRenders[typeof(CustomWidget)] = new CustomWidgetSkiaRenderer();
 
         Content = new Grid
         {

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/MainPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/MainPage.xaml.cs
@@ -4,7 +4,6 @@ using Mapsui.Samples.Common;
 using Mapsui.Samples.Common.Extensions;
 using Mapsui.Tiling;
 using RadioButton = Microsoft.UI.Xaml.Controls.RadioButton;
-using Mapsui.Samples.Common.Maps.Widgets;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -28,7 +27,6 @@ public sealed partial class MainPage : Page
 
         MapControl.Map.Layers.Add(OpenStreetMap.CreateTileLayer());
         MapControl.Map.Navigator.RotationLock = false;
-        MapControl.Renderer.WidgetRenders[typeof(CustomWidget)] = new CustomWidgetSkiaRenderer();
 
         CategoryComboBox.SelectionChanged += CategoryComboBoxSelectionChanged;
 

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/MainWindow.xaml.cs
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/MainWindow.xaml.cs
@@ -6,7 +6,6 @@ using Mapsui.Extensions;
 using Mapsui.Samples.Common;
 using Mapsui.Samples.Common.Extensions;
 using Mapsui.Tiling;
-using Mapsui.Samples.Common.Maps.Widgets;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -30,7 +29,6 @@ public sealed partial class MainWindow : Window
 
         MapControl.Map.Layers.Add(OpenStreetMap.CreateTileLayer());
         MapControl.Map.Navigator.RotationLock = false;
-        MapControl.Renderer.WidgetRenders[typeof(CustomWidget)] = new CustomWidgetSkiaRenderer();
 
         CategoryComboBox.SelectionChanged += CategoryComboBoxSelectionChanged;
 

--- a/Samples/Mapsui.Samples.Wpf/Window1.xaml.cs
+++ b/Samples/Mapsui.Samples.Wpf/Window1.xaml.cs
@@ -6,7 +6,6 @@ using System.Windows.Controls.Primitives;
 using Mapsui.Extensions;
 using Mapsui.Samples.Common;
 using Mapsui.Samples.Common.Extensions;
-using Mapsui.Samples.Common.Maps.Widgets;
 
 namespace Mapsui.Samples.Wpf;
 
@@ -26,7 +25,6 @@ public partial class Window1
 
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         MapControl.Map.Navigator.RotationLock = false;
-        MapControl.Renderer.WidgetRenders[typeof(CustomWidget)] = new CustomWidgetSkiaRenderer();
 
         CategoryComboBox.SelectionChanged += CategoryComboBoxSelectionChanged;
 

--- a/Tests/Mapsui.Rendering.Skia.Tests/MapLiveTests.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/MapLiveTests.cs
@@ -121,21 +121,8 @@ public class MapLiveTests
 
     private static MapRenderer CreateMapRenderer(IMapControl mapControl)
     {
-        var mapRenderer = new MapRenderer
-        {
-            WidgetRenders =
-            {
-                [typeof(CustomWidget)] = new CustomWidgetSkiaRenderer(),
-            }
-        };
-        foreach (var widgetRender in mapControl.Renderer.WidgetRenders)
-        {
-            if (!mapRenderer.WidgetRenders.Contains(widgetRender))
-            {
-                mapRenderer.WidgetRenders[widgetRender.Key] = widgetRender.Value;
-            }
-        }
-        return mapRenderer;
+        MapRenderer.RegisterWidgetRenderer(typeof(CustomWidget), new CustomWidgetSkiaRenderer());
+        return new MapRenderer();
     }
 
     [Test]

--- a/Tests/Mapsui.Rendering.Skia.Tests/MapRegressionTests.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/MapRegressionTests.cs
@@ -143,21 +143,8 @@ public class MapRegressionTests
 
     internal static MapRenderer CreateMapRenderer(IMapControl mapControl)
     {
-        var mapRenderer = new MapRenderer
-        {
-            WidgetRenders =
-            {
-                [typeof(CustomWidget)] = new CustomWidgetSkiaRenderer(),
-            }
-        };
-        foreach (var widgetRender in mapControl.Renderer.WidgetRenders)
-        {
-            if (!mapRenderer.WidgetRenders.Contains(widgetRender))
-            {
-                mapRenderer.WidgetRenders[widgetRender.Key] = widgetRender.Value;
-            }
-        }
-        return mapRenderer;
+        MapRenderer.RegisterWidgetRenderer(typeof(CustomWidget), new CustomWidgetSkiaRenderer());
+        return new MapRenderer();
     }
 
     [Test]

--- a/docs/general/markdown/performance-widget.md
+++ b/docs/general/markdown/performance-widget.md
@@ -40,10 +40,11 @@ mapControl.Map.Widgets.Add(widget);
 5) To draw the widget on the screen, we need a widget renderer. To use the default widget renderer, use the following lines
 
 ```csharp
-mapControl.Renderer.WidgetRenders[typeof(Widgets.Performance.PerformanceWidget)] = new Rendering.Skia.SkiaWidgets.PerformanceWidgetRenderer(10, 10, 12, SkiaSharp.SKColors.Black, SkiaSharp.SKColors.White);
+Mapsui.Rendering.SkiaMapRenderer.RegisterWidgetRenderer(typeof(Widgets.Performance.PerformanceWidget), 
+  new Rendering.Skia.SkiaWidgets.PerformanceWidgetRenderer(10, 10, 12, SkiaSharp.SKColors.Black, SkiaSharp.SKColors.White));
 ```
 
-The first two parameters are the X and Y coordiantes for the widget. Third parameter is the text size. Fourth is the text color and fifth is the background color.
+The first two parameters are the X and Y coordinates for the widget. Third parameter is the text size. Fourth is the text color and fifth is the background color.
 ## Code copy
 
 ```csharp
@@ -61,7 +62,8 @@ widget.WidgetTouched += (sender, args) =>
 };
 
 mapControl.Map.Widgets.Add(widget);
-mapControl.Renderer.WidgetRenders[typeof(Widgets.Performance.PerformanceWidget)] = new Rendering.Skia.SkiaWidgets.PerformanceWidgetRenderer(10, 10, 12, SkiaSharp.SKColors.Black, SkiaSharp.SKColors.White);
+Mapsui.Rendering.SkiaMapRenderer.RegisterWidgetRenderer(typeof(Widgets.Performance.PerformanceWidget), 
+  new Rendering.Skia.SkiaWidgets.PerformanceWidgetRenderer(10, 10, 12, SkiaSharp.SKColors.Black, SkiaSharp.SKColors.White));
 ```
 
 ## Values


### PR DESCRIPTION
You can now register anywhere with:
```csharp
MapRenderer.RegisterStyleRenderer(typeof(CustomStyle), new SkiaCustomStyleRenderer());
```
One of our aims is to make the samples copy-pastable. This is one step in that direction. You can do the registering in the sample class itself.