### PR TITLE
Change default for Viewport.Resolution to zero

### DIFF
--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -501,7 +501,8 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     {
         if (map is null) return; // Although the Map property can not null the map argument can null during initializing and binding.
 
-        map.Navigator.SetSize(ViewportWidth, ViewportHeight);
+        if (HasSize())
+            map.Navigator.SetSize(ViewportWidth, ViewportHeight);
         SubscribeToMapEvents(map);
         Refresh();
     }
@@ -683,4 +684,6 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         OnMapInfo(CreateMapInfoEventArgs(position, worldPosition, tapType));
         return false;
     }
+
+    private bool HasSize() => ViewportWidth > 0 && ViewportHeight > 0;
 }

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -97,6 +97,10 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
     private void MapControlSizeChanged(object sender, SizeChangedEventArgs e)
     {
+        // Accessing ActualWidth and ActualHeight before size changed causes an exception, so we need to do it here.
+        ViewportWidth = ActualWidth;
+        ViewportHeight = ActualHeight;
+
         Clip = new RectangleGeometry { Rect = new Rect(0, 0, ActualWidth, ActualHeight) };
         SetViewportSize();
     }
@@ -171,8 +175,8 @@ public partial class MapControl : Grid, IMapControl, IDisposable
             _manipulationTracker.Manipulate([position], Map.Navigator.Manipulate);
     }
 
-    private double ViewportWidth => ActualWidth;
-    private double ViewportHeight => ActualHeight;
+    private double ViewportWidth { get; set; }
+    private double ViewportHeight { get; set; }
 
     private static void OnManipulationInertiaStarting(object? sender, ManipulationInertiaStartingEventArgs e)
     {

--- a/Mapsui/Limiting/ViewportLimiter.cs
+++ b/Mapsui/Limiting/ViewportLimiter.cs
@@ -9,7 +9,11 @@ public class ViewportLimiter : IViewportLimiter
 
     private static Viewport LimitResolution(Viewport viewport, MMinMax? zoomBounds)
     {
-        if (zoomBounds is null) return viewport;
+        if (viewport.Resolution <= 0) // Only limit when the resolution has been set.
+            return viewport;
+
+        if (zoomBounds is null)
+            return viewport;
 
         if (zoomBounds.Min > viewport.Resolution) return viewport with { Resolution = zoomBounds.Min };
         if (zoomBounds.Max < viewport.Resolution) return viewport with { Resolution = zoomBounds.Max };

--- a/Mapsui/Navigator.cs
+++ b/Mapsui/Navigator.cs
@@ -12,7 +12,7 @@ namespace Mapsui;
 
 public class Navigator
 {
-    private Viewport _viewport = new(0, 0, 1, 0, 0, 0);
+    private Viewport _viewport = new();
     private IEnumerable<AnimationEntry<Viewport>> _animations = [];
     private readonly List<Action> _initialization = [];
     private MMinMax? _defaultZoomBounds;
@@ -115,7 +115,7 @@ public class Navigator
 
     public bool IsInitialized { get; private set; } = false;
 
-    public void Initialize()
+    private void Initialize()
     {
         if (!IsInitialized)
         {

--- a/Mapsui/Viewport.cs
+++ b/Mapsui/Viewport.cs
@@ -4,8 +4,10 @@
 
 namespace Mapsui;
 
-public record struct Viewport
+public readonly record struct Viewport
 {
+    public Viewport() : this(0, 0, 0, 0, 0, 0) { }
+
     public Viewport(double centerX, double centerY, double resolution, double rotation, double width, double height)
     {
         CenterX = centerX;

--- a/Samples/Mapsui.Samples.Common/Maps/WFS/Wfs2_0Sample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/WFS/Wfs2_0Sample.cs
@@ -23,6 +23,8 @@ public class Wfs2_0Sample : ISample
         try
         {
             var map = new Map { CRS = crs };
+            // The default resolution was changed from 1 to 0 which broke this test so the resolution is set to one 1 explicitly.
+            map.Navigator.SetViewport(map.Navigator.Viewport with { Resolution = 1 });
             var provider = await CreateWfsProviderAsync();
             map.Layers.Add(CreateWfsLayer(provider));
 

--- a/Samples/Mapsui.Samples.Common/Maps/WFS/WfsPointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/WFS/WfsPointsSample.cs
@@ -23,6 +23,8 @@ public class WfsPointsSample : ISample
         try
         {
             var map = new Map { CRS = crs };
+            // The default resolution was changed from 1 to 0 which broke this test so the resolution is set to one 1 explicitly.
+            map.Navigator.SetViewport(map.Navigator.Viewport with { Resolution = 1 });
             var provider = await CreateWfsProviderAsync();
             map.Layers.Add(CreateWfsLayer(provider));
 

--- a/Tests/Mapsui.Tests.Common/Maps/WidgetsSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/WidgetsSample.cs
@@ -24,6 +24,9 @@ public class WidgetsSample : ISample
             CRS = "EPSG:3857",
         };
 
+        // The default resolution was changed from 1 to 0 which broke this test so the resolution is set to one 1 explicitly.
+        map.Navigator.SetViewport(map.Navigator.Viewport with { Resolution = 1 });
+
         map.Widgets.Add(CreateScaleBarWidget(map));
         map.Widgets.Add(CreateScaleBarWidget(map, HorizontalAlignment.Right, textAligment: Alignment.Right));
         map.Widgets.Add(CreateScaleBarWidget(map, verticalAlignment: VerticalAlignment.Bottom));

--- a/Tests/Mapsui.Tests.Common/Maps/WidgetsSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/WidgetsSample.cs
@@ -26,7 +26,6 @@ public class WidgetsSample : ISample
 
         // The default resolution was changed from 1 to 0 which broke this test so the resolution is set to one 1 explicitly.
         map.Navigator.SetViewport(map.Navigator.Viewport with { Resolution = 1 });
-
         map.Widgets.Add(CreateScaleBarWidget(map));
         map.Widgets.Add(CreateScaleBarWidget(map, HorizontalAlignment.Right, textAligment: Alignment.Right));
         map.Widgets.Add(CreateScaleBarWidget(map, verticalAlignment: VerticalAlignment.Bottom));


### PR DESCRIPTION
This is not a bug fix but it is to help to make the initialization code easier to understand. In general it makes more sense to have zero as default, like the other fields. This code change makes sure it stays zero unless there is enough information to set a sensible resolution. Before this PR resolution limiter changed the resolution, even if the size or pan bounds were not known.