### PR TITLE
Move RelativeOffset to a separate field

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
@@ -37,8 +37,7 @@ public class CalloutStyleRenderer : ISkiaStyleRenderer
         var drawableImage = (SvgDrawableImage)renderService.DrawableImageCache.GetOrCreate(calloutStyle.ImageIdOfCallout,
             () => new SvgDrawableImage(calloutStyle.BalloonDefinition.CreateCallout(contentDrawableImage.Picture)))!;
 
-        // Calc offset (relative or absolute)
-        var symbolOffset = calloutStyle.SymbolOffset.CalcOffset(drawableImage.Picture.CullRect.Width, drawableImage.Picture.CullRect.Height);
+        var offset = calloutStyle.Offset.Combine(calloutStyle.RelativeOffset.GetAbsoluteOffset(drawableImage.Picture.CullRect.Width, drawableImage.Picture.CullRect.Height));
 
         var rotation = (float)calloutStyle.SymbolRotation;
 
@@ -47,14 +46,14 @@ public class CalloutStyleRenderer : ISkiaStyleRenderer
             if (calloutStyle.RotateWithMap)
                 rotation += (float)viewport.Rotation;
             if (calloutStyle.SymbolOffsetRotatesWithMap)
-                symbolOffset = new Offset(symbolOffset.ToPoint().Rotate(-viewport.Rotation));
+                offset = new Offset(offset.ToPoint().Rotate(-viewport.Rotation));
         }
 
         // Save state of the canvas, so we could move and rotate the canvas
         canvas.Save();
 
         // Move 0/0 to the Anchor point of Callout
-        canvas.Translate((float)(x - symbolOffset.X), (float)(y - symbolOffset.Y));
+        canvas.Translate((float)(x - offset.X), (float)(y - offset.Y));
         canvas.Scale((float)calloutStyle.SymbolScale, (float)calloutStyle.SymbolScale);
 
         // 0/0 are assumed at center of image, but Picture has 0/0 at left top position

--- a/Mapsui.Rendering.Skia/SkiaStyles/LabelStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/LabelStyleRenderer.cs
@@ -431,7 +431,7 @@ public class LabelStyleRenderer : ISkiaStyleRenderer, IFeatureSize
 
         var drawRect = new SKRect(0, 0, rect.Right - rect.Left, rect.Bottom - rect.Top);
 
-        var offset = labelStyle.Offset.CalcOffset(drawRect.Width, drawRect.Height);
+        var offset = labelStyle.Offset.Combine(labelStyle.RelativeOffset.GetAbsoluteOffset(drawRect.Width, drawRect.Height));
 
         // Pythagoras for maximal distance
         var length = Math.Sqrt(offset.X * offset.X + offset.Y * offset.Y);

--- a/Mapsui.UI.MapView/Objects/Callout.cs
+++ b/Mapsui.UI.MapView/Objects/Callout.cs
@@ -577,7 +577,7 @@ public class Callout : IFeatureProvider, INotifyPropertyChanged
             Feature.Styles.Add(style);
         }
 
-        style.SymbolOffset = new Offset(Anchor.X, Anchor.Y);
+        style.Offset = new Offset(Anchor.X, Anchor.Y);
         style.SymbolOffsetRotatesWithMap = _pin.RotateWithMap;
         style.RotateWithMap = RotateWithMap;
         style.Rotation = (float)Rotation;

--- a/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
@@ -165,7 +165,7 @@ public class MyLocationLayer : BaseLayer
             Image = _stillImageSource,
             SymbolScale = Scale,
             SymbolRotation = Direction,
-            SymbolOffset = new Offset(0, 0),
+            Offset = new Offset(0, 0),
             Opacity = 1,
         };
 
@@ -175,7 +175,7 @@ public class MyLocationLayer : BaseLayer
             Image = _directionImageSource,
             SymbolScale = 0.2,
             SymbolRotation = 0,
-            SymbolOffset = new Offset(0, 0),
+            Offset = new Offset(0, 0),
             Opacity = 1,
         };
         _coStyle = new CalloutStyle
@@ -184,7 +184,7 @@ public class MyLocationLayer : BaseLayer
             Type = CalloutType.Single,
             Title = "",
             TitleFontColor = Color.Black,
-            SymbolOffset = new Offset(0, -SymbolStyle.DefaultHeight * 0.4f),
+            Offset = new Offset(0, -SymbolStyle.DefaultHeight * 0.4f),
             MaxWidth = 300,
             RotateWithMap = true,
             SymbolOffsetRotatesWithMap = true,

--- a/Mapsui.UI.MapView/Objects/Pin.cs
+++ b/Mapsui.UI.MapView/Objects/Pin.cs
@@ -501,7 +501,7 @@ public class Pin : IFeatureProvider, INotifyPropertyChanged
                     SymbolScale = Scale,
                     SymbolRotation = Rotation,
                     RotateWithMap = RotateWithMap,
-                    SymbolOffset = new Offset(Anchor.X, Anchor.Y),
+                    Offset = new Offset(Anchor.X, Anchor.Y),
                     Opacity = 1 - Transparency,
                     Enabled = IsVisible,
                 });
@@ -539,7 +539,7 @@ public class Pin : IFeatureProvider, INotifyPropertyChanged
                 break;
             case nameof(Anchor):
                 if (Feature != null)
-                    ((SymbolStyle)Feature.Styles.First()).SymbolOffset = new Offset(Anchor.X, Anchor.Y);
+                    ((SymbolStyle)Feature.Styles.First()).Offset = new Offset(Anchor.X, Anchor.Y);
                 break;
             case nameof(Rotation):
                 if (Feature != null)

--- a/Mapsui/Layers/MyLocationLayer.cs
+++ b/Mapsui/Layers/MyLocationLayer.cs
@@ -164,7 +164,7 @@ public class MyLocationLayer : BaseLayer, IDisposable
             Image = _stillImageSource,
             SymbolScale = Scale,
             SymbolRotation = Direction,
-            SymbolOffset = new Offset(0, 0),
+            Offset = new Offset(0, 0),
             Opacity = 1,
         };
 
@@ -174,7 +174,7 @@ public class MyLocationLayer : BaseLayer, IDisposable
             Image = _directionImageSource,
             SymbolScale = 0.2,
             SymbolRotation = 0,
-            SymbolOffset = new Offset(0, 0),
+            Offset = new Offset(0, 0),
             Opacity = 1,
         };
 
@@ -187,7 +187,7 @@ public class MyLocationLayer : BaseLayer, IDisposable
             MaxWidth = 300,
             RotateWithMap = true,
             SymbolOffsetRotatesWithMap = true,
-            SymbolOffset = new Offset(0, -SymbolStyle.DefaultHeight * 0.4f),
+            Offset = new Offset(0, -SymbolStyle.DefaultHeight * 0.4f),
             BalloonDefinition = new CalloutBalloonDefinition
             {
                 Color = Color.White,

--- a/Mapsui/Styles/LabelStyle.cs
+++ b/Mapsui/Styles/LabelStyle.cs
@@ -153,9 +153,16 @@ public class LabelStyle : Style
     public Pen? Halo { get; set; }
 
     /// <summary>
-    /// Specifies relative position of labels with respect to objects label point
+    /// Specifies the position of labels with respect to objects label point
     /// </summary>
     public Offset Offset { get; set; }
+
+    /// <summary>
+    /// Specifies the position of labels with respect to objects label point relative to the size of the label.
+    /// Where X = 0.0 and Y = 0.0 would center the label and X = 0.5 and Y = 0.5 will have the label on the bottom right.
+    /// be drawn with the bottom left corner at the label point.
+    /// </summary>
+    public RelativeOffset RelativeOffset { get; set; } = new();
 
     /// <summary>
     /// Gets or sets whether Collision Detection is enabled for the labels.

--- a/Mapsui/Styles/Offset.cs
+++ b/Mapsui/Styles/Offset.cs
@@ -35,15 +35,9 @@ public class Offset
         return new MPoint(X, Y);
     }
 
-    /// <summary>
-    /// Calculate the real offset respecting width and height
-    /// </summary>
-    /// <param name="width">Width of the symbol</param>
-    /// <param name="height">Height of the symbol</param>
-    /// <returns>Calculated offset</returns>
-    public virtual Offset CalcOffset(double width, double height)
+    public Offset Combine(Offset offset)
     {
-        return this;
+        return new Offset(X + offset.X, Y + offset.Y);
     }
 
     public override bool Equals(object? obj)

--- a/Mapsui/Styles/RelativeOffset.cs
+++ b/Mapsui/Styles/RelativeOffset.cs
@@ -1,21 +1,28 @@
 ﻿namespace Mapsui.Styles;
 
 /// <summary>
-/// Relative offset of an image to the center of the source. The unit of measure
-/// is the width or height of an image. So in case of an an offset of (0.5, 0.5) 
-/// the symbol will be moved half the width of the image to the right and half the 
+/// Offset relative to the size of the item to which it applies. The unit of measure
+/// is the width or height of an image. A relative offset of X = 0, and Y = 0 will be centered.
+/// An offset of (0.5, 0.5) the symbol will be moved half the width of the image to the right and half the 
 /// height of the image to the top. So the bottom left point of the image will be on
 /// the location.
 /// </summary>
-public class RelativeOffset : Offset
+public class RelativeOffset
 {
     public RelativeOffset() { }
 
-    public RelativeOffset(double x, double y) : base(x, y) { }
+    public RelativeOffset(double x, double y)
+    {
+        X = x;
+        Y = y;
+    }
 
-    public RelativeOffset(Offset offset) : base(offset) { }
+    public RelativeOffset(RelativeOffset offset) : this(offset.X, offset.Y) { }
 
-    public RelativeOffset(MPoint point) : base(point) { }
+    public RelativeOffset(MPoint point) : this(point.X, point.Y) { }
+
+    public double X { get; set; } = 0;
+    public double Y { get; set; } = 0;
 
     /// <summary>
     /// Calculate the real offset respecting width and height
@@ -23,7 +30,7 @@ public class RelativeOffset : Offset
     /// <param name="width">Width of the symbol</param>
     /// <param name="height">Height of the symbol</param>
     /// <returns>Calculated offset</returns>
-    public override Offset CalcOffset(double width, double height)
+    public Offset GetAbsoluteOffset(double width, double height)
     {
         return new Offset(width * X, height * Y);
     }

--- a/Mapsui/Styles/SymbolStyle.cs
+++ b/Mapsui/Styles/SymbolStyle.cs
@@ -66,6 +66,9 @@ public class SymbolStyle : VectorStyle, IHasImage
     /// </remarks>
     public double SymbolScale { get; set; } = 1.0;
 
+    [Obsolete("Use Offset or RelativeOffset instead", true)]
+    public Offset SymbolOffset { get; set; } = new Offset();
+
     /// <summary>
     ///     Gets or sets the offset in pixels of the symbol.
     /// </summary>
@@ -73,7 +76,12 @@ public class SymbolStyle : VectorStyle, IHasImage
     ///     The symbol offset is scaled with the <see cref="SymbolScale" /> property and refers to the offset of
     ///     <see cref="SymbolScale" />=1.0.
     /// </remarks>
-    public Offset SymbolOffset { get; set; } = new Offset(0, 0);
+    public Offset Offset { get; set; } = new Offset();
+
+    /// <summary>
+    /// Offset of the symbol in units relative to the size of the symbol. When X = 0 and Y = 0 it will be centered.
+    /// </summary>
+    public RelativeOffset RelativeOffset { get; set; } = new RelativeOffset();
 
     /// <summary>
     /// Should SymbolOffset position rotate with map
@@ -98,10 +106,10 @@ public class SymbolStyle : VectorStyle, IHasImage
         if (!SymbolScale.Equals(SymbolScale))
             return false;
 
-        if ((SymbolOffset == null) ^ (symbolStyle.SymbolOffset == null))
+        if ((Offset == null) ^ (symbolStyle.Offset == null))
             return false;
 
-        if ((SymbolOffset != null) && !SymbolOffset.Equals(symbolStyle.SymbolOffset))
+        if ((Offset != null) && !Offset.Equals(symbolStyle.Offset))
             return false;
 
         if (Math.Abs(SymbolRotation - symbolStyle.SymbolRotation) > Constants.Epsilon)
@@ -127,7 +135,7 @@ public class SymbolStyle : VectorStyle, IHasImage
         return
             Image?.GetHashCode() ^
             SymbolScale.GetHashCode() ^
-            SymbolOffset.GetHashCode() ^
+            Offset.GetHashCode() ^
             SymbolRotation.GetHashCode() ^
             UnitType.GetHashCode() ^
             SymbolType.GetHashCode() ^

--- a/Mapsui/Styles/SymbolStyles.cs
+++ b/Mapsui/Styles/SymbolStyles.cs
@@ -10,7 +10,7 @@ public static class SymbolStyles
             SvgFillColor = fillColor ?? Color.FromArgb(255, 57, 115, 199),
             SvgStrokeColor = strokeColor ?? Color.FromArgb(210, 245, 245, 245),
         },
-        SymbolOffset = new RelativeOffset(0.0, 0.5),
+        RelativeOffset = new RelativeOffset(0.0, 0.5),
         SymbolScale = symbolScale,
     };
 }

--- a/Mapsui/Styles/Thematics/GradientTheme.cs
+++ b/Mapsui/Styles/Thematics/GradientTheme.cs
@@ -126,7 +126,7 @@ public class GradientTheme : Style, IThemeStyle
         var fraction = Fraction(value, instance.Min, instance.Max);
 
         result.Image = (fraction > 0.5) ? min.Image : max.Image;
-        result.SymbolOffset = fraction > 0.5 ? min.SymbolOffset ?? new Offset() : max.SymbolOffset ?? new Offset();
+        result.Offset = fraction > 0.5 ? min.Offset ?? new Offset() : max.Offset ?? new Offset();
         // We don't interpolate the offset but let it follow the symbol instead
         result.SymbolScale = InterpolateDouble(min.SymbolScale, max.SymbolScale, fraction);
 

--- a/Samples/Mapsui.Samples.Common/DataBuilders/GeodanOfficesLayerBuilder.cs
+++ b/Samples/Mapsui.Samples.Common/DataBuilders/GeodanOfficesLayerBuilder.cs
@@ -18,7 +18,7 @@ public class GeodanOfficesLayerBuilder
             Style = new SymbolStyle
             {
                 Image = imageSource,
-                SymbolOffset = new Offset { Y = 64 },
+                Offset = new Offset { Y = 64 },
                 SymbolScale = 0.25
             },
             Name = "Geodan Offices"

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSample.cs
@@ -47,7 +47,7 @@ public sealed class AnimatedPointsSample : ISample, IDisposable
     {
         Image = "embedded://Mapsui.Samples.Common.Images.arrow.svg",
         SymbolScale = 0.5,
-        SymbolOffset = new RelativeOffset(0.0, 0.5),
+        RelativeOffset = new RelativeOffset(0.0, 0.5),
         Opacity = 0.5f,
         SymbolRotation = (double)feature["rotation"]!
     };

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/CustomSvgColorSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/CustomSvgColorSample.cs
@@ -61,7 +61,7 @@ public class CustomSvgStyleSample : ISample
                     SvgFillColor = GetTypeColor((int)f.Id % 4),
                     SvgStrokeColor = Color.Black,
                 },
-                SymbolOffset = new RelativeOffset(0.0, 0.5), // The point at the bottom should be at the location
+                RelativeOffset = new RelativeOffset(0.0, 0.5), // The point at the bottom should be at the location
                 SymbolScale = 0.5,
                 SymbolRotation = -CalculateAngle(new MPoint(0, 0), featurePosition) - 90, // Let them point to the center of hte map
                 RotateWithMap = true,

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
@@ -60,7 +60,7 @@ public class DynamicSvgStyleSample : ISample
                     Source = imageSource,
                     BlendModeColor = ToColor(distanceBetweenZeroAndOne) // 3. Use BlendModeColor to change the color of the svg
                 },
-                SymbolOffset = new RelativeOffset(0.0, 0.0),
+                RelativeOffset = new RelativeOffset(0.0, 0.0),
                 // 1. Change scale based on the distance
                 SymbolScale = 0.25 + (0.25 * distanceBetweenZeroAndOne),
                 // 2. Change angle pointing to the info click position

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
@@ -78,7 +78,7 @@ public class PointsSample : ISample
     {
         var imageSource = "embedded://Mapsui.Samples.Common.Images.home.png"; // Designed by Freepik http://www.freepik.com
         var bitmapHeight = 176; // To set the offset correct we need to know the bitmap height
-        return new SymbolStyle { Image = imageSource, SymbolScale = 0.20, SymbolOffset = new Offset(0, bitmapHeight * 0.5) };
+        return new SymbolStyle { Image = imageSource, SymbolScale = 0.20, Offset = new Offset(0, bitmapHeight * 0.5) };
     }
 }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
@@ -92,7 +92,7 @@ public class CustomCalloutStyleSample : IMapControlSample
             SvgFillColor = Color.FromString("#4193CF"),
             SvgStrokeColor = Color.DimGrey,
         },
-        SymbolOffset = new RelativeOffset(0.0, 0.5), // The symbols point should be at the geolocation.        
+        RelativeOffset = new RelativeOffset(0.0, 0.5), // The symbols point should be at the geolocation.        
     };
 }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Info/GeoJsonInfoSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/GeoJsonInfoSample.cs
@@ -22,7 +22,7 @@ public class GeoJsonInfoSample : ISample
     }
 
     public string Name => "GeoJson Info";
-    public string Category => "Info";
+    public string Category => "MapInfo";
 
     public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
 

--- a/Samples/Mapsui.Samples.Common/Maps/Info/ImageCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/ImageCalloutSample.cs
@@ -25,7 +25,7 @@ public class ImageCalloutSample : ISample
     private static readonly Random _random = new(1);
 
     public string Name => "Image Callout";
-    public string Category => "Info";
+    public string Category => "MapInfo";
 
     private const string _pointLayerName = "Point with callout";
 

--- a/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
@@ -22,7 +22,7 @@ namespace Mapsui.Samples.Common.Maps.Info;
 public class SingleCalloutSample : ISample
 {
     public string Name => "Single Callout";
-    public string Category => "Info";
+    public string Category => "MapInfo";
 
     private const string _calloutLayerName = "Cities with callouts";
 
@@ -91,7 +91,7 @@ public class SingleCalloutSample : ISample
             TitleFontColor = Color.Gray,
             MaxWidth = 120,
             Enabled = false,
-            SymbolOffset = new Offset(0, SymbolStyle.DefaultHeight * 1f),
+            Offset = new Offset(0, SymbolStyle.DefaultHeight * 1f),
             BalloonDefinition = new CalloutBalloonDefinition
             {
                 RectRadius = 10,

--- a/Samples/Mapsui.Samples.Common/Maps/Info/WmsInfoSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/WmsInfoSample.cs
@@ -10,7 +10,7 @@ namespace Mapsui.Samples.Common.Maps.Info;
 public class WmsInfoSample : ISample
 {
     public string Name => "Wms Info";
-    public string Category => "Info";
+    public string Category => "MapInfo";
 
     private const string _mapInfoLayerName = "Windsnelheden (PDOK)";
 

--- a/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
@@ -75,7 +75,7 @@ public static class SampleLayerExtensions
                         SvgFillColor = Color.CornflowerBlue,
                         SvgStrokeColor = Color.Black,
                     },
-                    SymbolOffset = new RelativeOffset(0.0, 0.5), // The point at the bottom should be at the location
+                    RelativeOffset = new RelativeOffset(0.0, 0.5), // The point at the bottom should be at the location
                     SymbolScale = 1,
                 },
                 new ThemeStyle(f =>
@@ -83,7 +83,7 @@ public static class SampleLayerExtensions
                     return new CalloutStyle()
                     {
                         Enabled = enabledFromFeature(f),
-                        SymbolOffset = new Offset(0, 52),
+                        Offset = new Offset(0, 52),
                         TitleFont = { FontFamily = null, Size = 24, Italic = false, Bold = true },
                         TitleFontColor = Color.Black,
                         Type = CalloutType.Single,

--- a/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
@@ -71,7 +71,7 @@ public class PointProjectionSample : ISample
         return new SymbolStyle
         {
             Image = imageSource,
-            SymbolOffset = new Offset { Y = 64 },
+            Offset = new Offset { Y = 64 },
             SymbolScale = 0.25,
             Opacity = 0.5f
         };

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SvgSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SvgSample.cs
@@ -54,6 +54,6 @@ public class SvgSample : ISample
     {
         Image = "embedded://Mapsui.Samples.Common.Images.Pin.svg",
         SymbolScale = 0.5,
-        SymbolOffset = new RelativeOffset(0.0, 0.5)
+        RelativeOffset = new RelativeOffset(0.0, 0.5)
     };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SymbolsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SymbolsSample.cs
@@ -67,17 +67,17 @@ public class SymbolsSample : ISample
 
     private static IEnumerable<IStyle> CreateDiverseStyles()
     {
-        const int diameter = 16;
-        return new List<IStyle>
-        {
-            new SymbolStyle {SymbolScale = 0.8, SymbolOffset = new Offset(0, 0), SymbolType = SymbolType.Rectangle},
-            new SymbolStyle {SymbolScale = 0.6, SymbolOffset = new Offset(diameter, diameter), SymbolType = SymbolType.Rectangle, Fill = new Brush(Color.Red)},
-            new SymbolStyle {SymbolScale = 1, SymbolOffset = new Offset(diameter, -diameter), SymbolType = SymbolType.Rectangle},
-            new SymbolStyle {SymbolScale = 1, SymbolOffset = new Offset(-diameter, -diameter), SymbolType = SymbolType.Rectangle},
-            new SymbolStyle {SymbolScale = 0.8, SymbolOffset = new Offset(0, 0)},
-            new SymbolStyle {SymbolScale = 1.2, SymbolOffset = new Offset(diameter, 0)},
-            new SymbolStyle {SymbolScale = 1, SymbolOffset = new Offset(0, diameter)},
-            new SymbolStyle {SymbolScale = 1, SymbolOffset = new Offset(diameter, diameter)},
+        const int radius = 16;
+        return
+        [
+            new SymbolStyle {SymbolScale = 0.8, Offset = new Offset(0, 0), SymbolType = SymbolType.Rectangle},
+            new SymbolStyle {SymbolScale = 0.6, Offset = new Offset(radius, radius), SymbolType = SymbolType.Rectangle, Fill = new Brush(Color.Red)},
+            new SymbolStyle {SymbolScale = 1, Offset = new Offset(radius, -radius), SymbolType = SymbolType.Rectangle},
+            new SymbolStyle {SymbolScale = 1, Offset = new Offset(-radius, -radius), SymbolType = SymbolType.Rectangle},
+            new SymbolStyle {SymbolScale = 0.8, Offset = new Offset(0, 0)},
+            new SymbolStyle {SymbolScale = 1.2, Offset = new Offset(radius, 0)},
+            new SymbolStyle {SymbolScale = 1, Offset = new Offset(0, radius)},
+            new SymbolStyle {SymbolScale = 1, Offset = new Offset(radius, radius)},
             CreateBitmapStyle("embedded://Mapsui.Samples.Common.Images.ic_place_black_24dp.png", 0.7),
             CreateBitmapStyle("embedded://Mapsui.Samples.Common.Images.ic_place_black_24dp.png", 0.8),
             CreateBitmapStyle("embedded://Mapsui.Samples.Common.Images.ic_place_black_24dp.png", 0.9),
@@ -86,17 +86,17 @@ public class SymbolsSample : ISample
             CreateSvgStyle("embedded://Mapsui.Samples.Common.Images.Pin.svg", 0.8),
             CreateSvgStyle("embedded://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg", 0.05),
             CreateSvgStyle("embedded://Mapsui.Samples.Common.Images.Ghostscript_Tiger.svg", 0.1),
-        };
+        ];
     }
 
     private static SymbolStyle CreateBitmapStyle(string embeddedResourcePath, double scale)
     {
-        return new SymbolStyle { Image = embeddedResourcePath, SymbolScale = scale, SymbolOffset = new Offset(0, 32) };
+        return new SymbolStyle { Image = embeddedResourcePath, SymbolScale = scale, Offset = new Offset(0, 32) };
     }
 
     private static SymbolStyle CreateSvgStyle(string embeddedResourcePath, double scale)
     {
-        return new SymbolStyle { Image = embeddedResourcePath, SymbolScale = scale, SymbolOffset = new RelativeOffset(0.0, 0.5) };
+        return new SymbolStyle { Image = embeddedResourcePath, SymbolScale = scale, RelativeOffset = new RelativeOffset(0.0, 0.5) };
     }
 
     private static PointFeature CreatePointWithStackedStyles() => new(new MPoint(5000000, -5000000))

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/ThemeStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/ThemeStyleSample.cs
@@ -103,7 +103,7 @@ public class ThemeStyleSample : ISample
     private static SymbolStyle CreateCityStyle() => new()
     {
         Image = "embedded://Mapsui.Samples.Common.Images.location.png",
-        SymbolOffset = new Offset { Y = 64 },
+        Offset = new Offset { Y = 64 },
         SymbolScale = 0.25
     };
 }

--- a/Tests/Mapsui.Rendering.Skia.Tests/SymbolStyleFeatureSizeTests.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/SymbolStyleFeatureSizeTests.cs
@@ -44,7 +44,7 @@ public class SymbolStyleFeatureSizeTests
         var symbolStyle = new SymbolStyle
         {
             SymbolType = SymbolType.Rectangle,
-            SymbolOffset = new Offset(2, 0),
+            Offset = new Offset(2, 0),
         };
 
         using var renderService = new RenderService();
@@ -59,7 +59,7 @@ public class SymbolStyleFeatureSizeTests
         var symbolStyle = new SymbolStyle
         {
             SymbolType = SymbolType.Rectangle,
-            SymbolOffset = new Offset(0, 2),
+            Offset = new Offset(0, 2),
         };
 
         using var renderService = new RenderService();
@@ -74,7 +74,7 @@ public class SymbolStyleFeatureSizeTests
         var symbolStyle = new SymbolStyle
         {
             SymbolType = SymbolType.Rectangle,
-            SymbolOffset = new Offset(2, 2),
+            Offset = new Offset(2, 2),
         };
 
         using var renderService = new RenderService();

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolWithRotationAndOffsetSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolWithRotationAndOffsetSample.cs
@@ -62,7 +62,7 @@ public class BitmapSymbolWithRotationAndOffsetSample : ISample
         feature.Styles.Add(new SymbolStyle
         {
             Image = imageSource,
-            SymbolOffset = new Offset { Y = -24 },
+            Offset = new Offset { Y = -24 },
             SymbolRotation = rotation,
             RotateWithMap = true,
         });

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolWithRotationAndOffsetSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolWithRotationAndOffsetSample.cs
@@ -38,20 +38,17 @@ public class BitmapSymbolWithRotationAndOffsetSample : ISample
         return map;
     }
 
-    private static IEnumerable<IFeature> CreateProviderWithRotatedBitmapSymbols()
-    {
-        return new List<IFeature>
+    private static List<IFeature> CreateProviderWithRotatedBitmapSymbols() =>
+    [
+        new GeometryFeature
         {
-            new GeometryFeature
-            {
-                Geometry = new Point(75, 75),
-                Styles = new[] {new SymbolStyle {Fill = new Brush(Color.Red)}}
-            }, // for reference
-            CreateFeatureWithRotatedBitmapSymbol(75, 125, 90),
-            CreateFeatureWithRotatedBitmapSymbol(125, 125, 180),
-            CreateFeatureWithRotatedBitmapSymbol(125, 75, 270)
-        };
-    }
+            Geometry = new Point(75, 75),
+            Styles = [new SymbolStyle { Fill = new Brush(Color.Red) }]
+        }, // for reference
+        CreateFeatureWithRotatedBitmapSymbol(75, 125, 90),
+        CreateFeatureWithRotatedBitmapSymbol(125, 125, 180),
+        CreateFeatureWithRotatedBitmapSymbol(125, 75, 270)
+    ];
 
     private static GeometryFeature CreateFeatureWithRotatedBitmapSymbol(double x, double y, double rotation)
     {

--- a/Tests/Mapsui.Tests.Common/Maps/CalloutSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/CalloutSample.cs
@@ -86,7 +86,7 @@ public class CalloutSample : ISample
             Type = CalloutType.Detail,
             MaxWidth = 120,
             Enabled = true,
-            SymbolOffset = new Offset(0, SymbolStyle.DefaultHeight * 1f),
+            Offset = new Offset(0, SymbolStyle.DefaultHeight * 1f),
             BalloonDefinition = new CalloutBalloonDefinition
             {
                 RectRadius = 10,


### PR DESCRIPTION
This is a breaking change in the SymbolStyles. It was changed for two reasons:
- The current setup was confusing. RelativeOffset was derived from Offset and you assigned it to an Offset. So, as a developer it looked like the class was Offset but it was actually RelativeOffset. The CalcOffset needed a width and height even if it was no relative offset.
- The width and size are not know in several situations. In those case I want to pass the RelativeOffset into the Image renderer.