### PR TITLE
Change WPF width/height update to follow the logic used WinUI

### DIFF
--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -97,6 +97,10 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
     private void MapControlSizeChanged(object sender, SizeChangedEventArgs e)
     {
+        // Accessing ActualWidth and ActualHeight before size changed causes an exception, so we need to do it here.
+        ViewportWidth = ActualWidth;
+        ViewportHeight = ActualHeight;
+
         Clip = new RectangleGeometry { Rect = new Rect(0, 0, ActualWidth, ActualHeight) };
         SetViewportSize();
     }
@@ -171,8 +175,8 @@ public partial class MapControl : Grid, IMapControl, IDisposable
             _manipulationTracker.Manipulate([position], Map.Navigator.Manipulate);
     }
 
-    private double ViewportWidth => ActualWidth;
-    private double ViewportHeight => ActualHeight;
+    private double ViewportWidth { get; set; }
+    private double ViewportHeight { get; set; }
 
     private static void OnManipulationInertiaStarting(object? sender, ManipulationInertiaStartingEventArgs e)
     {


### PR DESCRIPTION
I am researching a problem in WPF startup. I suspected the original code caused a crash because this is what occurred in WinUI, however I could not reproduce that problem and I am not sure this actually is a problem. Changing this anyway to err on the save side.