### PR TITLE
Add Tapped, PointerPressed, PointerMoved, PointerReleased events to Map

### DIFF
--- a/Mapsui.Nts/Editing/EditManipulation.cs
+++ b/Mapsui.Nts/Editing/EditManipulation.cs
@@ -32,7 +32,7 @@ public static class EditManipulation
 
         var result = false;
 
-        if (e.TapType == TapType.Hover)
+        if (e.GestureType == GestureType.Hover)
         {
             editManager.HoveringVertex(e.GetMapInfo([]));
             result = false;
@@ -80,7 +80,7 @@ public static class EditManipulation
         if (editManager.EditMode == EditMode.Modify)
         {
             var mapInfo = e.GetMapInfo([editLayer]);
-            if (e.ShiftPressed || e.TapType == TapType.DoubleTap || e.TapType == TapType.LongPress)
+            if (e.ShiftPressed || e.GestureType == GestureType.DoubleTap || e.GestureType == GestureType.LongPress)
             {
                 return editManager.TryDeleteCoordinate(
                     mapInfo, editManager.VertexRadius);
@@ -93,9 +93,9 @@ public static class EditManipulation
         }
         else if (editManager.EditMode is EditMode.DrawingPolygon or EditMode.DrawingLine)
         {
-            if (e.ShiftPressed || e.TapType == TapType.DoubleTap || e.TapType == TapType.LongPress)
+            if (e.ShiftPressed || e.GestureType == GestureType.DoubleTap || e.GestureType == GestureType.LongPress)
             {
-                if (e.TapType != TapType.DoubleTap) // Add last vertex but not on a double tap because it is preceded by a single tap.
+                if (e.GestureType != GestureType.DoubleTap) // Add last vertex but not on a double tap because it is preceded by a single tap.
                     editManager.AddVertex(navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
                 return editManager.EndEdit();
             }
@@ -103,7 +103,7 @@ public static class EditManipulation
                 editManager.AddVertex(navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
         }
         else if (editManager.EditMode is EditMode.AddPoint or EditMode.AddLine or EditMode.AddPolygon)
-            if (e.TapType == TapType.SingleTap)
+            if (e.GestureType == GestureType.SingleTap)
                 editManager.AddVertex(navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
 
         if (editManager.SelectMode)

--- a/Mapsui.Nts/Editing/EditManipulation.cs
+++ b/Mapsui.Nts/Editing/EditManipulation.cs
@@ -32,7 +32,7 @@ public static class EditManipulation
 
         var result = false;
 
-        if (!e.LeftButton)
+        if (e.TapType == TapType.None)
         {
             editManager.HoveringVertex(e.GetMapInfo([]));
             result = false;

--- a/Mapsui.Nts/Editing/EditManipulation.cs
+++ b/Mapsui.Nts/Editing/EditManipulation.cs
@@ -32,7 +32,7 @@ public static class EditManipulation
 
         var result = false;
 
-        if (e.TapType == TapType.None)
+        if (e.TapType == TapType.Hover)
         {
             editManager.HoveringVertex(e.GetMapInfo([]));
             result = false;
@@ -80,7 +80,7 @@ public static class EditManipulation
         if (editManager.EditMode == EditMode.Modify)
         {
             var mapInfo = e.GetMapInfo([editLayer]);
-            if (e.ShiftPressed || e.TapType == TapType.Double || e.TapType == TapType.Long)
+            if (e.ShiftPressed || e.TapType == TapType.DoubleTap || e.TapType == TapType.LongPress)
             {
                 return editManager.TryDeleteCoordinate(
                     mapInfo, editManager.VertexRadius);
@@ -93,9 +93,9 @@ public static class EditManipulation
         }
         else if (editManager.EditMode is EditMode.DrawingPolygon or EditMode.DrawingLine)
         {
-            if (e.ShiftPressed || e.TapType == TapType.Double || e.TapType == TapType.Long)
+            if (e.ShiftPressed || e.TapType == TapType.DoubleTap || e.TapType == TapType.LongPress)
             {
-                if (e.TapType != TapType.Double) // Add last vertex but not on a double tap because it is preceded by a single tap.
+                if (e.TapType != TapType.DoubleTap) // Add last vertex but not on a double tap because it is preceded by a single tap.
                     editManager.AddVertex(navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
                 return editManager.EndEdit();
             }
@@ -103,7 +103,7 @@ public static class EditManipulation
                 editManager.AddVertex(navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
         }
         else if (editManager.EditMode is EditMode.AddPoint or EditMode.AddLine or EditMode.AddPolygon)
-            if (e.TapType == TapType.Single)
+            if (e.TapType == TapType.SingleTap)
                 editManager.AddVertex(navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
 
         if (editManager.SelectMode)

--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -133,7 +133,7 @@ public partial class MapControl : ViewGroup, IMapControl
                     return;
                 break;
             case MotionEventActions.Move:
-                if (OnMapPointerMoved(positions, false))
+                if (OnPointerMoved(positions, false))
                     return;
                 _manipulationTracker.Manipulate(positions, Map.Navigator.Manipulate);
                 break;

--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -129,7 +129,7 @@ public partial class MapControl : ViewGroup, IMapControl
         {
             case MotionEventActions.Down:
                 _manipulationTracker.Restart(positions);
-                if (OnMapPointerPressed(positions))
+                if (OnPointerPressed(positions))
                     return;
                 break;
             case MotionEventActions.Move:
@@ -138,7 +138,7 @@ public partial class MapControl : ViewGroup, IMapControl
                 _manipulationTracker.Manipulate(positions, Map.Navigator.Manipulate);
                 break;
             case MotionEventActions.Up:
-                OnMapPointerReleased(positions);
+                OnPointerReleased(positions);
 
 
                 break;

--- a/Mapsui.UI.Avalonia/MapControl.cs
+++ b/Mapsui.UI.Avalonia/MapControl.cs
@@ -97,13 +97,13 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
         var position = e.GetPosition(this).ToScreenPosition();
         if (isHovering)
         {
-            if (OnMapPointerMoved([position], isHovering))
+            if (OnPointerMoved([position], isHovering))
                 return;
         }
         else
         {
             _positions[e.Pointer.Id] = position;
-            if (OnMapPointerMoved(_positions.Values.ToArray(), isHovering))
+            if (OnPointerMoved(_positions.Values.ToArray(), isHovering))
                 return;
             _manipulationTracker.Manipulate(_positions.Values.ToArray(), Map.Navigator.Manipulate);
         }

--- a/Mapsui.UI.Avalonia/MapControl.cs
+++ b/Mapsui.UI.Avalonia/MapControl.cs
@@ -84,7 +84,7 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
         if (_positions.Count == 1) // Not sure if this check is necessary.
             _manipulationTracker.Restart(_positions.Values.ToArray());
 
-        if (OnMapPointerPressed(_positions.Values.ToArray()))
+        if (OnPointerPressed(_positions.Values.ToArray()))
             return;
 
         e.Pointer.Capture(this);
@@ -115,7 +115,7 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
         _positions.TryRemove(e.Pointer.Id, out _);
         var position = e.GetPosition(this).ToScreenPosition();
 
-        OnMapPointerReleased([position]);
+        OnPointerReleased([position]);
 
         e.Pointer.Capture(null);
     }

--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -174,7 +174,7 @@ public partial class MapControl : ComponentBase, IMapControl
             var isHovering = !IsMouseButtonPressed(e);
             var position = e.ToScreenPosition(_clientRect);
 
-            if (OnMapPointerMoved([position], isHovering))
+            if (OnPointerMoved([position], isHovering))
                 return;
 
             if (!isHovering)
@@ -248,7 +248,7 @@ public partial class MapControl : ComponentBase, IMapControl
             if (positions.Length == 1)
                 _lastMovePosition = positions[0]; // Workaround for missing touch-up location.
 
-            if (OnMapPointerMoved(positions))
+            if (OnPointerMoved(positions, false))
                 return;
 
 

--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -162,7 +162,7 @@ public partial class MapControl : ComponentBase, IMapControl
 
             _manipulationTracker.Restart([position]);
 
-            if (OnMapPointerPressed([position]))
+            if (OnPointerPressed([position]))
                 return;
         });
     }
@@ -189,7 +189,7 @@ public partial class MapControl : ComponentBase, IMapControl
         Catch.Exceptions(() =>
         {
             var position = e.ToScreenPosition(_clientRect);
-            OnMapPointerReleased([position]);
+            OnPointerReleased([position]);
         });
     }
 
@@ -235,7 +235,7 @@ public partial class MapControl : ComponentBase, IMapControl
             var positions = e.TargetTouches.ToScreenPositions(_clientRect);
             _manipulationTracker.Restart(positions);
 
-            if (OnMapPointerPressed(positions))
+            if (OnPointerPressed(positions))
                 return;
         });
     }
@@ -263,7 +263,7 @@ public partial class MapControl : ComponentBase, IMapControl
             if (_lastMovePosition is null)
                 return;
             var position = _lastMovePosition.Value;
-            OnMapPointerReleased([position]);
+            OnPointerReleased([position]);
         });
     }
 

--- a/Mapsui.UI.Eto/MapControl.cs
+++ b/Mapsui.UI.Eto/MapControl.cs
@@ -57,7 +57,7 @@ public partial class MapControl : SkiaDrawable, IMapControl
         var isHovering = IsHovering(e);
         var position = e.Location.ToScreenPosition();
 
-        if (OnMapPointerMoved([position], isHovering))
+        if (OnPointerMoved([position], isHovering))
             return;
 
         if (!isHovering)

--- a/Mapsui.UI.Eto/MapControl.cs
+++ b/Mapsui.UI.Eto/MapControl.cs
@@ -46,7 +46,7 @@ public partial class MapControl : SkiaDrawable, IMapControl
 
         _manipulationTracker.Restart([position]);
 
-        if (OnMapPointerPressed([position]))
+        if (OnPointerPressed([position]))
             return;
     }
 
@@ -70,7 +70,7 @@ public partial class MapControl : SkiaDrawable, IMapControl
 
         SetCursorInDefaultMode();
         var position = e.Location.ToScreenPosition();
-        OnMapPointerReleased([position]);
+        OnPointerReleased([position]);
     }
 
     protected override void OnLoadComplete(EventArgs e)

--- a/Mapsui.UI.MapView/EventArgs/CalloutClickedEventArgs.cs
+++ b/Mapsui.UI.MapView/EventArgs/CalloutClickedEventArgs.cs
@@ -24,7 +24,7 @@ public sealed class CalloutClickedEventArgs : EventArgs
     /// <summary>
     /// Number of taps
     /// </summary>
-    public TapType TapType { get; }
+    public GestureType GestureType { get; }
 
     /// <summary>
     /// Flag, if this event was handled
@@ -32,11 +32,11 @@ public sealed class CalloutClickedEventArgs : EventArgs
     /// <value><c>true</c> if handled; otherwise, <c>false</c>.</value>
     public bool Handled { get; set; } = false;
 
-    internal CalloutClickedEventArgs(Callout? callout, Position point, Point screenPoint, TapType tapType)
+    internal CalloutClickedEventArgs(Callout? callout, Position point, Point screenPoint, GestureType gestureType)
     {
         Callout = callout;
         Point = point;
         ScreenPoint = screenPoint;
-        TapType = tapType;
+        GestureType = gestureType;
     }
 }

--- a/Mapsui.UI.MapView/EventArgs/DrawableClickedEventArgs.cs
+++ b/Mapsui.UI.MapView/EventArgs/DrawableClickedEventArgs.cs
@@ -19,7 +19,7 @@ public sealed class DrawableClickedEventArgs : EventArgs
     /// <summary>
     /// Number of taps
     /// </summary>
-    public TapType TapType { get; }
+    public GestureType GestureType { get; }
 
     /// <summary>
     /// Flag, if this event was handled
@@ -27,10 +27,10 @@ public sealed class DrawableClickedEventArgs : EventArgs
     /// <value><c>true</c> if handled; otherwise, <c>false</c>.</value>
     public bool Handled { get; set; } = false;
 
-    internal DrawableClickedEventArgs(Position point, Point screenPoint, TapType tapType)
+    internal DrawableClickedEventArgs(Position point, Point screenPoint, GestureType gestureType)
     {
         Point = point;
         ScreenPoint = screenPoint;
-        TapType = tapType;
+        GestureType = gestureType;
     }
 }

--- a/Mapsui.UI.MapView/EventArgs/MapClickedEventArgs.cs
+++ b/Mapsui.UI.MapView/EventArgs/MapClickedEventArgs.cs
@@ -13,7 +13,7 @@ public sealed class MapClickedEventArgs : EventArgs
     /// <summary>
     /// Number of taps
     /// </summary>
-    public TapType TapType { get; }
+    public GestureType GestureType { get; }
 
     /// <summary>
     /// Flag, if this event was handled
@@ -21,9 +21,9 @@ public sealed class MapClickedEventArgs : EventArgs
     /// <value><c>true</c> if handled; otherwise, <c>false</c>.</value>
     public bool Handled { get; set; } = false;
 
-    public MapClickedEventArgs(Position point, TapType tapType)
+    public MapClickedEventArgs(Position point, GestureType gestureType)
     {
         Point = point;
-        TapType = tapType;
+        GestureType = gestureType;
     }
 }

--- a/Mapsui.UI.MapView/EventArgs/PinClickedEventArgs.cs
+++ b/Mapsui.UI.MapView/EventArgs/PinClickedEventArgs.cs
@@ -18,7 +18,7 @@ public sealed class PinClickedEventArgs : EventArgs
     /// <summary>
     /// Number of taps
     /// </summary>
-    public TapType TapType { get; }
+    public GestureType GestureType { get; }
 
     /// <summary>
     /// Flag, if this event was handled
@@ -26,10 +26,10 @@ public sealed class PinClickedEventArgs : EventArgs
     /// <value><c>true</c> if handled; otherwise, <c>false</c>.</value>
     public bool Handled { get; set; } = false;
 
-    internal PinClickedEventArgs(Pin pin, Position point, TapType tapType)
+    internal PinClickedEventArgs(Pin pin, Position point, GestureType gestureType)
     {
         Pin = pin;
         Point = point;
-        TapType = tapType;
+        GestureType = gestureType;
     }
 }

--- a/Mapsui.UI.MapView/EventArgs/TappedEventArgs.cs
+++ b/Mapsui.UI.MapView/EventArgs/TappedEventArgs.cs
@@ -6,12 +6,12 @@ namespace Mapsui.UI;
 public class TappedEventArgs : EventArgs
 {
     public ScreenPosition ScreenPosition { get; }
-    public TapType TapType { get; }
+    public GestureType GestureType { get; }
     public bool Handled { get; set; } = false;
 
-    public TappedEventArgs(ScreenPosition screenPosition, TapType tapType)
+    public TappedEventArgs(ScreenPosition screenPosition, GestureType gestureType)
     {
         ScreenPosition = screenPosition;
-        TapType = tapType;
+        GestureType = gestureType;
     }
 }

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -553,7 +553,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
                 SelectedPinChanged?.Invoke(this, new SelectedPinChangedEventArgs(SelectedPin));
 
-                var pinArgs = new PinClickedEventArgs(clickedPin, Map.Navigator.Viewport.ScreenToWorld(mapInfo.ScreenPosition).ToNative(), e.TapType);
+                var pinArgs = new PinClickedEventArgs(clickedPin, Map.Navigator.Viewport.ScreenToWorld(mapInfo.ScreenPosition).ToNative(), e.GestureType);
 
                 PinClicked?.Invoke(this, pinArgs);
 
@@ -581,7 +581,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
             var calloutArgs = new CalloutClickedEventArgs(clickedCallout,
                 Map.Navigator.Viewport.ScreenToWorld(mapInfo.ScreenPosition).ToNative(),
-                new Point(mapInfo.ScreenPosition.X, mapInfo.ScreenPosition.Y), e.TapType);
+                new Point(mapInfo.ScreenPosition.X, mapInfo.ScreenPosition.Y), e.GestureType);
 
             clickedCallout?.HandleCalloutClicked(this, calloutArgs);
 
@@ -604,7 +604,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
                     {
                         var drawableArgs = new DrawableClickedEventArgs(
                             Map.Navigator.Viewport.ScreenToWorld(mapInfo.ScreenPosition).ToNative(),
-                            new Point(mapInfo.ScreenPosition.X, mapInfo.ScreenPosition.Y), e.TapType);
+                            new Point(mapInfo.ScreenPosition.X, mapInfo.ScreenPosition.Y), e.GestureType);
 
                         drawable?.HandleClicked(drawableArgs);
 
@@ -621,7 +621,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
         {
             var args = new DrawableClickedEventArgs(
                 Map.Navigator.Viewport.ScreenToWorld(mapInfo.ScreenPosition).ToNative(),
-                new Point(mapInfo.ScreenPosition.X, mapInfo.ScreenPosition.Y), e.TapType);
+                new Point(mapInfo.ScreenPosition.X, mapInfo.ScreenPosition.Y), e.GestureType);
 
             MyLocationLayer?.HandleClicked(args);
 
@@ -642,7 +642,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             var worldPosition = map.Navigator.Viewport.ScreenToWorld(screenPosition);
             var getRemoteMapInfoAsync = () => RemoteMapInfoFetcher.GetRemoteMapInfoAsync(screenPosition, map.Navigator.Viewport, map.Layers);
             var mapInfoEventArgs = new MapInfoEventArgs(screenPosition, worldPosition,
-                e.TapType, map.Navigator.Viewport, handled, GetMapInfo, GetRemoteMapInfoAsync);
+                e.GestureType, map.Navigator.Viewport, handled, GetMapInfo, GetRemoteMapInfoAsync);
 
             HandlerInfo(mapInfoEventArgs);
 
@@ -651,7 +651,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             if (!handled)
             {
                 // if nothing else was hit, then we hit the map
-                var args = new MapClickedEventArgs(worldPosition.ToNative(), e.TapType);
+                var args = new MapClickedEventArgs(worldPosition.ToNative(), e.GestureType);
                 MapClicked?.Invoke(this, args);
 
                 if (args.Handled)

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -178,7 +178,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
                 if (_positions.Count == 1) // Not sure if this check is necessary.
                     _manipulationTracker.Restart(_positions.Values.ToArray());
 
-                if (OnMapPointerPressed(_positions.Values.ToArray()))
+                if (OnPointerPressed(_positions.Values.ToArray()))
                     return;
             }
             else if (e.ActionType == SKTouchAction.Moved)
@@ -207,7 +207,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
             {
                 // Delete e.Id from _touches, because finger is released
                 _positions.Remove(e.Id, out var releasedTouch);
-                OnMapPointerReleased([position]);
+                OnPointerReleased([position]);
             }
             else if (e.ActionType == SKTouchAction.Cancelled)
             {

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -188,14 +188,14 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
                 if (isHovering)
                 {
                     // In case of hovering we need to send the current position which added to the _positions array
-                    if (OnMapPointerMoved([position], isHovering))
+                    if (OnPointerMoved([position], isHovering))
                         return;
                 }
                 else
                 {
                     _positions[e.Id] = position;
 
-                    if (OnMapPointerMoved(_positions.Values.ToArray(), isHovering))
+                    if (OnPointerMoved(_positions.Values.ToArray(), isHovering))
                         return;
 
                     _manipulationTracker.Manipulate(_positions.Values.ToArray(), Map.Navigator.Manipulate);

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -283,6 +283,9 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     /// Called whenever the map is clicked. The MapInfoEventArgs contain the features that were hit in
     /// the layers that have IsMapInfoLayer set to true. 
     /// </summary>
+    /// <remarks>
+    /// The Map.Tapped event is preferred over the Info event. This event is kept for backwards compatibility.
+    /// </remarks>
     public event EventHandler<MapInfoEventArgs>? Info;
 
     /// <summary>
@@ -698,6 +701,8 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnMapPointerPressed(ScreenPosition screenPosition, MPoint worldPosition)
     {
+        Logger.Log(LogLevel.Information, $"Map.PointerPressed");
+
         return Map.OnPointerPressed(new MapEventArgs(screenPosition, worldPosition, GestureType.Press,
             Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
     }
@@ -710,12 +715,15 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnMapPointerReleased(ScreenPosition screenPosition, MPoint worldPosition)
     {
+        Logger.Log(LogLevel.Information, $"Map.PointerReleased");
+
         return Map.OnPointerReleased(new MapEventArgs(screenPosition, worldPosition, GestureType.Release, 
             Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
     }
 
     private bool OnMapTapped(ScreenPosition screenPosition, GestureType gestureType, MPoint worldPosition)
     {
+        Logger.Log(LogLevel.Information, $"Map.Tapped. {nameof(GestureType)}: {gestureType}");
         return Map.OnTapped(new MapEventArgs(screenPosition, worldPosition, gestureType, 
             Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
     }

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -583,7 +583,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnWidgetPointerPressed(ScreenPosition screenPosition, MPoint worldPosition, bool shiftPressed)
     {
-        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, TapType.Single, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
+        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, TapType.Press, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
         
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
         {
@@ -606,7 +606,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnWidgetPointerReleased(ScreenPosition screenPosition, MPoint worldPosition, bool shiftPressed)
     {
-        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, TapType.Single, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
+        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, TapType.Release, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
         
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
         {
@@ -646,14 +646,14 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         return OnMapPointerPressed(screenPosition, worldPosition);
     }
 
-    private bool OnMapPointerMoved(ReadOnlySpan<ScreenPosition> screenPositions, bool isHovering = false)
+    private bool OnPointerMoved(ReadOnlySpan<ScreenPosition> screenPositions, bool isHovering)
     {
         if (screenPositions.Length != 1)
             return false;
 
+        var tapType = isHovering ? TapType.Hover : TapType.Drag;
         var screenPosition = screenPositions[0];
         var worldPosition = Map.Navigator.Viewport.ScreenToWorld(screenPosition);
-        var tapType = isHovering ? TapType.None : TapType.Single;
         if (OnWidgetPointerMoved(screenPosition, worldPosition, tapType, GetShiftPressed()))
             return true;
         if (OnMapPointerMoved(screenPosition, worldPosition, tapType))
@@ -698,7 +698,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnMapPointerPressed(ScreenPosition screenPosition, MPoint worldPosition)
     {
-        return Map.OnPointerPressed(new MapEventArgs(screenPosition, worldPosition, TapType.Single,
+        return Map.OnPointerPressed(new MapEventArgs(screenPosition, worldPosition, TapType.Press,
             Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
     }
 
@@ -710,7 +710,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnMapPointerReleased(ScreenPosition screenPosition, MPoint worldPosition)
     {
-        return Map.OnPointerReleased(new MapEventArgs(screenPosition, worldPosition, TapType.Single, 
+        return Map.OnPointerReleased(new MapEventArgs(screenPosition, worldPosition, TapType.Release, 
             Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
     }
 

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -542,9 +542,9 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         return stream.ToArray();
     }
 
-    private MapInfoEventArgs CreateMapInfoEventArgs(ScreenPosition screenPosition, MPoint worldPosition, TapType tapType)
+    private MapInfoEventArgs CreateMapInfoEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType)
     {
-        return new MapInfoEventArgs(screenPosition, worldPosition, tapType, Map.Navigator.Viewport, false, GetMapInfo, GetRemoteMapInfoAsync);
+        return new MapInfoEventArgs(screenPosition, worldPosition, gestureType, Map.Navigator.Viewport, false, GetMapInfo, GetRemoteMapInfoAsync);
     }
 
     public MapInfo GetMapInfo(ScreenPosition screenPosition, IEnumerable<ILayer> layers)
@@ -583,7 +583,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnWidgetPointerPressed(ScreenPosition screenPosition, MPoint worldPosition, bool shiftPressed)
     {
-        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, TapType.Press, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
+        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, GestureType.Press, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
         
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
         {
@@ -594,9 +594,9 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         return false;
     }
 
-    private bool OnWidgetPointerMoved(ScreenPosition screenPosition, MPoint worldPosition, TapType tapType, bool shiftPressed)
+    private bool OnWidgetPointerMoved(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, bool shiftPressed)
     {
-        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, tapType, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
+        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, gestureType, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
 
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
             if (widget.OnPointerMoved(Map.Navigator, eventArgs))
@@ -606,7 +606,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnWidgetPointerReleased(ScreenPosition screenPosition, MPoint worldPosition, bool shiftPressed)
     {
-        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, TapType.Release, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
+        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, GestureType.Release, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
         
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
         {
@@ -617,14 +617,14 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         return false;
     }
 
-    private bool OnWidgetTapped(ScreenPosition screenPosition, MPoint worldPosition, TapType tapType, bool shiftPressed)
+    private bool OnWidgetTapped(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, bool shiftPressed)
     {
-        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, tapType, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
+        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, gestureType, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
 
         var touchedWidgets = WidgetInput.GetWidgetsAtPosition(screenPosition, Map);
         foreach (var widget in touchedWidgets)
         {
-            Logger.Log(LogLevel.Information, $"Widget.Tapped: {widget.GetType().Name} TapType: {tapType} KeyState: {shiftPressed}");
+            Logger.Log(LogLevel.Information, $"Widget.Tapped: {widget.GetType().Name} {nameof(GestureType)}: {gestureType} KeyState: {shiftPressed}");
             if (widget.OnTapped(Map.Navigator, eventArgs))
                 return true;
         }
@@ -651,12 +651,12 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         if (screenPositions.Length != 1)
             return false;
 
-        var tapType = isHovering ? TapType.Hover : TapType.Drag;
+        var gestureType = isHovering ? GestureType.Hover : GestureType.Drag;
         var screenPosition = screenPositions[0];
         var worldPosition = Map.Navigator.Viewport.ScreenToWorld(screenPosition);
-        if (OnWidgetPointerMoved(screenPosition, worldPosition, tapType, GetShiftPressed()))
+        if (OnWidgetPointerMoved(screenPosition, worldPosition, gestureType, GetShiftPressed()))
             return true;
-        if (OnMapPointerMoved(screenPosition, worldPosition, tapType))
+        if (OnMapPointerMoved(screenPosition, worldPosition, gestureType))
             return true;
         if (!isHovering)
             _flingTracker.AddEvent(screenPosition, DateTime.Now.Ticks);
@@ -683,40 +683,40 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         return handled;
     }
 
-    private bool OnMapTapped(ScreenPosition screenPosition, TapType tapType)
+    private bool OnMapTapped(ScreenPosition screenPosition, GestureType gestureType)
     {
         var worldPosition = Map.Navigator.Viewport.ScreenToWorld(screenPosition);
-        if (OnWidgetTapped(screenPosition, worldPosition, tapType, GetShiftPressed()))
+        if (OnWidgetTapped(screenPosition, worldPosition, gestureType, GetShiftPressed()))
             return true;
         if (Map is null)
             return false;
-        if (OnMapTapped(screenPosition, tapType, worldPosition))
+        if (OnMapTapped(screenPosition, gestureType, worldPosition))
             return true;
-        OnMapInfo(CreateMapInfoEventArgs(screenPosition, worldPosition, tapType));
+        OnMapInfo(CreateMapInfoEventArgs(screenPosition, worldPosition, gestureType));
         return false;
     }
 
     private bool OnMapPointerPressed(ScreenPosition screenPosition, MPoint worldPosition)
     {
-        return Map.OnPointerPressed(new MapEventArgs(screenPosition, worldPosition, TapType.Press,
+        return Map.OnPointerPressed(new MapEventArgs(screenPosition, worldPosition, GestureType.Press,
             Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
     }
 
-    private bool OnMapPointerMoved(ScreenPosition screenPosition, MPoint worldPosition, TapType tapType)
+    private bool OnMapPointerMoved(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType)
     {
-        return Map.OnPointerMoved(new MapEventArgs(screenPosition, worldPosition, tapType, 
+        return Map.OnPointerMoved(new MapEventArgs(screenPosition, worldPosition, gestureType, 
             Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
     }
 
     private bool OnMapPointerReleased(ScreenPosition screenPosition, MPoint worldPosition)
     {
-        return Map.OnPointerReleased(new MapEventArgs(screenPosition, worldPosition, TapType.Release, 
+        return Map.OnPointerReleased(new MapEventArgs(screenPosition, worldPosition, GestureType.Release, 
             Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
     }
 
-    private bool OnMapTapped(ScreenPosition screenPosition, TapType tapType, MPoint worldPosition)
+    private bool OnMapTapped(ScreenPosition screenPosition, GestureType gestureType, MPoint worldPosition)
     {
-        return Map.OnTapped(new MapEventArgs(screenPosition, worldPosition, tapType, 
+        return Map.OnTapped(new MapEventArgs(screenPosition, worldPosition, gestureType, 
             Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
     }
 

--- a/Mapsui.UI.WinUI/MapControl.cs
+++ b/Mapsui.UI.WinUI/MapControl.cs
@@ -113,9 +113,9 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
     private void MapControl_PointerPressed(object sender, PointerRoutedEventArgs e)
     {
-        var position = e.GetCurrentPoint(this).Position.ToScreenPosition();
+        var screenPosition = e.GetCurrentPoint(this).Position.ToScreenPosition();
 
-        if (OnMapPointerPressed([position]))
+        if (OnPointerPressed([screenPosition]))
             return;
     }
 
@@ -136,8 +136,8 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
     private void MapControl_PointerReleased(object sender, PointerRoutedEventArgs e)
     {
-        var position = e.GetCurrentPoint(this).Position.ToScreenPosition();
-        OnMapPointerReleased([position]);
+        var screenPosition = e.GetCurrentPoint(this).Position.ToScreenPosition();
+        OnPointerReleased([screenPosition]);
     }
 
     private bool IsHovering(PointerRoutedEventArgs e)

--- a/Mapsui.UI.WinUI/MapControl.cs
+++ b/Mapsui.UI.WinUI/MapControl.cs
@@ -128,7 +128,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
             return;
         var position = e.GetCurrentPoint(this).Position.ToScreenPosition();
 
-        if (OnMapPointerMoved([position], true)) // Only for hover events
+        if (OnPointerMoved([position], true)) // Only for hover events
             return;
 
         RefreshGraphics(); // Todo: Figure out if we really need to refresh the graphics here. It might be better to only do this when the map is actually changed. In that case it should perhaps be done  in the users handler to OnMapPointerMoved
@@ -256,7 +256,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
     {
         var manipulation = ToManipulation(e);
 
-        if (OnMapPointerMoved([manipulation.Center]))
+        if (OnPointerMoved([manipulation.Center], false))
             return;
 
         Map.Navigator.Manipulate(ToManipulation(e));

--- a/Mapsui.UI.WindowsForms/MapControl.cs
+++ b/Mapsui.UI.WindowsForms/MapControl.cs
@@ -111,10 +111,10 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
 
     private void MapControlMouseDown(object? sender, MouseEventArgs e)
     {
-        var position = GetScreenPosition(e.Location);
-        _manipulationTracker.Restart([position]);
+        var screenPosition = GetScreenPosition(e.Location);
+        _manipulationTracker.Restart([screenPosition]);
 
-        OnMapPointerPressed([position]);
+        OnPointerPressed([screenPosition]);
     }
 
     private void MapControlMouseMove(object? sender, MouseEventArgs e)
@@ -131,8 +131,8 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
 
     private void MapControlMouseUp(object? sender, MouseEventArgs e)
     {
-        var position = GetScreenPosition(e.Location);
-        OnMapPointerReleased([position]);
+        var screenPosition = GetScreenPosition(e.Location);
+        OnPointerReleased([screenPosition]);
     }
 
     private void MapControlMouseWheel(object? sender, MouseEventArgs e)

--- a/Mapsui.UI.WindowsForms/MapControl.cs
+++ b/Mapsui.UI.WindowsForms/MapControl.cs
@@ -122,7 +122,7 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
         var isHovering = IsHovering(e);
         var position = GetScreenPosition(e.Location);
 
-        if (OnMapPointerMoved([position], isHovering))
+        if (OnPointerMoved([position], isHovering))
             return;
 
         if (!isHovering)

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -168,7 +168,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         var isHovering = IsHovering(e);
         var position = e.GetPosition(this).ToScreenPosition();
 
-        if (OnMapPointerMoved([position], isHovering))
+        if (OnPointerMoved([position], isHovering))
             return;
 
         if (!isHovering)

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -123,7 +123,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         var position = e.GetPosition(this).ToScreenPosition();
         _manipulationTracker.Restart([position]);
 
-        if (OnMapPointerPressed([position]))
+        if (OnPointerPressed([position]))
             return;
 
         CaptureMouse();
@@ -132,21 +132,21 @@ public partial class MapControl : Grid, IMapControl, IDisposable
     private void MapControlMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
         var position = e.GetPosition(this).ToScreenPosition();
-        OnMapPointerReleased([position]);
+        OnPointerReleased([position]);
         ReleaseMouseCapture();
     }
 
     private void MapControl_TouchDown(object? sender, TouchEventArgs e)
     {
         var position = e.GetTouchPoint(this).Position.ToScreenPosition();
-        if (OnMapPointerPressed([position]))
+        if (OnPointerPressed([position]))
             return;
     }
 
     private void MapControlTouchUp(object? sender, TouchEventArgs e)
     {
         var position = e.GetTouchPoint(this).Position.ToScreenPosition();
-        if (OnMapPointerReleased([position]))
+        if (OnPointerReleased([position]))
             return;
     }
 

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -152,7 +152,7 @@ public partial class MapControl : UIView, IMapControl
             base.TouchesMoved(touches, e);
             var positions = GetScreenPositions(e, this);
 
-            if (OnMapPointerMoved(positions))
+            if (OnPointerMoved(positions, false))
                 return;
 
             _manipulationTracker.Manipulate(positions, Map.Navigator.Manipulate);

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -140,7 +140,7 @@ public partial class MapControl : UIView, IMapControl
             if (positions.Length == 1)
                 _manipulationTracker.Restart(positions);
 
-            if (OnMapPointerPressed(positions))
+            if (OnPointerPressed(positions))
                 return;
         });
     }
@@ -165,7 +165,7 @@ public partial class MapControl : UIView, IMapControl
         {
             base.TouchesEnded(touches, e);
             var positions = GetScreenPositions(e, this);
-            OnMapPointerReleased(positions);
+            OnPointerReleased(positions);
         });
     }
 

--- a/Mapsui/BaseEventArgs.cs
+++ b/Mapsui/BaseEventArgs.cs
@@ -9,7 +9,7 @@ namespace Mapsui;
 public delegate Task<MapInfo> GetRemoteMapInfoAsyncDelegate(ScreenPosition screenPosition, Viewport viewport, IEnumerable<ILayer> layers);
 public delegate MapInfo GetMapInfoDelegate(ScreenPosition screenPosition, IEnumerable<ILayer> layers);
 
-public class BaseEventArgs(ScreenPosition screenPosition, MPoint worldPosition, TapType tapType, Viewport viewport,
+public class BaseEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, Viewport viewport,
     GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync) : EventArgs
 {
     /// <summary>
@@ -25,7 +25,7 @@ public class BaseEventArgs(ScreenPosition screenPosition, MPoint worldPosition, 
     /// <summary>
     /// Number of clicks on the Widget
     /// </summary>
-    public TapType TapType { get; } = tapType;
+    public GestureType GestureType { get; } = gestureType;
 
     /// <summary>
     /// Viewport of the map at the moment of the event

--- a/Mapsui/Layers/MyLocationLayer.cs
+++ b/Mapsui/Layers/MyLocationLayer.cs
@@ -127,7 +127,7 @@ public class MyLocationLayer : BaseLayer, IDisposable
     /// <summary>
     /// This event is triggered whenever the MyLocation symbol or label is clicked.
     /// </summary>
-    public event EventHandler<MapInfoEventArgs>? Clicked;
+    public event EventHandler<MapEventArgs>? Tapped;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="T:Mapsui.Layers.MyLocationLayer"/> class
@@ -149,7 +149,7 @@ public class MyLocationLayer : BaseLayer, IDisposable
         ArgumentNullException.ThrowIfNull(map);
 
         _map = map;
-        _map.Info += HandleClicked;
+        _map.Tapped += MapTapped;
 
         Enabled = true;
 
@@ -497,12 +497,14 @@ public class MyLocationLayer : BaseLayer, IDisposable
         return modified;
     }
 
-    private void HandleClicked(object? sender, MapInfoEventArgs e)
+    private bool MapTapped(Map map, MapEventArgs e)
     {
         var mapInfo = e.GetMapInfo([this]);
         if (mapInfo.Feature != null && mapInfo.Feature.Equals(_feature))
         {
-            Clicked?.Invoke(this, e);
+            Tapped?.Invoke(this, e);
+            return true;
         }
+        return false;
     }
 }

--- a/Mapsui/Manipulations/GestureType.cs
+++ b/Mapsui/Manipulations/GestureType.cs
@@ -1,0 +1,33 @@
+﻿namespace Mapsui.Manipulations;
+
+public enum GestureType
+{
+    /// <summary>
+    /// First up after a down on nearly the same position.
+    /// </summary>
+    SingleTap,
+    /// <summary>
+    /// Two SingleTaps on nearly the same position within a certain time period.
+    /// </summary>
+    DoubleTap,
+    /// <summary>
+    /// // Previously down on nearly the same position during some specific period.
+    /// </summary>
+    LongPress,
+    /// <summary>
+    /// Previously up on other position.
+    /// </summary>
+    Hover,
+    /// <summary>
+    /// Previously down on other position.
+    /// </summary>
+    Drag,
+    /// <summary>
+    /// First up.
+    /// </summary>
+    Release,
+    /// <summary>
+    /// First down.
+    /// </summary>
+    Press,
+}

--- a/Mapsui/Manipulations/TapGestureTracker.cs
+++ b/Mapsui/Manipulations/TapGestureTracker.cs
@@ -5,10 +5,34 @@ namespace Mapsui.Manipulations;
 
 public enum TapType
 {
-    Single,
-    Double,
-    Long,
-    None
+    /// <summary>
+    /// First up after a down on nearly the same position.
+    /// </summary>
+    SingleTap,
+    /// <summary>
+    /// Two SingleTaps on nearly the same position within a certain time period.
+    /// </summary>
+    DoubleTap,
+    /// <summary>
+    /// // Previously down on nearly the same position during some specific period.
+    /// </summary>
+    LongPress,
+    /// <summary>
+    /// Previously up on other position.
+    /// </summary>
+    Hover,
+    /// <summary>
+    /// Previously down on other position.
+    /// </summary>
+    Drag,
+    /// <summary>
+    /// First up.
+    /// </summary>
+    Release,
+    /// <summary>
+    /// First down.
+    /// </summary>
+    Press,
 }
 
 public class TapGestureTracker
@@ -41,7 +65,7 @@ public class TapGestureTracker
                 var distanceToPreviousTap = tapEndPosition.Value.Distance(_previousTapPosition.Value);
                 _previousTapPosition = null;
                 if (duration < _maxTapDuration && distanceToPreviousTap < maxTapDistance) // This distance check is between this and the previous tap.
-                    return onTapped(tapEndPosition.Value, TapType.Double); // Within wait period so fire.
+                    return onTapped(tapEndPosition.Value, TapType.DoubleTap); // Within wait period so fire.
             }
             else
             {
@@ -50,7 +74,7 @@ public class TapGestureTracker
                 // If the second tap is within the wait period we should fire a double tap
                 // but not another single tap.
                 _ = StartWaitingForSecondTapAsync(); // Fire and forget
-                return onTapped(tapEndPosition.Value, TapType.Single);
+                return onTapped(tapEndPosition.Value, TapType.SingleTap);
             }
         }
         else
@@ -62,7 +86,7 @@ public class TapGestureTracker
                 && distance < maxTapDistance;
 
             if (isLongTap)
-                return onTapped(tapEndPosition.Value, TapType.Long);
+                return onTapped(tapEndPosition.Value, TapType.LongPress);
         }
         return false;
     }

--- a/Mapsui/Manipulations/TapGestureTracker.cs
+++ b/Mapsui/Manipulations/TapGestureTracker.cs
@@ -3,38 +3,6 @@ using System.Threading.Tasks;
 
 namespace Mapsui.Manipulations;
 
-public enum TapType
-{
-    /// <summary>
-    /// First up after a down on nearly the same position.
-    /// </summary>
-    SingleTap,
-    /// <summary>
-    /// Two SingleTaps on nearly the same position within a certain time period.
-    /// </summary>
-    DoubleTap,
-    /// <summary>
-    /// // Previously down on nearly the same position during some specific period.
-    /// </summary>
-    LongPress,
-    /// <summary>
-    /// Previously up on other position.
-    /// </summary>
-    Hover,
-    /// <summary>
-    /// Previously down on other position.
-    /// </summary>
-    Drag,
-    /// <summary>
-    /// First up.
-    /// </summary>
-    Release,
-    /// <summary>
-    /// First down.
-    /// </summary>
-    Press,
-}
-
 public class TapGestureTracker
 {
     private readonly double _maxTapDuration = 0.5;
@@ -48,7 +16,7 @@ public class TapGestureTracker
 
     /// <returns>Indicates if the event was handled. If it is handled the caller should not do any further
     /// handling. The implementation of the tap event determines if the event is handled.</returns>
-    public bool TapIfNeeded(ScreenPosition? tapEndPosition, double maxTapDistance, Func<ScreenPosition, TapType, bool> onTapped)
+    public bool TapIfNeeded(ScreenPosition? tapEndPosition, double maxTapDistance, Func<ScreenPosition, GestureType, bool> onTapped)
     {
         if (_tapStartPosition is null) return false;
         if (tapEndPosition is null) return false; // Note, this uses the tapEndPosition parameter.
@@ -65,7 +33,7 @@ public class TapGestureTracker
                 var distanceToPreviousTap = tapEndPosition.Value.Distance(_previousTapPosition.Value);
                 _previousTapPosition = null;
                 if (duration < _maxTapDuration && distanceToPreviousTap < maxTapDistance) // This distance check is between this and the previous tap.
-                    return onTapped(tapEndPosition.Value, TapType.DoubleTap); // Within wait period so fire.
+                    return onTapped(tapEndPosition.Value, GestureType.DoubleTap); // Within wait period so fire.
             }
             else
             {
@@ -74,7 +42,7 @@ public class TapGestureTracker
                 // If the second tap is within the wait period we should fire a double tap
                 // but not another single tap.
                 _ = StartWaitingForSecondTapAsync(); // Fire and forget
-                return onTapped(tapEndPosition.Value, TapType.SingleTap);
+                return onTapped(tapEndPosition.Value, GestureType.SingleTap);
             }
         }
         else
@@ -86,7 +54,7 @@ public class TapGestureTracker
                 && distance < maxTapDistance;
 
             if (isLongTap)
-                return onTapped(tapEndPosition.Value, TapType.LongPress);
+                return onTapped(tapEndPosition.Value, GestureType.LongPress);
         }
         return false;
     }

--- a/Mapsui/Manipulations/TapGestureTracker.cs
+++ b/Mapsui/Manipulations/TapGestureTracker.cs
@@ -7,7 +7,8 @@ public enum TapType
 {
     Single,
     Double,
-    Long
+    Long,
+    None
 }
 
 public class TapGestureTracker
@@ -23,7 +24,7 @@ public class TapGestureTracker
 
     /// <returns>Indicates if the event was handled. If it is handled the caller should not do any further
     /// handling. The implementation of the tap event determines if the event is handled.</returns>
-    public bool TapIfNeeded(ScreenPosition? tapEndPosition, double maxTapDistance, Func<ScreenPosition, TapType, bool> onTap)
+    public bool TapIfNeeded(ScreenPosition? tapEndPosition, double maxTapDistance, Func<ScreenPosition, TapType, bool> onTapped)
     {
         if (_tapStartPosition is null) return false;
         if (tapEndPosition is null) return false; // Note, this uses the tapEndPosition parameter.
@@ -40,7 +41,7 @@ public class TapGestureTracker
                 var distanceToPreviousTap = tapEndPosition.Value.Distance(_previousTapPosition.Value);
                 _previousTapPosition = null;
                 if (duration < _maxTapDuration && distanceToPreviousTap < maxTapDistance) // This distance check is between this and the previous tap.
-                    return onTap(tapEndPosition.Value, TapType.Double); // Within wait period so fire.
+                    return onTapped(tapEndPosition.Value, TapType.Double); // Within wait period so fire.
             }
             else
             {
@@ -49,7 +50,7 @@ public class TapGestureTracker
                 // If the second tap is within the wait period we should fire a double tap
                 // but not another single tap.
                 _ = StartWaitingForSecondTapAsync(); // Fire and forget
-                return onTap(tapEndPosition.Value, TapType.Single);
+                return onTapped(tapEndPosition.Value, TapType.Single);
             }
         }
         else
@@ -61,7 +62,7 @@ public class TapGestureTracker
                 && distance < maxTapDistance;
 
             if (isLongTap)
-                return onTap(tapEndPosition.Value, TapType.Long);
+                return onTapped(tapEndPosition.Value, TapType.Long);
         }
         return false;
     }

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -175,6 +175,9 @@ public class Map : INotifyPropertyChanged, IDisposable
     /// Called whenever the map is clicked. The MapInfoEventArgs contain the features that were hit in
     /// the layers that have IsMapInfoLayer set to true. 
     /// </summary>
+    /// <remarks>
+    /// The Tapped event is preferred over the Info event. This event is kept for backwards compatibility.
+    /// </remarks>
     public event EventHandler<MapInfoEventArgs>? Info;
 
     /// <summary>

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -247,6 +247,26 @@ public class Map : INotifyPropertyChanged, IDisposable
         }
     }
 
+    public virtual bool OnTapped(MapEventArgs e)
+    {
+        return Tapped(this, e);
+    }
+
+    public virtual bool OnPointerPressed(MapEventArgs e)
+    {
+        return PointerPressed(this, e);
+    }
+
+    public virtual bool OnPointerMoved(MapEventArgs e)
+    {
+        return PointerMoved(this, e);
+    }
+
+    public virtual bool OnPointerReleased(MapEventArgs e)
+    {
+        return PointerReleased(this, e);
+    }
+
     private void LayersCollectionChanged(object sender, LayerCollectionChangedEventArgs args)
     {
         foreach (var layer in args.RemovedLayers ?? [])

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -247,21 +247,25 @@ public class Map : INotifyPropertyChanged, IDisposable
         }
     }
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual bool OnTapped(MapEventArgs e)
     {
         return Tapped(this, e);
     }
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual bool OnPointerPressed(MapEventArgs e)
     {
         return PointerPressed(this, e);
     }
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual bool OnPointerMoved(MapEventArgs e)
     {
         return PointerMoved(this, e);
     }
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual bool OnPointerReleased(MapEventArgs e)
     {
         return PointerReleased(this, e);

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -43,6 +43,11 @@ public class Map : INotifyPropertyChanged, IDisposable
         Navigator.ViewportChanged += Navigator_ViewportChanged;
     }
 
+    public Func<Map, MapEventArgs, bool> Tapped { get; set; } = (s, e) => false;
+    public Func<Map, MapEventArgs, bool> PointerPressed { get; set; } = (s, e) => false;
+    public Func<Map, MapEventArgs, bool> PointerMoved { get; set; } = (s, e) => false;
+    public Func<Map, MapEventArgs, bool> PointerReleased { get; set; } = (s, e) => false;
+
     private void Navigator_ViewportChanged(object? sender, ViewportChangedEventArgs e)
     {
         RefreshGraphics();

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -7,7 +7,6 @@
 using Mapsui.Extensions;
 using Mapsui.Fetcher;
 using Mapsui.Layers;
-using Mapsui.Logging;
 using Mapsui.Styles;
 using Mapsui.Widgets;
 using Mapsui.Widgets.InfoWidgets;
@@ -43,9 +42,21 @@ public class Map : INotifyPropertyChanged, IDisposable
         Navigator.ViewportChanged += Navigator_ViewportChanged;
     }
 
+    /// <summary>
+    /// Event that is triggered when the map is tapped. Can be a single tap, double tap or long press.
+    /// </summary>
     public Func<Map, MapEventArgs, bool> Tapped { get; set; } = (s, e) => false;
+    /// <summary>
+    /// Event that is triggered when on pointer down.
+    /// </summary>
     public Func<Map, MapEventArgs, bool> PointerPressed { get; set; } = (s, e) => false;
+    /// <summary>
+    /// Event that is triggered when on pointer move. Can be a drag or hover.
+    /// </summary>
     public Func<Map, MapEventArgs, bool> PointerMoved { get; set; } = (s, e) => false;
+    /// <summary>
+    /// Event that is triggered when on pointer up.
+    /// </summary>
     public Func<Map, MapEventArgs, bool> PointerReleased { get; set; } = (s, e) => false;
 
     private void Navigator_ViewportChanged(object? sender, ViewportChangedEventArgs e)
@@ -424,6 +435,5 @@ public class Map : INotifyPropertyChanged, IDisposable
         HorizontalAlignment = HorizontalAlignment.Stretch,
         BackColor = Color.Transparent,
         Opacity = 0.0f,
-        LogLevelFilter = LogLevel.Trace,
     };
 }

--- a/Mapsui/MapEventArgs.cs
+++ b/Mapsui/MapEventArgs.cs
@@ -4,9 +4,9 @@ namespace Mapsui;
 
 public class MapEventArgs : BaseEventArgs
 {
-    public MapEventArgs(ScreenPosition screenPosition, MPoint worldPosition, TapType tapType, Viewport viewport,
+    public MapEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, Viewport viewport,
         GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync)
-        : base(screenPosition, worldPosition, tapType, viewport, getMapInfo, getRemoteMapInfoAsync)
+        : base(screenPosition, worldPosition, gestureType, viewport, getMapInfo, getRemoteMapInfoAsync)
     {
     }
 }

--- a/Mapsui/MapEventArgs.cs
+++ b/Mapsui/MapEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using Mapsui.Manipulations;
+
+namespace Mapsui;
+
+public class MapEventArgs : BaseEventArgs
+{
+    public MapEventArgs(ScreenPosition screenPosition, MPoint worldPosition, TapType tapType, Viewport viewport,
+        GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync)
+        : base(screenPosition, worldPosition, tapType, viewport, getMapInfo, getRemoteMapInfoAsync)
+    {
+    }
+}

--- a/Mapsui/MapInfoEventArgs.cs
+++ b/Mapsui/MapInfoEventArgs.cs
@@ -2,9 +2,9 @@
 
 namespace Mapsui;
 
-public class MapInfoEventArgs(ScreenPosition screenPosition, MPoint worldPosition, TapType tapType,
+public class MapInfoEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType,
     Viewport viewport, bool handled, GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync)
-        : BaseEventArgs(screenPosition, worldPosition, tapType, viewport, getMapInfo, getRemoteMapInfoAsync)
+        : BaseEventArgs(screenPosition, worldPosition, gestureType, viewport, getMapInfo, getRemoteMapInfoAsync)
 {
     /// <summary>
     /// If the interaction was handled by the event subscriber

--- a/Mapsui/Widgets/ButtonWidgets/ButtonWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/ButtonWidget.cs
@@ -8,8 +8,7 @@ public class ButtonWidget : TextBoxWidget
     /// <summary>
     /// Event which is called if widget is touched
     /// </summary>
-    public Func<ButtonWidget, WidgetEventArgs, bool> Tapped = (s, e) => false;
-
+    public Func<ButtonWidget, WidgetEventArgs, bool> Tapped { get; set; } = (s, e) => false;
 
     /// <summary>
     /// Handle touch to Widget

--- a/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
@@ -67,6 +67,9 @@ public class LoggingWidget : TextBoxWidget
         if (!ShouldLog(Enabled, ShowLoggingInMap))
             return;
 
+        if (LogLevelFilter < level)
+            return;
+
         var entry = new LogEntry { LogLevel = level, FormattedLogLine = ToFormattedLogLine(level, description, exception) };
 
         _listOfLogEntries.Enqueue(entry);

--- a/Mapsui/Widgets/InfoWidgets/MapInfoWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/MapInfoWidget.cs
@@ -45,7 +45,7 @@ public class MapInfoWidget : TextBoxWidget
         // Todo: Avoid Map in the constructor. Perhaps the event args should have a GetMapInfoAsync method
         _map = map;
         _layers = getMapInfoLayers;
-        _map.Info += Map_Info;
+        _map.Tapped += MapTapped;
 
         VerticalAlignment = VerticalAlignment.Bottom;
         HorizontalAlignment = HorizontalAlignment.Left;
@@ -56,15 +56,15 @@ public class MapInfoWidget : TextBoxWidget
         TextColor = Color.White;
     }
 
-    private void Map_Info(object? sender, MapInfoEventArgs a)
+    private bool MapTapped(Map map, MapEventArgs e)
     {
-        var mapInfo = a.GetMapInfo(_layers());
+        var mapInfo = e.GetMapInfo(_layers());
         Text = FeatureToText(mapInfo.Feature);
         _map.RefreshGraphics();
         // Try to load async data
         Catch.Exceptions(async () =>
         {
-            var info = await a.GetRemoteMapInfoAsync(_map.Layers.Where(t => t is ILayerFeatureInfo));
+            var info = await e.GetRemoteMapInfoAsync(_map.Layers.Where(t => t is ILayerFeatureInfo));
             var featureText = FeatureToText(info.Feature);
             if (!string.IsNullOrEmpty(featureText))
             {
@@ -72,6 +72,7 @@ public class MapInfoWidget : TextBoxWidget
                 _map.RefreshGraphics();
             }
         });
+        return true;
     }
 
     public Func<IFeature?, string> FeatureToText { get; set; } = (f) =>

--- a/Mapsui/Widgets/InfoWidgets/RulerWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/RulerWidget.cs
@@ -49,30 +49,30 @@ public class RulerWidget(Map map) : BaseWidget
 
     public override bool OnPointerMoved(Navigator navigator, WidgetEventArgs e)
     {
-        if (e.TapType == TapType.Hover)
+        if (e.GestureType == GestureType.Hover)
             return false; // Not dragging.
 
         CurrentPosition = _map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
         DistanceInKilometers = GetDistance(StartPosition, CurrentPosition);
-        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(TapType.Drag));
+        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(GestureType.Drag));
         _map.RefreshGraphics();
         return true;
     }
 
     public override bool OnPointerReleased(Navigator navigator, WidgetEventArgs e)
     {
-        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(TapType.Release));
+        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(GestureType.Release));
         _map.RefreshGraphics();
         return true;
     }
 
     public override bool OnTapped(Navigator navigator, WidgetEventArgs e)
     {
-        if (e.TapType == TapType.SingleTap)
+        if (e.GestureType == GestureType.SingleTap)
         {
             StartPosition = _map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
             CurrentPosition = null;
-            DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(TapType.SingleTap));
+            DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(GestureType.SingleTap));
             _map.RefreshGraphics();
         }
         return true;
@@ -116,8 +116,8 @@ public class RulerWidget(Map map) : BaseWidget
         return (startFeature, currentFeature);
     }
 
-    public class RulerWidgetUpdatedEventArgs(TapType tapType) : EventArgs
+    public class RulerWidgetUpdatedEventArgs(GestureType gestureType) : EventArgs
     {
-        public TapType TapType { get; } = tapType;
+        public GestureType GestureType { get; } = gestureType;
     }
 }

--- a/Mapsui/Widgets/InfoWidgets/RulerWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/RulerWidget.cs
@@ -10,14 +10,6 @@ namespace Mapsui.Widgets.InfoWidgets;
 
 public class RulerWidget(Map map) : BaseWidget
 {
-    public enum RulerTapType
-    {
-        Down,
-        Drag,
-        Hover,
-        Up
-    }
-
     private readonly Map _map = map;
 
     public Color Color { get; set; } = new Color(192, 30, 20, 255);
@@ -57,30 +49,30 @@ public class RulerWidget(Map map) : BaseWidget
 
     public override bool OnPointerMoved(Navigator navigator, WidgetEventArgs e)
     {
-        if (e.TapType == TapType.None)
+        if (e.TapType == TapType.Hover)
             return false; // Not dragging.
 
         CurrentPosition = _map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
         DistanceInKilometers = GetDistance(StartPosition, CurrentPosition);
-        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(RulerTapType.Drag));
+        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(TapType.Drag));
         _map.RefreshGraphics();
         return true;
     }
 
     public override bool OnPointerReleased(Navigator navigator, WidgetEventArgs e)
     {
-        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(RulerTapType.Up));
+        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(TapType.Release));
         _map.RefreshGraphics();
         return true;
     }
 
     public override bool OnTapped(Navigator navigator, WidgetEventArgs e)
     {
-        if (e.TapType == TapType.Single)
+        if (e.TapType == TapType.SingleTap)
         {
             StartPosition = _map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
             CurrentPosition = null;
-            DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(RulerTapType.Down));
+            DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(TapType.SingleTap));
             _map.RefreshGraphics();
         }
         return true;
@@ -124,8 +116,8 @@ public class RulerWidget(Map map) : BaseWidget
         return (startFeature, currentFeature);
     }
 
-    public class RulerWidgetUpdatedEventArgs(RulerTapType tapType) : EventArgs
+    public class RulerWidgetUpdatedEventArgs(TapType tapType) : EventArgs
     {
-        public RulerTapType TapType { get; } = tapType;
+        public TapType TapType { get; } = tapType;
     }
 }

--- a/Mapsui/Widgets/InfoWidgets/RulerWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/RulerWidget.cs
@@ -4,12 +4,13 @@ using Mapsui.Styles;
 using System;
 using Mapsui.Widgets.BoxWidgets;
 using System.Collections.Generic;
+using Mapsui.Manipulations;
 
 namespace Mapsui.Widgets.InfoWidgets;
 
 public class RulerWidget(Map map) : BaseWidget
 {
-    public enum TapType
+    public enum RulerTapType
     {
         Down,
         Drag,
@@ -56,30 +57,30 @@ public class RulerWidget(Map map) : BaseWidget
 
     public override bool OnPointerMoved(Navigator navigator, WidgetEventArgs e)
     {
-        if (!e.LeftButton)
+        if (e.TapType == TapType.None)
             return false; // Not dragging.
 
         CurrentPosition = _map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
         DistanceInKilometers = GetDistance(StartPosition, CurrentPosition);
-        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(e.LeftButton ? TapType.Drag : TapType.Hover));
+        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(RulerTapType.Drag));
         _map.RefreshGraphics();
         return true;
     }
 
     public override bool OnPointerReleased(Navigator navigator, WidgetEventArgs e)
     {
-        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(TapType.Up));
+        DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(RulerTapType.Up));
         _map.RefreshGraphics();
         return true;
     }
 
     public override bool OnTapped(Navigator navigator, WidgetEventArgs e)
     {
-        if (e.TapType == Manipulations.TapType.Single)
+        if (e.TapType == TapType.Single)
         {
             StartPosition = _map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
             CurrentPosition = null;
-            DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(TapType.Down));
+            DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(RulerTapType.Down));
             _map.RefreshGraphics();
         }
         return true;
@@ -123,8 +124,8 @@ public class RulerWidget(Map map) : BaseWidget
         return (startFeature, currentFeature);
     }
 
-    public class RulerWidgetUpdatedEventArgs(TapType tapType) : EventArgs
+    public class RulerWidgetUpdatedEventArgs(RulerTapType tapType) : EventArgs
     {
-        public TapType TapType { get; } = tapType;
+        public RulerTapType TapType { get; } = tapType;
     }
 }

--- a/Mapsui/Widgets/WidgetEventArgs.cs
+++ b/Mapsui/Widgets/WidgetEventArgs.cs
@@ -5,9 +5,9 @@ namespace Mapsui.Widgets;
 /// <summary>
 /// Arguments for a touched event of a widget
 /// </summary>
-public class WidgetEventArgs(ScreenPosition screenPosition, MPoint worldPosition, TapType tapType, Viewport viewport,
+public class WidgetEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType getstureType, Viewport viewport,
     bool shiftPressed, GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync)
-    : BaseEventArgs(screenPosition, worldPosition, tapType, viewport, getMapInfo, getRemoteMapInfoAsync)
+    : BaseEventArgs(screenPosition, worldPosition, getstureType, viewport, getMapInfo, getRemoteMapInfoAsync)
 {
     /// <summary>
     /// Shift key pressed while touching

--- a/Mapsui/Widgets/WidgetEventArgs.cs
+++ b/Mapsui/Widgets/WidgetEventArgs.cs
@@ -6,14 +6,9 @@ namespace Mapsui.Widgets;
 /// Arguments for a touched event of a widget
 /// </summary>
 public class WidgetEventArgs(ScreenPosition screenPosition, MPoint worldPosition, TapType tapType, Viewport viewport,
-    bool leftButton, bool shiftPressed, GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync)
+    bool shiftPressed, GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync)
     : BaseEventArgs(screenPosition, worldPosition, tapType, viewport, getMapInfo, getRemoteMapInfoAsync)
 {
-    /// <summary>
-    /// Left button used while touching
-    /// </summary>
-    public bool LeftButton { get; } = leftButton;
-
     /// <summary>
     /// Shift key pressed while touching
     /// </summary>

--- a/Mapsui/Widgets/WidgetEventArgs.cs
+++ b/Mapsui/Widgets/WidgetEventArgs.cs
@@ -5,9 +5,9 @@ namespace Mapsui.Widgets;
 /// <summary>
 /// Arguments for a touched event of a widget
 /// </summary>
-public class WidgetEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType getstureType, Viewport viewport,
+public class WidgetEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, Viewport viewport,
     bool shiftPressed, GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync)
-    : BaseEventArgs(screenPosition, worldPosition, getstureType, viewport, getMapInfo, getRemoteMapInfoAsync)
+    : BaseEventArgs(screenPosition, worldPosition, gestureType, viewport, getMapInfo, getRemoteMapInfoAsync)
 {
     /// <summary>
     /// Shift key pressed while touching

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportCenterAndZoomAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportCenterAndZoomAnimationSample.cs
@@ -22,13 +22,12 @@ public class ViewportCenterAndZoomAnimationSample : ISample
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Widgets.Add(new ZoomInOutWidget { Margin = new MRect(20, 40) });
         map.Widgets.Add(CreateTextBox("Tap on the map to center on that location and zoom in on it"));
-
-        map.Info += (s, e) =>
+        map.Tapped += (m, e) =>
         {
             // Animate to the new center and new resolution
-            map.Navigator.CenterOnAndZoomTo(e.WorldPosition, e.Viewport.Resolution * 0.5, 500, Easing.CubicOut);
+            m.Navigator.CenterOnAndZoomTo(e.WorldPosition, e.Viewport.Resolution * 0.5, 500, Easing.CubicOut);
+            return true;
         };
-
         return map;
     }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportCenterOnAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportCenterOnAnimationSample.cs
@@ -20,18 +20,15 @@ public class ViewportCenterOnAnimationSample : ISample
 
     public static Map CreateMap()
     {
-        string instructions = "Tap on the map to center on that location";
-
         var map = new Map { CRS = "EPSG:3857" };
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Widgets.Add(new ZoomInOutWidget { Margin = new MRect(20, 40) });
-
-        map.Widgets.Add(CreateTextBox(instructions));
-
-        map.Info += (s, e) =>
+        map.Widgets.Add(CreateTextBox("Tap on the map to center on that location"));
+        map.Tapped += (m, e) =>
         {
             // Animate to the new center.
-            map.Navigator.CenterOn(e.WorldPosition, 500, Easing.CubicOut);
+            m.Navigator.CenterOn(e.WorldPosition, 500, Easing.CubicOut);
+            return true;
         };
         return map;
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportFlyToAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportFlyToAnimationSample.cs
@@ -23,13 +23,12 @@ public class ViewportFlyToAnimationSample : ISample
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Widgets.Add(new ZoomInOutWidget { Margin = new MRect(20, 40) });
         map.Widgets.Add(CreateTextBox("Tap on the map to fly to that location. The fly-to animation zooms out and then in."));
-
-        map.Info += (s, e) =>
+        map.Tapped += (m, e) =>
         {
             // 'FlyTo' is a specific navigation that moves to a new center while moving in and out.
-            map.Navigator.FlyTo(e.WorldPosition, e.Viewport.Resolution * 1.5, 500);
+            m.Navigator.FlyTo(e.WorldPosition, e.Viewport.Resolution * 1.5, 500);
+            return true;
         };
-
         return map;
     }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportZoomAroundLocationAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportZoomAroundLocationAnimationSample.cs
@@ -23,15 +23,14 @@ public class ViewportZoomAroundLocationAnimationSample : ISample
         var map = new Map { CRS = "EPSG:3857" };
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Widgets.Add(new ZoomInOutWidget { Margin = new MRect(20, 40) });
-
         map.Widgets.Add(CreateTextBox("Tap on the map to zoom in the location where you tapped. " +
             "The map will stay centered on the place where you tap."));
-
-        map.Info += (s, e) =>
+        map.Tapped += (m, e) =>
         {
             // Zoom in while keeping centerOfZoom at the same position. If you click somewhere to zoom in the mouse pointer
             // will still be above the same location in the map. This can be you used for mouse wheel zoom.
-            map.Navigator.ZoomTo(e.Viewport.Resolution * 0.5, e.ScreenPosition!, 500, Easing.CubicOut);
+            m.Navigator.ZoomTo(e.Viewport.Resolution * 0.5, e.ScreenPosition!, 500, Easing.CubicOut);
+            return true;
         };
         return map;
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
@@ -23,23 +23,24 @@ public class DynamicSvgStyleSample : ISample
     public Task<Map> CreateMapAsync()
     {
         var infoPosition = new MPoint(); // Use closure to keep track of the info click position
-
         var map = new Map();
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(new MemoryLayer("Dynamic Svg Style")
-        {
-            Features = RandomPointsBuilder.CreateRandomFeatures(map.Extent, 1000),
-            Style = CreateDynamicSvgStyle(() => infoPosition)
-        });
-
-        map.Info += (s, e) =>
+        map.Layers.Add(CreateLayerWithDynamicSvgStyle(infoPosition, map));
+        map.Tapped += (m, e) =>
         {
             infoPosition = e.WorldPosition; // Set the info position to use in the dynamic style
-            map.Layers.First().DataHasChanged(); // To notify the map that a redraw is needed.
+            m.Layers.First().DataHasChanged(); // To notify the map that a redraw is needed.
+            return true;
         };
-
         return Task.FromResult(map);
     }
+
+    private MemoryLayer CreateLayerWithDynamicSvgStyle(MPoint infoPosition, Map map) => new()
+    {
+        Name = "Dynamic Svg Style",
+        Features = RandomPointsBuilder.CreateRandomFeatures(map.Extent, 1000),
+        Style = CreateDynamicSvgStyle(() => infoPosition)
+    };
 
     private IStyle CreateDynamicSvgStyle(Func<MPoint> getInfoPosition) // Use Func to make it get the latest clicked position
     {

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/WriteToLayerSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/WriteToLayerSample.cs
@@ -5,6 +5,7 @@ using Mapsui.Tiling;
 using NetTopologySuite.Geometries;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Mapsui.Samples.Common.Maps.Demo;
@@ -16,20 +17,16 @@ public class WriteToLayerSample : ISample
 
     [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP001:Dispose created")]
     [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP004:Don't ignore created IDisposable")]
-    public Task<Map> CreateMapAsync()
+    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+
+    private static Map CreateMap()
     {
         var map = new Map();
-
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
-
-        var layer = new GenericCollectionLayer<List<IFeature>>
+        map.Layers.Add(CreateGenericCollectionLayer());
+        map.Tapped += (m, e) =>
         {
-            Style = SymbolStyles.CreatePinStyle()
-        };
-        map.Layers.Add(layer);
-
-        map.Info += (s, e) =>
-        {
+            var layer = (GenericCollectionLayer<List<IFeature>>)m.Layers.First(l => l.Name == "GenericCollectionLayer");
             // Add a point to the layer using the Info position
             layer?.Features.Add(new GeometryFeature
             {
@@ -37,9 +34,17 @@ public class WriteToLayerSample : ISample
             });
             // To notify the map that a redraw is needed.
             layer?.DataHasChanged();
-            return;
+            return true;
         };
+        return map;
+    }
 
-        return Task.FromResult(map);
+    private static GenericCollectionLayer<List<IFeature>> CreateGenericCollectionLayer()
+    {
+        return new GenericCollectionLayer<List<IFeature>>
+        {
+            Name = "GenericCollectionLayer",
+            Style = SymbolStyles.CreatePinStyle()
+        };
     }
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
@@ -12,6 +12,7 @@ using Mapsui.Widgets.InfoWidgets;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Topten.RichTextKit;
 using IStyle = Mapsui.Styles.IStyle;
 
@@ -34,29 +35,29 @@ public class CustomCalloutStyleSample : IMapControlSample
         MapRenderer.RegisterStyleRenderer(typeof(CustomCalloutStyle), new CustomCalloutStyleRenderer());
 
         var map = new Map();
-
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
 
         var points = RandomPointsBuilder.GenerateRandomPoints(map.Extent, 25, 9898);
-        var calloutLayer = CreateCalloutLayer(CreateFeatures(points));
-        map.Layers.Add(calloutLayer);
+        map.Layers.Add(CreateCalloutLayer(CreateFeatures(points)));
 
         map.Widgets.Add(new MapInfoWidget(map, l => l.Name == _customStyleLayerName));
-        map.Info += (s, e) => MapOnInfo(s, e, calloutLayer);
+        map.Tapped += MapTapped;
 
         return map;
     }
 
-    private static void MapOnInfo(object? sender, MapInfoEventArgs e, ILayer calloutLayer)
+    private static bool MapTapped(Map map, MapEventArgs e)
     {
-        var feature = e.GetMapInfo([calloutLayer]).Feature;
+        var feature = e.GetMapInfo(map.Layers.Where(l => l.Name == _customStyleLayerName)).Feature;
         if (feature is not null)
         {
             if (feature["show-callout"]?.ToString() == "true")
                 feature["show-callout"] = "false";
             else
                 feature["show-callout"] = "true";
+            return true;
         }
+        return false;
     }
 
     private static MemoryLayer CreateCalloutLayer(IEnumerable<IFeature> features) => new()

--- a/Samples/Mapsui.Samples.Common/Maps/Info/ImageCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/ImageCalloutSample.cs
@@ -29,30 +29,30 @@ public class ImageCalloutSample : ISample
 
     private const string _pointLayerName = "Point with callout";
 
-    public Task<Map> CreateMapAsync()
+    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+
+    private static Map CreateMap()
     {
         var map = new Map();
-
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        var pointLayer = CreatePointLayer();
-        map.Layers.Add(pointLayer);
+        map.Layers.Add(CreatePointLayer());
         map.Navigator.CenterOnAndZoomTo(map.Layers.Get(1).Extent!.Centroid, map.Navigator.Resolutions[5]);
-
         map.Widgets.Add(new MapInfoWidget(map, l => l.Name == _pointLayerName));
-        map.Info += (s, e) => MapOnInfo(s, e, pointLayer);
-
-        return Task.FromResult(map);
+        map.Tapped += MapTapped;
+        return map;
     }
 
-    private static void MapOnInfo(object? sender, MapInfoEventArgs e, ILayer pointLayer)
+    private static bool MapTapped(Map map, MapEventArgs e)
     {
-        var mapInfo = e.GetMapInfo([pointLayer]);
+        var mapInfo = e.GetMapInfo(map.Layers.Where(l => l.Name == _pointLayerName));
         var calloutStyle = mapInfo.Feature?.Styles.OfType<CalloutStyle>().FirstOrDefault();
         if (calloutStyle is not null)
         {
             calloutStyle.Enabled = !calloutStyle.Enabled;
             mapInfo.Layer?.DataHasChanged();
+            return true;
         }
+        return false;
     }
 
     private static Layer CreatePointLayer()

--- a/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
@@ -31,25 +31,26 @@ public class SingleCalloutSample : ISample
         var map = new Map();
 
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        var pointLayer = CreatePointLayer();
-        map.Layers.Add(pointLayer);
+        map.Layers.Add(CreatePointLayer());
         map.Navigator.CenterOnAndZoomTo(map.Layers.Get(1).Extent!.Centroid, map.Navigator.Resolutions[5]);
-        map.Info += (s, e) => MapOnInfo(s, e, pointLayer);
+        map.Tapped += MapTapped;
 
         map.Widgets.Add(new MapInfoWidget(map, l => l.Name == _calloutLayerName));
 
         return Task.FromResult(map);
     }
 
-    private static void MapOnInfo(object? sender, MapInfoEventArgs e, ILayer pointLayer)
+    private static bool MapTapped(Map map, MapEventArgs e)
     {
-        var mapInfo = e.GetMapInfo([pointLayer]);
+        var mapInfo = e.GetMapInfo(map.Layers.Where(l => l.Name == _calloutLayerName));
         var calloutStyle = mapInfo.Feature?.Styles.OfType<CalloutStyle>().FirstOrDefault();
         if (calloutStyle is not null)
         {
             calloutStyle.Enabled = !calloutStyle.Enabled;
             mapInfo.Layer?.DataHasChanged(); // To trigger a refresh of graphics.
+            return true;
         }
+        return false;
     }
 
     private static MemoryLayer CreatePointLayer()

--- a/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
@@ -41,10 +41,14 @@ public static class SampleMapBuilderExtensions
 {
     public static ILayer WithPinWithCalloutLayer(this ILayer layer, Map map)
     {
-        map.Info += (s, e) =>
+        map.Tapped += (m, e) =>
         {
             if (e.GetMapInfo([layer]).Feature?.Data is UserData data)
+            {
                 data.CalloutEnabled = !data.CalloutEnabled;
+                return true;
+            }
+            return false;
         };
 
         layer.WithPinAndCallout(

--- a/Samples/Mapsui.Samples.Common/Maps/Navigation/MyLocationLayerSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Navigation/MyLocationLayerSample.cs
@@ -42,7 +42,7 @@ public class MyLocationLayerSample : ISample, IDisposable
 
         var points = CreatePoints(centerOfLondonOntario);
 
-        map.Info += (s, e) =>
+        map.Tapped += (m, e) =>
         {
             if (_count >= 20)
                 _count = 0;
@@ -55,6 +55,7 @@ public class MyLocationLayerSample : ISample, IDisposable
             _myLocationLayer.UpdateMySpeed(points[_count].Item4);
 
             _count++;
+            return true;
         };
 
         return Task.FromResult(map);

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SelectionStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SelectionStyleSample.cs
@@ -17,24 +17,26 @@ internal class SelectionStyleSample : ISample
     public string Name => "Selection";
     public string Category => "Styles";
 
-    public Task<Map> CreateMapAsync()
+    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+
+    private static Map CreateMap()
     {
         var map = new Map();
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        var pointLayer = CreatePointLayer();
-        map.Layers.Add(pointLayer);
-        map.Info += (s, e) => ToggleSelected(e.GetMapInfo([pointLayer]).Feature);
-
+        map.Layers.Add(CreatePointLayer());
         map.Widgets.Add(new MapInfoWidget(map, l => l.Name == "Points"));
-
-        return Task.FromResult(map);
+        map.Tapped += MapTapped;
+        return map;
     }
 
-    private static void ToggleSelected(IFeature? feature)
+    private static bool MapTapped(Map map, MapEventArgs e)
     {
-        if (feature is null) return;
+        var feature = e.GetMapInfo(map.Layers.Where(l => l.Name == "Points")).Feature;
+        if (feature is null)
+            return false; ;
         if (feature["selected"] is null) feature["selected"] = "true";
         else feature["selected"] = null;
+        return true;
     }
 
     public static ILayer CreatePointLayer() => new Layer("Points")

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
@@ -27,7 +27,7 @@ public class ButtonWidgetSample : ISample
 
         map.Widgets.Add(CreateButtonWidget("Tap me", VerticalAlignment.Top, HorizontalAlignment.Left, (s, e) =>
         {
-            if (e.TapType == TapType.Double)
+            if (e.TapType == TapType.DoubleTap)
                 return false;
             s.Text = $"Tapped {++_tapCount} times";
             map.RefreshGraphics();
@@ -47,7 +47,7 @@ public class ButtonWidgetSample : ISample
         }));
         map.Widgets.Add(CreateButtonWidget("Double Tap me", VerticalAlignment.Bottom, HorizontalAlignment.Left, (s, e) =>
         {
-            if (e.TapType == TapType.Single)
+            if (e.TapType == TapType.SingleTap)
                 return false;
             s.Text = $"Double Tapped {++_doubleTapCount} times";
             map.RefreshGraphics();

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
@@ -27,7 +27,7 @@ public class ButtonWidgetSample : ISample
 
         map.Widgets.Add(CreateButtonWidget("Tap me", VerticalAlignment.Top, HorizontalAlignment.Left, (s, e) =>
         {
-            if (e.TapType == TapType.DoubleTap)
+            if (e.GestureType == GestureType.DoubleTap)
                 return false;
             s.Text = $"Tapped {++_tapCount} times";
             map.RefreshGraphics();
@@ -47,7 +47,7 @@ public class ButtonWidgetSample : ISample
         }));
         map.Widgets.Add(CreateButtonWidget("Double Tap me", VerticalAlignment.Bottom, HorizontalAlignment.Left, (s, e) =>
         {
-            if (e.TapType == TapType.SingleTap)
+            if (e.GestureType == GestureType.SingleTap)
                 return false;
             s.Text = $"Double Tapped {++_doubleTapCount} times";
             map.RefreshGraphics();

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
@@ -53,7 +53,7 @@ public class CustomWidget : BaseWidget
     {
         base.OnTapped(navigator, e);
 
-        if (e.TapType == TapType.SingleTap)
+        if (e.GestureType == GestureType.SingleTap)
             Color = GenerateRandomColor();
         else
             Color = Mapsui.Styles.Color.Transparent;

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
@@ -53,7 +53,7 @@ public class CustomWidget : BaseWidget
     {
         base.OnTapped(navigator, e);
 
-        if (e.TapType == TapType.Single)
+        if (e.TapType == TapType.SingleTap)
             Color = GenerateRandomColor();
         else
             Color = Mapsui.Styles.Color.Transparent;

--- a/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
+++ b/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
@@ -40,7 +40,7 @@ public class ManyPinsSample : IMapViewSample
 
         switch (e?.TapType)
         {
-            case TapType.Single:
+            case TapType.SingleTap:
                 var pin = new Pin(mapView)
                 {
                     Label = $"PinType.Pin {markerNum++}",
@@ -75,7 +75,7 @@ public class ManyPinsSample : IMapViewSample
                 mapView.Pins.Add(pin);
                 pin.ShowCallout();
                 break;
-            case TapType.Double:
+            case TapType.DoubleTap:
                 foreach (var r in assembly.GetManifestResourceNames())
                     System.Diagnostics.Debug.WriteLine(r);
 

--- a/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
+++ b/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
@@ -38,9 +38,9 @@ public class ManyPinsSample : IMapViewSample
         foreach (var str in assembly.GetManifestResourceNames())
             System.Diagnostics.Debug.WriteLine(str);
 
-        switch (e?.TapType)
+        switch (e?.GestureType)
         {
-            case TapType.SingleTap:
+            case GestureType.SingleTap:
                 var pin = new Pin(mapView)
                 {
                     Label = $"PinType.Pin {markerNum++}",
@@ -75,7 +75,7 @@ public class ManyPinsSample : IMapViewSample
                 mapView.Pins.Add(pin);
                 pin.ShowCallout();
                 break;
-            case TapType.DoubleTap:
+            case GestureType.DoubleTap:
                 foreach (var r in assembly.GetManifestResourceNames())
                     System.Diagnostics.Debug.WriteLine(r);
 
@@ -90,7 +90,7 @@ public class ManyPinsSample : IMapViewSample
                 });
                 break;
             default:
-                throw new Exception("Unknown TapType. This is bug in Mapsui.");
+                throw new Exception($"Unknown {nameof(GestureType)}. This is bug in Mapsui.");
         }
 
         return true;

--- a/Samples/Mapsui.Samples.MapView/PinSample.cs
+++ b/Samples/Mapsui.Samples.MapView/PinSample.cs
@@ -38,7 +38,7 @@ public class PinSample : IMapViewSample
         var position = mapClickedArgs.Point;
         switch (mapClickedArgs.TapType)
         {
-            case TapType.Single:
+            case TapType.SingleTap:
                 var pin = new Pin(mapView)
                 {
                     Label = $"PinType.Pin {_markerNum++}",
@@ -81,7 +81,7 @@ public class PinSample : IMapViewSample
                 }
                 pin.Callout.CalloutClicked += (s, e) =>
                 {
-                    if (e.TapType == TapType.Double)
+                    if (e.TapType == TapType.DoubleTap)
                     {
                         // Double click on callout moves pin
                         var p = e.Callout?.Pin;
@@ -103,7 +103,7 @@ public class PinSample : IMapViewSample
                 mapView.Pins.Add(pin);
                 pin.ShowCallout();
                 break;
-            case TapType.Double:
+            case TapType.DoubleTap:
                 var resourceName = "embedded://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg";
                 mapView.Pins.Add(new Pin(mapView)
                 {

--- a/Samples/Mapsui.Samples.MapView/PinSample.cs
+++ b/Samples/Mapsui.Samples.MapView/PinSample.cs
@@ -36,9 +36,9 @@ public class PinSample : IMapViewSample
             System.Diagnostics.Debug.WriteLine(str);
 
         var position = mapClickedArgs.Point;
-        switch (mapClickedArgs.TapType)
+        switch (mapClickedArgs.GestureType)
         {
-            case TapType.SingleTap:
+            case GestureType.SingleTap:
                 var pin = new Pin(mapView)
                 {
                     Label = $"PinType.Pin {_markerNum++}",
@@ -81,7 +81,7 @@ public class PinSample : IMapViewSample
                 }
                 pin.Callout.CalloutClicked += (s, e) =>
                 {
-                    if (e.TapType == TapType.DoubleTap)
+                    if (e.GestureType == GestureType.DoubleTap)
                     {
                         // Double click on callout moves pin
                         var p = e.Callout?.Pin;
@@ -103,7 +103,7 @@ public class PinSample : IMapViewSample
                 mapView.Pins.Add(pin);
                 pin.ShowCallout();
                 break;
-            case TapType.DoubleTap:
+            case GestureType.DoubleTap:
                 var resourceName = "embedded://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg";
                 mapView.Pins.Add(new Pin(mapView)
                 {

--- a/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
@@ -135,13 +135,13 @@ public sealed partial class MainPageLarge : ContentPage, IDisposable
     {
         if (e.Pin != null)
         {
-            if (e.TapType == TapType.Double)
+            if (e.TapType == TapType.DoubleTap)
             {
                 // Hide Pin when double click
                 //DisplayAlert($"Pin {e.Pin.Label}", $"Is at position {e.Pin.Position}", "Ok");
                 e.Pin.IsVisible = false;
             }
-            if (e.TapType == TapType.Single)
+            if (e.TapType == TapType.SingleTap)
                 if (e.Pin.Callout.IsVisible)
                     e.Pin.HideCallout();
                 else

--- a/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
@@ -135,13 +135,13 @@ public sealed partial class MainPageLarge : ContentPage, IDisposable
     {
         if (e.Pin != null)
         {
-            if (e.TapType == TapType.DoubleTap)
+            if (e.GestureType == GestureType.DoubleTap)
             {
                 // Hide Pin when double click
                 //DisplayAlert($"Pin {e.Pin.Label}", $"Is at position {e.Pin.Position}", "Ok");
                 e.Pin.IsVisible = false;
             }
-            if (e.TapType == TapType.SingleTap)
+            if (e.GestureType == GestureType.SingleTap)
                 if (e.Pin.Callout.IsVisible)
                     e.Pin.HideCallout();
                 else

--- a/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
@@ -101,13 +101,13 @@ public sealed partial class MapPage : ContentPage, IDisposable
     {
         if (e.Pin != null)
         {
-            if (e.TapType == TapType.Double)
+            if (e.TapType == TapType.DoubleTap)
             {
                 // Hide Pin when double click
                 //DisplayAlert($"Pin {e.Pin.Label}", $"Is at position {e.Pin.Position}", "Ok");
                 e.Pin.IsVisible = false;
             }
-            if (e.TapType == TapType.Single)
+            if (e.TapType == TapType.SingleTap)
                 if (e.Pin.Callout.IsVisible)
                     e.Pin.HideCallout();
                 else

--- a/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
@@ -101,13 +101,13 @@ public sealed partial class MapPage : ContentPage, IDisposable
     {
         if (e.Pin != null)
         {
-            if (e.TapType == TapType.DoubleTap)
+            if (e.GestureType == GestureType.DoubleTap)
             {
                 // Hide Pin when double click
                 //DisplayAlert($"Pin {e.Pin.Label}", $"Is at position {e.Pin.Position}", "Ok");
                 e.Pin.IsVisible = false;
             }
-            if (e.TapType == TapType.SingleTap)
+            if (e.GestureType == GestureType.SingleTap)
                 if (e.Pin.Callout.IsVisible)
                     e.Pin.HideCallout();
                 else


### PR DESCRIPTION
Breaking change:
- Rename TapType to GestureType and renamed the fields.

Done:
- Add Tapped, PointerPressed, PointerMoved, PointerReleased events to the Map, similar how they work on widgets.
- Used `Tapped` event instead of `Info` event in all the samples.

Follow ups:
- Perhaps add all four callbacks to all widgets (add them to BaseWidget). As a consequence the ButtonWidget will be functionally equivalent TextBoxWidgets (from which it is derived), that is weird, but other than that I see mostly advantaged. Performance will not be impacted because touch detection is already done in the Map. And it is simple to understand, all four are everywhere.
- Perhaps we do not need the RulerWidgetUpdatedEventArgs. Just the regular widget events (once they are everywhere).
- Do we need separate MapEventArgs and WidgetEventArgs? ShiftState is now only on the widget but applies on the map too.
