### PR TITLE
Fix: Correct AspnetCore References for Blazor 9.0 and 8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,10 +50,10 @@
     <PackageVersion Include="Mapsui.Uno.WinUI" Version="5.0.0-beta.4" />
     <PackageVersion Include="Mapsui.WinUI" Version="5.0.0-beta.4" />
     <PackageVersion Include="Mapsui.Wpf" Version="5.0.0-beta.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.8" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.12.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[8.0.0,9.0.0)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="[6.2.14,7.0.0)" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="[2.6.2,3.0.0)" />

--- a/Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj
+++ b/Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj
@@ -17,14 +17,19 @@
 
 	<ItemGroup>
     <PackageReference Include="SkiaSharp.Views.Blazor" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
     <PackageReference Include="DotNext.Threading" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)'=='net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" VersionOverride="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" VersionOverride="9.0.2" />
   </ItemGroup>
 
   <!--target to remove System.Memory-->


### PR DESCRIPTION
Reference the Correct AspNetCore 8.0 references for Blazor 8.0 
and AspnetCore 9.0 References for Blazor 9.0