### PR TITLE
Move SymbolStyle.Image to new ImageStyle class

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -258,6 +258,7 @@ dotnet_diagnostic.CA1512.severity = silent # CA1512: Use ArgumentOutOfRangeExcep
 dotnet_diagnostic.IDE0059.severity = warning # IDE0059: Unnecessary assignment of a value
 dotnet_diagnostic.CA2208.severity = silent # CA2208: Instantiate argument exceptions correctly
 dotnet_diagnostic.VSTHRD200.severity = warning # VSTHRD200: Use "Async" suffix for async methods 
+dotnet_diagnostic.CS0184.severity = error # CS0184: 'is' expression's given expression is never of the provided type
 
 # Spelling
 spelling_exclusion_path = spelling_exclusion.txt
@@ -292,3 +293,4 @@ dotnet_diagnostic.IDISP026.severity = error
 
 # An alternative to IDISPXXX is to enable CA2000:
 # dotnet_diagnostic.CA2000.severity = error
+

--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -50,6 +50,7 @@ public sealed class MapRenderer : IRenderer, IDisposable
         _styleRenderers[typeof(VectorStyle)] = new VectorStyleRenderer();
         _styleRenderers[typeof(LabelStyle)] = new LabelStyleRenderer();
         _styleRenderers[typeof(SymbolStyle)] = new SymbolStyleRenderer();
+        _styleRenderers[typeof(ImageStyle)] = new ImageStyleRenderer();
         _styleRenderers[typeof(CalloutStyle)] = new CalloutStyleRenderer();
 
         _widgetRenderers[typeof(TextBoxWidget)] = new TextBoxWidgetRenderer();

--- a/Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj
+++ b/Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj
@@ -5,6 +5,7 @@
     <Description>Mapsui - Library for mapping</Description>
     <PackageTags>$(PackageTags) rendering skia</PackageTags>
 		<IsPackable>true</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
@@ -79,7 +79,7 @@ public class CalloutStyleRenderer : ISkiaStyleRenderer
         {
             using var recorder = new SKPictureRecorder();
             var image = renderService.DrawableImageCache.GetOrCreate(callout.Image.SourceId,
-                () => SymbolStyleRenderer.TryCreateDrawableImage(callout.Image, renderService.ImageSourceCache));
+                () => ImageStyleRenderer.TryCreateDrawableImage(callout.Image, renderService.ImageSourceCache));
             if (image is null)
             {
                 Logger.Log(LogLevel.Error, $"Image not found: {callout.Image.Source}");

--- a/Mapsui.Rendering.Skia/SkiaStyles/ImageStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/ImageStyleRenderer.cs
@@ -1,0 +1,203 @@
+﻿using Mapsui.Extensions;
+using Mapsui.Layers;
+using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Rendering.Skia.Extensions;
+using Mapsui.Rendering.Skia.Images;
+using Mapsui.Rendering.Skia.SkiaStyles;
+using Mapsui.Styles;
+using SkiaSharp;
+using Svg.Skia;
+using System;
+
+namespace Mapsui.Rendering.Skia;
+
+public class ImageStyleRenderer : ISkiaStyleRenderer, IFeatureSize
+{
+    private static readonly SKSamplingOptions _skSamplingOptions = new(SKFilterMode.Linear, SKMipmapMode.None);
+
+    public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, IStyle style, RenderService renderService, long iteration)
+    {
+        var symbolStyle = (ImageStyle)style;
+        feature.CoordinateVisitor((x, y, setter) =>
+        {
+            DrawXY(canvas, viewport, layer, x, y, symbolStyle, renderService);
+        });
+        return true;
+    }
+
+    public static void DrawXY(SKCanvas canvas, Viewport viewport, ILayer layer, double x, double y, ImageStyle imageStyle, RenderService renderService)
+    {
+        if (imageStyle.Image is null)
+            return;
+
+        var opacity = (float)(layer.Opacity * imageStyle.Opacity);
+        var (destinationX, destinationY) = viewport.WorldToScreenXY(x, y);
+
+        canvas.Save();
+        canvas.Translate((float)destinationX, (float)destinationY);
+        canvas.Scale((float)imageStyle.SymbolScale, (float)imageStyle.SymbolScale);
+
+        var rotation = imageStyle.SymbolRotation;
+        if (imageStyle.RotateWithMap)
+            rotation += viewport.Rotation;
+        if (rotation != 0)
+            canvas.RotateDegrees((float)rotation);
+
+        canvas.Translate((float)imageStyle.Offset.X, (float)-imageStyle.Offset.Y);
+
+        DrawSourceImage(canvas, imageStyle.Image, imageStyle.RelativeOffset, renderService, opacity);
+
+        canvas.Restore();
+    }
+
+    private static void DrawSourceImage(SKCanvas canvas, Image image, RelativeOffset symbolOffset, RenderService renderService, float opacity)
+    {
+        canvas.Save();
+
+        if (image is null)
+            throw new Exception("SymbolStyle.Image should not be null in the DrawImage render method");
+
+        var drawableImage = renderService.DrawableImageCache.GetOrCreate(image.SourceId,
+            () => TryCreateDrawableImage(image, renderService.ImageSourceCache));
+        if (drawableImage == null)
+            return;
+
+        var offset = symbolOffset.GetAbsoluteOffset(drawableImage.Width, drawableImage.Height); // Offset can be relative to the size so that is why Width and Height is needed.
+
+        canvas.Translate((float)offset.X, -(float)offset.Y);
+
+        if (drawableImage is BitmapDrawableImage bitmapImage)
+        {
+            if (image.BitmapRegion is not null) // Get image for region if specified
+            {
+                var key = image.GetSourceIdForBitmapRegion();
+                if (renderService.DrawableImageCache.GetOrCreate(key, () => CreateBitmapImageForRegion(bitmapImage, image.BitmapRegion)) is BitmapDrawableImage bitmapRegionImage)
+                    bitmapImage = bitmapRegionImage;
+            }
+
+            DrawSKImage(canvas, bitmapImage.Image, opacity);
+
+        }
+        else if (drawableImage is SvgDrawableImage svgImage)
+        {
+            if (image.SvgFillColor.HasValue || image.SvgStrokeColor.HasValue) // Get custom colored SVG if custom colors are set
+            {
+                var key = image.GetSourceIdForSvgWithCustomColors();
+                if (renderService.DrawableImageCache.GetOrCreate(key, () => CreateCustomColoredSvg(image, svgImage)) is SvgDrawableImage customColoredSvgImage)
+                    svgImage = customColoredSvgImage;
+            }
+
+            DrawSKPicture(canvas, svgImage.Picture, opacity, image.BlendModeColor);
+        }
+        canvas.Restore();
+    }
+
+    public static void DrawSKImage(SKCanvas canvas, SKImage bitmap, float opacity)
+    {
+        using var paint = new SKPaint { Color = new SKColor(255, 255, 255, (byte)(255 * opacity)) };
+
+        var halfWidth = bitmap.Width >> 1;
+        var halfHeight = bitmap.Height >> 1;
+
+        var rect = new SKRect(-halfWidth, -halfHeight, halfWidth, halfHeight);
+
+        canvas.DrawImage(bitmap, rect, _skSamplingOptions, paint);
+    }
+
+    public static void DrawSKPicture(SKCanvas canvas, SKPicture picture, float opacity, Color? blendModeColor)
+    {
+        using var skPaint = CreatePaintForSKPicture(opacity, blendModeColor);
+
+        var halfWidth = picture.CullRect.Width / 2;
+        var halfHeight = picture.CullRect.Height / 2;
+
+        var matrix = SKMatrix.CreateTranslation(-halfWidth, -halfHeight);
+
+        canvas.DrawPicture(picture, in matrix, skPaint);
+    }
+
+    private static SKPaint CreatePaintForSKPicture(float opacity, Color? blendModeColor)
+    {
+        var paint = new SKPaint();
+
+        if (blendModeColor is not null)
+            paint.ColorFilter = SKColorFilter.CreateBlendMode(blendModeColor.ToSkia(opacity), SKBlendMode.SrcIn);
+
+        if (Math.Abs(opacity - 1) > Utilities.Constants.Epsilon)
+            paint.Color = new SKColor(255, 255, 255, (byte)(255 * opacity));
+
+        return paint;
+    }
+
+    private static SvgDrawableImage CreateCustomColoredSvg(Image image, SvgDrawableImage originalSvgImage)
+    {
+        var originalStream = originalSvgImage.OriginalStream ?? throw new NullReferenceException("Original Stream is null");
+        using var modifiedSvgStream = SvgColorModifier.GetModifiedSvg(originalStream, image.SvgFillColor, image.SvgStrokeColor);
+#pragma warning disable IDISP001
+#pragma warning disable IDISP004
+        var skSvg = new SKSvg();
+        modifiedSvgStream.Position = 0;
+        skSvg.Load(modifiedSvgStream);
+#pragma warning restore IDISP001
+#pragma warning restore IDISP004
+        if (skSvg.Picture is null)
+            throw new Exception("Failed to load modified SVG picture.");
+        return new SvgDrawableImage(skSvg.Picture);
+    }
+
+    private static BitmapDrawableImage CreateBitmapImageForRegion(BitmapDrawableImage bitmapImage, BitmapRegion sprite)
+    {
+        return new BitmapDrawableImage(bitmapImage.Image.Subset(new SKRectI(sprite.X, sprite.Y, sprite.X + sprite.Width, sprite.Y + sprite.Height)));
+    }
+
+    bool IFeatureSize.NeedsFeature => false;
+
+    double IFeatureSize.FeatureSize(IStyle style, IRenderService renderService, IFeature? feature)
+    {
+        if (style is ImageStyle symbolStyle)
+        {
+            return FeatureSize(symbolStyle, renderService);
+        }
+
+        return 0;
+    }
+
+    public static double FeatureSize(ImageStyle imageStyle, IRenderService renderService)
+    {
+        Size symbolSize = new Size(SymbolStyle.DefaultWidth, SymbolStyle.DefaultHeight);
+
+        if (imageStyle.Image is not null)
+        {
+            var image = ((RenderService)renderService).DrawableImageCache.GetOrCreate(imageStyle.Image.SourceId,
+                () => TryCreateDrawableImage(imageStyle.Image, ((RenderService)renderService).ImageSourceCache));
+            if (image != null)
+                symbolSize = new Size(image.Width, image.Height);
+        }
+
+
+        var size = Math.Max(symbolSize.Height, symbolSize.Width);
+        size *= imageStyle.SymbolScale; // Symbol Scale
+        size = Math.Max(size, SymbolStyle.DefaultWidth); // if defaultWith is larger take this.
+
+        // Calc offset (relative or absolute)
+        var offset = imageStyle.Offset.Combine(imageStyle.RelativeOffset.GetAbsoluteOffset(symbolSize.Width, symbolSize.Height));
+
+        // Pythagoras for maximal distance
+        var length = Math.Sqrt(offset.X * offset.X + offset.Y * offset.Y);
+
+        // add length to size multiplied by two because the total size increased by the offset
+        size += length * 2;
+
+        return size;
+    }
+
+    // Todo: Figure out a better place for this method
+    public static IDrawableImage? TryCreateDrawableImage(Image image, ImageSourceCache imageSourceCache)
+    {
+        var imageBytes = imageSourceCache.Get(image);
+        if (imageBytes == null)
+            return null;
+        var drawableImage = ImageHelper.ToDrawableImage(imageBytes);
+        return drawableImage;
+    }
+}

--- a/Mapsui.Rendering.Skia/SkiaStyles/LabelStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/LabelStyleRenderer.cs
@@ -24,12 +24,11 @@ public class LabelStyleRenderer : ISkiaStyleRenderer, IFeatureSize
 
         using var holder = vectorCache.GetOrCreate((style, text, layerOpacity), CreateLabelAsBitmap);
         var image = holder.Instance;
-        var offsetX = style.Offset is RelativeOffset ? image.Width * style.Offset.X : style.Offset.X;
-        var offsetY = style.Offset is RelativeOffset ? image.Height * style.Offset.Y : style.Offset.Y;
+        var offset = style.Offset.Combine(style.RelativeOffset.GetAbsoluteOffset(image.Width, image.Height));
 
         if (image is BitmapDrawableImage bitmapImage)
             BitmapRenderer.Draw(canvas, bitmapImage.Image, (int)Math.Round(x), (int)Math.Round(y),
-                offsetX: (float)offsetX, offsetY: (float)-offsetY,
+                offsetX: (float)offset.X, offsetY: (float)-offset.Y,
                 horizontalAlignment: style.HorizontalAlignment, verticalAlignment: style.VerticalAlignment);
         else
             throw new InvalidOperationException("Unexpected drawable image type");
@@ -208,12 +207,11 @@ public class LabelStyleRenderer : ISkiaStyleRenderer, IFeatureSize
         var horizontalAlign = CalcHorizontalAlignment(style.HorizontalAlignment);
         var verticalAlign = CalcVerticalAlignment(style.VerticalAlignment);
 
-        var offsetX = style.Offset is RelativeOffset ? drawRect.Width * style.Offset.X : style.Offset.X;
-        var offsetY = style.Offset is RelativeOffset ? drawRect.Height * style.Offset.Y : style.Offset.Y;
+        var offset = style.Offset.Combine(style.RelativeOffset.GetAbsoluteOffset(drawRect.Width, drawRect.Height));
 
         drawRect.Offset(
-            x - drawRect.Width * horizontalAlign + (float)offsetX,
-            y - drawRect.Height * verticalAlign + (float)offsetY);
+            x - drawRect.Width * horizontalAlign + (float)offset.X,
+            y - drawRect.Height * verticalAlign + (float)offset.Y);
 
         // If style has a background color, than draw background rectangle
         if (style.BackColor != null)

--- a/Mapsui.Rendering.Skia/SkiaStyles/PolygonRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/PolygonRenderer.cs
@@ -216,7 +216,7 @@ internal static class PolygonRenderer
         if (image is null)
             return null;
         var drawableImage = renderService.DrawableImageCache.GetOrCreate(image.SourceId,
-            () => SymbolStyleRenderer.TryCreateDrawableImage(image, renderService.ImageSourceCache));
+            () => ImageStyleRenderer.TryCreateDrawableImage(image, renderService.ImageSourceCache));
         if (drawableImage == null)
             return null;
 

--- a/Mapsui.Rendering.Skia/SkiaStyles/SymbolStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/SymbolStyleRenderer.cs
@@ -2,19 +2,15 @@
 using Mapsui.Layers;
 using Mapsui.Rendering.Skia.Cache;
 using Mapsui.Rendering.Skia.Extensions;
-using Mapsui.Rendering.Skia.Images;
 using Mapsui.Rendering.Skia.SkiaStyles;
 using Mapsui.Styles;
 using SkiaSharp;
-using Svg.Skia;
 using System;
 
 namespace Mapsui.Rendering.Skia;
 
 public class SymbolStyleRenderer : ISkiaStyleRenderer, IFeatureSize
 {
-    private static SKSamplingOptions _skSamplingOptions = new(SKFilterMode.Linear, SKMipmapMode.None);
-
     public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, IStyle style, RenderService renderService, long iteration)
     {
         var symbolStyle = (SymbolStyle)style;
@@ -42,115 +38,12 @@ public class SymbolStyleRenderer : ISkiaStyleRenderer, IFeatureSize
 
         canvas.Translate((float)symbolStyle.Offset.X, (float)-symbolStyle.Offset.Y);
 
-        if (symbolStyle.Image is Image sourceImage)
-            DrawSourceImage(canvas, sourceImage, symbolStyle.RelativeOffset, renderService, opacity);
-        else
-            DrawBuiltInImage(canvas, symbolStyle, renderService.VectorCache, opacity);
+        DrawSymbolType(canvas, symbolStyle, renderService.VectorCache, opacity);
 
         canvas.Restore();
     }
 
-    private static void DrawSourceImage(SKCanvas canvas, Image image, RelativeOffset symbolOffset, RenderService renderService, float opacity)
-    {
-        canvas.Save();
-
-        if (image is null)
-            throw new Exception("SymbolStyle.Image should not be null in the DrawImage render method");
-
-        var drawableImage = renderService.DrawableImageCache.GetOrCreate(image.SourceId,
-            () => TryCreateDrawableImage(image, renderService.ImageSourceCache));
-        if (drawableImage == null)
-            return;
-
-        var offset = symbolOffset.GetAbsoluteOffset(drawableImage.Width, drawableImage.Height); // Offset can be relative to the size so that is why Width and Height is needed.
-
-        canvas.Translate((float)offset.X, -(float)offset.Y);
-
-        if (drawableImage is BitmapDrawableImage bitmapImage)
-        {
-            if (image.BitmapRegion is not null) // Get image for region if specified
-            {
-                var key = image.GetSourceIdForBitmapRegion();
-                if (renderService.DrawableImageCache.GetOrCreate(key, () => CreateBitmapImageForRegion(bitmapImage, image.BitmapRegion)) is BitmapDrawableImage bitmapRegionImage)
-                    bitmapImage = bitmapRegionImage;
-            }
-
-            DrawSKImage(canvas, bitmapImage.Image, opacity);
-
-        }
-        else if (drawableImage is SvgDrawableImage svgImage)
-        {
-            if (image.SvgFillColor.HasValue || image.SvgStrokeColor.HasValue) // Get custom colored SVG if custom colors are set
-            {
-                var key = image.GetSourceIdForSvgWithCustomColors();
-                if (renderService.DrawableImageCache.GetOrCreate(key, () => CreateCustomColoredSvg(image, svgImage)) is SvgDrawableImage customColoredSvgImage)
-                    svgImage = customColoredSvgImage;
-            }
-
-            DrawSKPicture(canvas, svgImage.Picture, opacity, image.BlendModeColor);
-        }
-        canvas.Restore();
-    }
-
-    public static void DrawSKImage(SKCanvas canvas, SKImage bitmap, float opacity)
-    {
-        using var paint = new SKPaint { Color = new SKColor(255, 255, 255, (byte)(255 * opacity)) };
-
-        var halfWidth = bitmap.Width >> 1;
-        var halfHeight = bitmap.Height >> 1;
-
-        var rect = new SKRect(-halfWidth, -halfHeight, halfWidth, halfHeight);
-
-        canvas.DrawImage(bitmap, rect, _skSamplingOptions, paint);
-    }
-
-    public static void DrawSKPicture(SKCanvas canvas, SKPicture picture, float opacity, Color? blendModeColor)
-    {
-        using var skPaint = CreatePaintForSKPicture(opacity, blendModeColor);
-
-        var halfWidth = picture.CullRect.Width / 2;
-        var halfHeight = picture.CullRect.Height / 2;
-
-        var matrix = SKMatrix.CreateTranslation(-halfWidth, -halfHeight);
-
-        canvas.DrawPicture(picture, in matrix, skPaint);
-    }
-
-    private static SKPaint CreatePaintForSKPicture(float opacity, Color? blendModeColor)
-    {
-        var paint = new SKPaint();
-
-        if (blendModeColor is not null)
-            paint.ColorFilter = SKColorFilter.CreateBlendMode(blendModeColor.ToSkia(opacity), SKBlendMode.SrcIn);
-
-        if (Math.Abs(opacity - 1) > Utilities.Constants.Epsilon)
-            paint.Color = new SKColor(255, 255, 255, (byte)(255 * opacity));
-
-        return paint;
-    }
-
-    private static SvgDrawableImage CreateCustomColoredSvg(Image image, SvgDrawableImage originalSvgImage)
-    {
-        var originalStream = originalSvgImage.OriginalStream ?? throw new NullReferenceException("Original Stream is null");
-        using var modifiedSvgStream = SvgColorModifier.GetModifiedSvg(originalStream, image.SvgFillColor, image.SvgStrokeColor);
-#pragma warning disable IDISP001
-#pragma warning disable IDISP004
-        var skSvg = new SKSvg();
-        modifiedSvgStream.Position = 0;
-        skSvg.Load(modifiedSvgStream);
-#pragma warning restore IDISP001
-#pragma warning restore IDISP004
-        if (skSvg.Picture is null)
-            throw new Exception("Failed to load modified SVG picture.");
-        return new SvgDrawableImage(skSvg.Picture);
-    }
-
-    private static BitmapDrawableImage CreateBitmapImageForRegion(BitmapDrawableImage bitmapImage, BitmapRegion sprite)
-    {
-        return new BitmapDrawableImage(bitmapImage.Image.Subset(new SKRectI(sprite.X, sprite.Y, sprite.X + sprite.Width, sprite.Y + sprite.Height)));
-    }
-
-    private static void DrawBuiltInImage(SKCanvas canvas, SymbolStyle symbolStyle, VectorCache vectorCache,
+    private static void DrawSymbolType(SKCanvas canvas, SymbolStyle symbolStyle, VectorCache vectorCache,
         float opacity)
     {
         canvas.Save();
@@ -262,27 +155,8 @@ public class SymbolStyleRenderer : ISkiaStyleRenderer, IFeatureSize
 
     public static double FeatureSize(SymbolStyle symbolStyle, IRenderService renderService)
     {
-        Size symbolSize = new Size(SymbolStyle.DefaultWidth, SymbolStyle.DefaultHeight);
-
-        switch (symbolStyle.SymbolType)
-        {
-            case SymbolType.Image:
-                if (symbolStyle.Image is not null)
-                {
-                    var image = ((RenderService)renderService).DrawableImageCache.GetOrCreate(symbolStyle.Image.SourceId,
-                        () => TryCreateDrawableImage(symbolStyle.Image, ((RenderService)renderService).ImageSourceCache));
-                    if (image != null)
-                        symbolSize = new Size(image.Width, image.Height);
-                }
-
-                break;
-            case SymbolType.Ellipse:
-            case SymbolType.Rectangle:
-            case SymbolType.Triangle:
-                var vectorSize = VectorStyleRenderer.FeatureSize(symbolStyle);
-                symbolSize = new Size(vectorSize, vectorSize);
-                break;
-        }
+        var vectorSize = VectorStyleRenderer.FeatureSize(symbolStyle);
+        Size symbolSize = new Size(vectorSize, vectorSize);
 
         var size = Math.Max(symbolSize.Height, symbolSize.Width);
         size *= symbolStyle.SymbolScale; // Symbol Scale
@@ -299,15 +173,4 @@ public class SymbolStyleRenderer : ISkiaStyleRenderer, IFeatureSize
 
         return size;
     }
-
-    // Todo: Figure out a better place for this method
-    public static IDrawableImage? TryCreateDrawableImage(Image image, ImageSourceCache imageSourceCache)
-    {
-        var imageBytes = imageSourceCache.Get(image);
-        if (imageBytes == null)
-            return null;
-        var drawableImage = ImageHelper.ToDrawableImage(imageBytes);
-        return drawableImage;
-    }
-
 }

--- a/Mapsui.Rendering.Skia/SkiaWidgets/ImageButtonWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/ImageButtonWidgetRenderer.cs
@@ -18,7 +18,7 @@ public class ImageButtonWidgetRenderer : ISkiaWidgetRenderer
             throw new InvalidOperationException("ImageSource is not set");
 
         var drawableImage = renderService.DrawableImageCache.GetOrCreate(button.Image.SourceId,
-            () => SymbolStyleRenderer.TryCreateDrawableImage(button.Image, renderService.ImageSourceCache));
+            () => ImageStyleRenderer.TryCreateDrawableImage(button.Image, renderService.ImageSourceCache));
         if (drawableImage == null)
             return;
 

--- a/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
+++ b/Mapsui.UI.MapView/Objects/MyLocationLayer.cs
@@ -26,8 +26,8 @@ public class MyLocationLayer : BaseLayer
 {
     private MapView _mapView;
     private readonly GeometryFeature _feature;
-    private readonly SymbolStyle _locStyle;  // style for the location indicator
-    private readonly SymbolStyle _dirStyle;  // style for the view-direction indicator
+    private readonly ImageStyle _locStyle;  // style for the location indicator
+    private readonly ImageStyle _dirStyle;  // style for the view-direction indicator
     private readonly CalloutStyle _coStyle;  // style for the callout
 
     private static readonly string _movingImageSource = "embedded://Mapsui.Resources.Images.MyLocationMoving.svg";
@@ -159,7 +159,7 @@ public class MyLocationLayer : BaseLayer
             ["Label"] = "MyLocation moving",
         };
 
-        _locStyle = new SymbolStyle
+        _locStyle = new ImageStyle
         {
             Enabled = true,
             Image = _stillImageSource,
@@ -169,7 +169,7 @@ public class MyLocationLayer : BaseLayer
             Opacity = 1,
         };
 
-        _dirStyle = new SymbolStyle
+        _dirStyle = new ImageStyle
         {
             Enabled = false,
             Image = _directionImageSource,

--- a/Mapsui.UI.MapView/Objects/Pin.cs
+++ b/Mapsui.UI.MapView/Objects/Pin.cs
@@ -491,7 +491,7 @@ public class Pin : IFeatureProvider, INotifyPropertyChanged
             {
                 // We only want to have one style
                 Feature.Styles.Clear();
-                Feature.Styles.Add(new SymbolStyle
+                Feature.Styles.Add(new ImageStyle
                 {
                     Image = new Image
                     {

--- a/Mapsui/Layers/MyLocationLayer.cs
+++ b/Mapsui/Layers/MyLocationLayer.cs
@@ -19,8 +19,8 @@ public class MyLocationLayer : BaseLayer, IDisposable
 {
     private readonly Map _map;
     private readonly PointFeature _feature;
-    private readonly SymbolStyle _locStyle;  // style for the location indicator
-    private readonly SymbolStyle _dirStyle;  // style for the view-direction indicator
+    private readonly ImageStyle _locStyle;  // style for the location indicator
+    private readonly ImageStyle _dirStyle;  // style for the view-direction indicator
     private readonly CalloutStyle _coStyle;  // style for the callout
 
     private static readonly string _movingImageSource = "embedded://Mapsui.Resources.Images.MyLocationMoving.svg";
@@ -158,7 +158,7 @@ public class MyLocationLayer : BaseLayer, IDisposable
             ["Label"] = "MyLocation",
         };
 
-        _locStyle = new SymbolStyle
+        _locStyle = new ImageStyle
         {
             Enabled = true,
             Image = _stillImageSource,
@@ -168,7 +168,7 @@ public class MyLocationLayer : BaseLayer, IDisposable
             Opacity = 1,
         };
 
-        _dirStyle = new SymbolStyle
+        _dirStyle = new ImageStyle
         {
             Enabled = false,
             Image = _directionImageSource,

--- a/Mapsui/Styles/BasePointStyle.cs
+++ b/Mapsui/Styles/BasePointStyle.cs
@@ -1,0 +1,53 @@
+﻿using System;
+
+namespace Mapsui.Styles;
+
+public abstract class BasePointStyle : Style, IPointStyle
+{
+    /// <summary>
+    /// Gets or sets the rotation of the symbol in degrees (clockwise is positive)
+    /// </summary>
+    public double SymbolRotation { get; set; }
+
+    /// <summary>
+    /// When true a symbol will rotate along with the rotation of the map.
+    /// This is useful if you need to symbolize the direction in which a vehicle
+    /// is moving. When the symbol is false it will retain it's position to the
+    /// screen. This is useful for pins like symbols. The default is false.
+    /// This mode is not supported in the WPF renderer.
+    /// </summary>
+    public bool RotateWithMap { get; set; }
+
+    /// <summary>
+    ///     Scale of the symbol (defaults to 1)
+    /// </summary>
+    /// <remarks>
+    ///     Setting the SymbolScale to '2.0' doubles the size of the symbol. A SymbolScale of 0.5 makes the scale half the size.
+    ///     of the original image
+    /// </remarks>
+    public double SymbolScale { get; set; } = 1.0;
+
+    [Obsolete("Use Offset or RelativeOffset instead", true)]
+    public Offset SymbolOffset { get; set; } = new Offset();
+
+    /// <summary>
+    ///     Gets or sets the offset in pixels of the symbol.
+    /// </summary>
+    /// <remarks>
+    ///     The symbol offset is scaled with the <see cref="SymbolScale" /> property and refers to the offset of
+    ///     <see cref="SymbolScale" />=1.0.
+    /// </remarks>
+    public Offset Offset { get; set; } = new Offset();
+
+    /// <summary>
+    /// Offset of the symbol in units relative to the size of the symbol. When X = 0 and Y = 0 it will be centered.
+    /// </summary>
+    public RelativeOffset RelativeOffset { get; set; } = new RelativeOffset();
+
+    /// <summary>
+    /// Should SymbolOffset position rotate with map
+    /// </summary>
+    public bool SymbolOffsetRotatesWithMap { get; set; }
+
+
+}

--- a/Mapsui/Styles/CalloutStyle.cs
+++ b/Mapsui/Styles/CalloutStyle.cs
@@ -57,7 +57,7 @@ public enum TailAlignment
 /// 3. Type = CalloutType.Custom
 ///    The bitmap with ID in Content will be shown
 /// </remarks>
-public class CalloutStyle : SymbolStyle, IHasImage
+public class CalloutStyle : ImageStyle, IHasImage
 {
     private CalloutType _type = CalloutType.Single;
     private double _rotation;
@@ -75,9 +75,6 @@ public class CalloutStyle : SymbolStyle, IHasImage
 
     public string ImageIdOfCallout { get; private set; } = Guid.NewGuid().ToString();
     public string ImageIdOfCalloutContent { get; private set; } = Guid.NewGuid().ToString();
-
-    public static new double DefaultWidth { get; set; } = 100;
-    public static new double DefaultHeight { get; set; } = 30;
 
     /// <summary>
     /// Type of Callout

--- a/Mapsui/Styles/IPointStyle.cs
+++ b/Mapsui/Styles/IPointStyle.cs
@@ -1,0 +1,12 @@
+﻿namespace Mapsui.Styles;
+
+public interface IPointStyle
+{
+    Offset Offset { get; set; }
+    RelativeOffset RelativeOffset { get; set; }
+    bool RotateWithMap { get; set; }
+    Offset SymbolOffset { get; set; }
+    bool SymbolOffsetRotatesWithMap { get; set; }
+    double SymbolRotation { get; set; }
+    double SymbolScale { get; set; }
+}

--- a/Mapsui/Styles/ImageStyle.cs
+++ b/Mapsui/Styles/ImageStyle.cs
@@ -1,0 +1,9 @@
+﻿namespace Mapsui.Styles;
+
+public class ImageStyle : BasePointStyle, IHasImage
+{
+    /// <summary>
+    /// Path to the the image to display during rendering. This can be url, file path or embedded resource.
+    /// </summary>
+    public Image? Image { get; set; }
+}

--- a/Mapsui/Styles/ImageStyles.cs
+++ b/Mapsui/Styles/ImageStyles.cs
@@ -1,8 +1,8 @@
 ﻿namespace Mapsui.Styles;
 
-public static class SymbolStyles
+public static class ImageStyles
 {
-    public static SymbolStyle CreatePinStyle(Color? fillColor = null, Color? strokeColor = null, double symbolScale = 1.0) => new()
+    public static ImageStyle CreatePinStyle(Color? fillColor = null, Color? strokeColor = null, double symbolScale = 1.0) => new()
     {
         Image = new Image
         {

--- a/Mapsui/Styles/SymbolStyle.cs
+++ b/Mapsui/Styles/SymbolStyle.cs
@@ -9,7 +9,6 @@ public enum SymbolType
     Ellipse,
     Rectangle,
     Triangle,
-    Image
 }
 
 public enum UnitType
@@ -18,7 +17,7 @@ public enum UnitType
     WorldUnit
 }
 
-public class SymbolStyle : VectorStyle, IHasImage
+public class SymbolStyle : VectorStyle, IPointStyle
 {
     public static double DefaultWidth { get; set; } = 32;
     public static double DefaultHeight { get; set; } = 32;
@@ -26,22 +25,6 @@ public class SymbolStyle : VectorStyle, IHasImage
     public SymbolType SymbolType { get; set; }
 
     public UnitType UnitType { get; set; }
-
-    private Image? _image;
-
-    /// <summary>
-    /// Path to the the image to display during rendering. This can be url, file path or embedded resource.
-    /// </summary>
-    public Image? Image
-    {
-        get => _image;
-        set
-        {
-            _image = value;
-            if (_image != null)
-                SymbolType = SymbolType.Image;
-        }
-    }
 
     /// <summary>
     /// Gets or sets the rotation of the symbol in degrees (clockwise is positive)
@@ -121,9 +104,6 @@ public class SymbolStyle : VectorStyle, IHasImage
         if (SymbolType != symbolStyle.SymbolType)
             return false;
 
-        if (Image != symbolStyle.Image)
-            return false;
-
         if (Math.Abs(Opacity - symbolStyle.Opacity) > Constants.Epsilon)
             return false;
 
@@ -133,13 +113,12 @@ public class SymbolStyle : VectorStyle, IHasImage
     public override int GetHashCode()
     {
         return
-            Image?.GetHashCode() ^
             SymbolScale.GetHashCode() ^
             Offset.GetHashCode() ^
             SymbolRotation.GetHashCode() ^
             UnitType.GetHashCode() ^
             SymbolType.GetHashCode() ^
-            base.GetHashCode() ?? 0;
+            base.GetHashCode();
     }
 
     public static bool operator ==(SymbolStyle? symbolStyle1, SymbolStyle? symbolStyle2)

--- a/Mapsui/Styles/Thematics/GradientTheme.cs
+++ b/Mapsui/Styles/Thematics/GradientTheme.cs
@@ -88,7 +88,7 @@ public class GradientTheme : Style, IThemeStyle
         {
             (LabelStyle minLabelStyle, LabelStyle maxLabelStyle)
                 => ToInterpolatedLabelStyle(minLabelStyle, maxLabelStyle, attr, this),
-            (SymbolStyle minSymbolStyle, SymbolStyle maxSymbolStyle)
+            (ImageStyle minSymbolStyle, ImageStyle maxSymbolStyle)
                 => ToInterpolatedSymbolStyle(minSymbolStyle, maxSymbolStyle, attr, this),
             (VectorStyle minVectorStyle, VectorStyle maxVectorStyle)
                 => ToInterpolatedVectorStyle(minVectorStyle, maxVectorStyle, attr, this),
@@ -119,9 +119,9 @@ public class GradientTheme : Style, IThemeStyle
         return result;
     }
 
-    private static SymbolStyle ToInterpolatedSymbolStyle(SymbolStyle min, SymbolStyle max, double value, GradientTheme instance)
+    private static ImageStyle ToInterpolatedSymbolStyle(ImageStyle min, ImageStyle max, double value, GradientTheme instance)
     {
-        var result = new SymbolStyle();
+        var result = new ImageStyle();
 
         var fraction = Fraction(value, instance.Min, instance.Max);
 

--- a/Samples/Mapsui.Samples.Common/DataBuilders/GeodanOfficesLayerBuilder.cs
+++ b/Samples/Mapsui.Samples.Common/DataBuilders/GeodanOfficesLayerBuilder.cs
@@ -15,7 +15,7 @@ public class GeodanOfficesLayerBuilder
         var layer = new MemoryLayer
         {
             Features = new[] { geodanAmsterdam, geodanDenBosch }.ToFeatures(),
-            Style = new SymbolStyle
+            Style = new ImageStyle
             {
                 Image = imageSource,
                 Offset = new Offset { Y = 64 },

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/AnimatedPointsSample.cs
@@ -43,7 +43,7 @@ public sealed class AnimatedPointsSample : ISample, IDisposable
 
     private static ThemeStyle CreatePointStyle() => new(CreateSvgArrowStyle);
 
-    private static SymbolStyle CreateSvgArrowStyle(IFeature feature) => new()
+    private static ImageStyle CreateSvgArrowStyle(IFeature feature) => new()
     {
         Image = "embedded://Mapsui.Samples.Common.Images.arrow.svg",
         SymbolScale = 0.5,

--- a/Samples/Mapsui.Samples.Common/Maps/DataFormats/ShapefileSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/DataFormats/ShapefileSample.cs
@@ -87,8 +87,8 @@ public class ShapefileSample : ISample
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
         var imageSource = "embedded://Mapsui.Samples.Common.Images.icon.png";
-        var cityMin = new SymbolStyle { Image = imageSource, SymbolScale = 0.5f };
-        var cityMax = new SymbolStyle { Image = imageSource, SymbolScale = 1f };
+        var cityMin = new ImageStyle { Image = imageSource, SymbolScale = 0.5f };
+        var cityMax = new ImageStyle { Image = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);
     }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/CustomSvgColorSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/CustomSvgColorSample.cs
@@ -53,7 +53,7 @@ public class CustomSvgStyleSample : ISample
             var distance = Algorithms.Distance(new MPoint(0, 0), featurePosition);
             var distanceBetweenZeroAndOne = Math.Min(distance / _circumferenceOfTheEarth, 1);
 
-            return new SymbolStyle
+            return new ImageStyle
             {
                 Image = new Image
                 {

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
@@ -53,7 +53,7 @@ public class DynamicSvgStyleSample : ISample
             var distance = Algorithms.Distance(tapPosition, featurePoint);
             var distanceBetweenZeroAndOne = Math.Min(distance / circumferenceOfTheEarth, 1);
 
-            return new SymbolStyle
+            return new ImageStyle
             {
                 Image = new Image
                 {

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/WriteToLayerSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/WriteToLayerSample.cs
@@ -44,7 +44,7 @@ public class WriteToLayerSample : ISample
         return new GenericCollectionLayer<List<IFeature>>
         {
             Name = "GenericCollectionLayer",
-            Style = SymbolStyles.CreatePinStyle()
+            Style = ImageStyles.CreatePinStyle()
         };
     }
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/PointsSample.cs
@@ -74,11 +74,11 @@ public class PointsSample : ISample
         return JsonSerializer.Deserialize(stream, PointsSampleContext.Default.ListCity) ?? [];
     }
 
-    private static SymbolStyle CreateBitmapStyle()
+    private static ImageStyle CreateBitmapStyle()
     {
         var imageSource = "embedded://Mapsui.Samples.Common.Images.home.png"; // Designed by Freepik http://www.freepik.com
         var bitmapHeight = 176; // To set the offset correct we need to know the bitmap height
-        return new SymbolStyle { Image = imageSource, SymbolScale = 0.20, Offset = new Offset(0, bitmapHeight * 0.5) };
+        return new ImageStyle { Image = imageSource, SymbolScale = 0.20, Offset = new Offset(0, bitmapHeight * 0.5) };
     }
 }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Geometries/VariousSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Geometries/VariousSample.cs
@@ -55,9 +55,9 @@ public class VariousSample : ISample, ISampleTest
             .Select(p => new PointFeature(p) { Styles = new List<IStyle> { style } }).ToList();
     }
 
-    private static SymbolStyle CreateBitmapStyle(string embeddedResourcePath)
+    private static ImageStyle CreateBitmapStyle(string embeddedResourcePath)
     {
-        return new SymbolStyle { Image = embeddedResourcePath, SymbolScale = 0.75 };
+        return new ImageStyle { Image = embeddedResourcePath, SymbolScale = 0.75 };
     }
 
     public async Task InitializeTestAsync(IMapControl mapControl)

--- a/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
@@ -84,7 +84,7 @@ public class CustomCalloutStyleSample : IMapControlSample
         return features;
     }
 
-    private static SymbolStyle CreatePinSymbol() => new()
+    private static ImageStyle CreatePinSymbol() => new()
     {
         Image = new Image
         {

--- a/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
@@ -59,7 +59,7 @@ public class SingleCalloutSample : ISample
         {
             Name = _calloutLayerName,
             Features = new MemoryProvider(GetCitiesFromEmbeddedResource()).Features,
-            Style = SymbolStyles.CreatePinStyle(symbolScale: 0.7),
+            Style = ImageStyles.CreatePinStyle(symbolScale: 0.7),
         };
     }
 

--- a/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
@@ -67,7 +67,7 @@ public static class SampleLayerExtensions
         {
             Styles =
             {
-                new SymbolStyle
+                new ImageStyle
                 {
                     Image = new Image
                     {

--- a/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithShapefileSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithShapefileSample.cs
@@ -92,8 +92,8 @@ public class ShapefileTileSample : ISample
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
         var imageSource = "embedded://Mapsui.Samples.Common.Images.icon.png";
-        var cityMin = new SymbolStyle { Image = imageSource, SymbolScale = 0.5f };
-        var cityMax = new SymbolStyle { Image = imageSource, SymbolScale = 1f };
+        var cityMin = new ImageStyle { Image = imageSource, SymbolScale = 0.5f };
+        var cityMax = new ImageStyle { Image = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);
     }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Projection/PointProjectionSample.cs
@@ -64,11 +64,11 @@ public class PointProjectionSample : ISample
     }
 
 
-    private static SymbolStyle CreateCityStyle()
+    private static ImageStyle CreateCityStyle()
     {
         var imageSource = "embedded://Mapsui.Samples.Common.Images.location.png";
 
-        return new SymbolStyle
+        return new ImageStyle
         {
             Image = imageSource,
             Offset = new Offset { Y = 64 },

--- a/Samples/Mapsui.Samples.Common/Maps/Projection/ShapefileProjectionSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Projection/ShapefileProjectionSample.cs
@@ -105,8 +105,8 @@ public class ShapefileProjectionSample : ISample
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
         var imageSource = "embedded://Mapsui.Samples.Common.Images.icon.png";
-        var cityMin = new SymbolStyle { Image = imageSource, SymbolScale = 0.5f };
-        var cityMax = new SymbolStyle { Image = imageSource, SymbolScale = 1f };
+        var cityMin = new ImageStyle { Image = imageSource, SymbolScale = 0.5f };
+        var cityMax = new ImageStyle { Image = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);
     }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Special/ShapefileTilingFilteringSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/ShapefileTilingFilteringSample.cs
@@ -101,8 +101,8 @@ public class ShapefileTilingFilteringSample : ISample
         // Cities below 1.000.000 gets the smallest symbol.
         // Cities with more than 5.000.000 the largest symbol.
         var imageSource = "embedded://Mapsui.Samples.Common.Images.icon.png";
-        var cityMin = new SymbolStyle { Image = imageSource, SymbolScale = 0.5f };
-        var cityMax = new SymbolStyle { Image = imageSource, SymbolScale = 1f };
+        var cityMin = new ImageStyle { Image = imageSource, SymbolScale = 0.5f };
+        var cityMax = new ImageStyle { Image = imageSource, SymbolScale = 1f };
         return new GradientTheme("POPULATION", 1000000, 5000000, cityMin, cityMax);
     }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/AtlasSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/AtlasSample.cs
@@ -57,7 +57,7 @@ public class AtlasSample : ISample
         }).ToList();
     }
 
-    private static SymbolStyle CreateSymbolStyle(int x, int y) => new()
+    private static ImageStyle CreateSymbolStyle(int x, int y) => new()
     {
         Image = new Image
         {

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SvgSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SvgSample.cs
@@ -50,7 +50,7 @@ public class SvgSample : ISample
         });
     }
 
-    private static SymbolStyle CreateSvgStyle() => new()
+    private static ImageStyle CreateSvgStyle() => new()
     {
         Image = "embedded://Mapsui.Samples.Common.Images.Pin.svg",
         SymbolScale = 0.5,

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SymbolsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SymbolsSample.cs
@@ -89,14 +89,14 @@ public class SymbolsSample : ISample
         ];
     }
 
-    private static SymbolStyle CreateBitmapStyle(string embeddedResourcePath, double scale)
+    private static ImageStyle CreateBitmapStyle(string embeddedResourcePath, double scale)
     {
-        return new SymbolStyle { Image = embeddedResourcePath, SymbolScale = scale, Offset = new Offset(0, 32) };
+        return new ImageStyle { Image = embeddedResourcePath, SymbolScale = scale, Offset = new Offset(0, 32) };
     }
 
-    private static SymbolStyle CreateSvgStyle(string embeddedResourcePath, double scale)
+    private static ImageStyle CreateSvgStyle(string embeddedResourcePath, double scale)
     {
-        return new SymbolStyle { Image = embeddedResourcePath, SymbolScale = scale, RelativeOffset = new RelativeOffset(0.0, 0.5) };
+        return new ImageStyle { Image = embeddedResourcePath, SymbolScale = scale, RelativeOffset = new RelativeOffset(0.0, 0.5) };
     }
 
     private static PointFeature CreatePointWithStackedStyles() => new(new MPoint(5000000, -5000000))

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/ThemeStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/ThemeStyleSample.cs
@@ -100,7 +100,7 @@ public class ThemeStyleSample : ISample
         };
     }
 
-    private static SymbolStyle CreateCityStyle() => new()
+    private static ImageStyle CreateCityStyle() => new()
     {
         Image = "embedded://Mapsui.Samples.Common.Images.location.png",
         Offset = new Offset { Y = 64 },

--- a/Tests/Mapsui.Rendering.Skia.Tests/SymbolStyleFeatureSizeTests.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/SymbolStyleFeatureSizeTests.cs
@@ -88,7 +88,7 @@ public class SymbolStyleFeatureSizeTests
     {
         // Arrange
         using var renderService = new RenderService();
-        var symbolStyle = new SymbolStyle
+        var symbolStyle = new ImageStyle
         {
             Image = "embedded://Mapsui.Resources.Images.Pin.svg",
         };
@@ -96,7 +96,7 @@ public class SymbolStyleFeatureSizeTests
         await renderService.ImageSourceCache.TryRegisterAsync(symbolStyle.Image);
 
         // Act
-        var size = SymbolStyleRenderer.FeatureSize(symbolStyle, renderService);
+        var size = ImageStyleRenderer.FeatureSize(symbolStyle, renderService);
 
         // Assert
         Assert.That(size, Is.EqualTo(56));

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapAtlasSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapAtlasSample.cs
@@ -55,27 +55,27 @@ public class BitmapAtlasSample : ISample
         [
             new PointFeature(new MPoint(256, 124))
             {
-                Styles = [new SymbolStyle { Image = atlasImageSource}]
+                Styles = [new ImageStyle { Image = atlasImageSource}]
             },
             new PointFeature(new MPoint(20, 280))
             {
-                Styles = [new SymbolStyle { Image = new Image { Source = atlasImageSource, BitmapRegion = spriteAmusementPark15 } }]
+                Styles = [new ImageStyle { Image = new Image { Source = atlasImageSource, BitmapRegion = spriteAmusementPark15 } }]
             },
             new PointFeature(new MPoint(60, 280))
             {
-                Styles = [new SymbolStyle {Image = new Image { Source = atlasImageSource, BitmapRegion = spriteClothingStore15 } }]
+                Styles = [new ImageStyle { Image = new Image { Source = atlasImageSource, BitmapRegion = spriteClothingStore15 } }]
             },
             new PointFeature(new MPoint(100, 280))
             {
-                Styles = [new SymbolStyle {Image = new Image { Source = atlasImageSource, BitmapRegion = spriteDentist15 } }]
+                Styles = [new ImageStyle { Image = new Image { Source = atlasImageSource, BitmapRegion = spriteDentist15 } }]
             },
             new PointFeature(new MPoint(180, 300))
             {
-                Styles = [new SymbolStyle {Image = new Image { Source = atlasImageSource, BitmapRegion = spritePedestrianPolygon } }]
+                Styles = [new ImageStyle { Image = new Image { Source = atlasImageSource, BitmapRegion = spritePedestrianPolygon } }]
             },
             new PointFeature(new MPoint(380, 280))
             {
-                Styles = [new SymbolStyle { Image = svgTigerImageSource, SymbolScale = 0.1}]
+                Styles = [new ImageStyle { Image = svgTigerImageSource, SymbolScale = 0.1}]
             }
         ];
     }

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolInCollectionSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolInCollectionSample.cs
@@ -57,12 +57,12 @@ public class BitmapSymbolInCollectionSample : ISample
             new GeometryFeature
             {
                 Geometry = new GeometryCollection([new Point(50, 100)]),
-                Styles = [new SymbolStyle { Image = circleImageSource }]
+                Styles = [new ImageStyle { Image = circleImageSource }]
             },
             new GeometryFeature
             {
                 Geometry = new GeometryCollection([new Point(100, 50)]),
-                Styles = [new SymbolStyle { Image = checkeredIconImageSource }]
+                Styles = [new ImageStyle { Image = checkeredIconImageSource }]
             },
             new GeometryFeature
             {

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolSample.cs
@@ -50,11 +50,11 @@ public class BitmapSymbolSample : ISample
             },
             new PointFeature(new MPoint(50, 100))
             {
-                Styles = [new SymbolStyle { Image = circleImageSource }]
+                Styles = [new ImageStyle { Image = circleImageSource }]
             },
             new PointFeature(new MPoint(100, 50))
             {
-                Styles = [new SymbolStyle { Image = checkeredImageSource }]
+                Styles = [new ImageStyle { Image = checkeredImageSource }]
             },
             new PointFeature(new MPoint(100, 100))
             {

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolWithRotationAndOffsetSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSymbolWithRotationAndOffsetSample.cs
@@ -56,7 +56,7 @@ public class BitmapSymbolWithRotationAndOffsetSample : ISample
 
         var feature = new GeometryFeature { Geometry = new Point(x, y) };
 
-        feature.Styles.Add(new SymbolStyle
+        feature.Styles.Add(new ImageStyle
         {
             Image = imageSource,
             Offset = new Offset { Y = -24 },

--- a/Tests/Mapsui.Tests.Common/Maps/SvgSymbolSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/SvgSymbolSample.cs
@@ -56,7 +56,7 @@ public class SvgSymbolSample : ISample
         }
     ];
 
-    private static SymbolStyle CreateSymbolStyle() => new()
+    private static ImageStyle CreateSymbolStyle() => new()
     {
         Image = new Image
         {


### PR DESCRIPTION
This is intended to prepare for a CustomPointStyle which could reuse a lot of the existing code. It would derive from BasePointStyle and should reuse some of the render logic of existing styles.

After this initial commit some more rendering code should move to a shared PointStyleRenderer.