### PR TITLE
Fix dotnet sdk version to avoid builds breaking on dotnet sdk releases

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,13 +1,13 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "version": "9.0.100",
-    "rollForward": "latestFeature"
+    "version": "9.0.200",
+    "rollForward": "disable"
   },
   "tools": {
     "allowPrerelease": false,
-    "dotnet": "9.0.100",
-    "rollForward": "latestFeature"
+    "dotnet": "9.0.200",
+    "rollForward": "disable"
   },
   "msbuild-sdks": {
     "Uno.Sdk": "5.5.56"


### PR DESCRIPTION
In another project the build server upgrade to 9.0.200 caused a compile error and changed 'dotnet format whitespace' behavior.