### PR TITLE
Add CustomPointStyle to make it easier to use custom SkiaSharp drawing

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaStyles/BitmapRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/BitmapRenderer.cs
@@ -8,13 +8,13 @@ internal class BitmapRenderer
 {
     // The field below is static for performance. Effect has not been measured.
     // Note that the default FilterQuality is None. Setting it explicitly to Low increases the quality.
-    private static readonly SKPaint DefaultPaint = new();
-    private static readonly SKSamplingOptions DefaultSamplingOptions = new(SKFilterMode.Linear, SKMipmapMode.None);
+    private static readonly SKPaint _defaultPaint = new();
+    private static readonly SKSamplingOptions _defaultSamplingOptions = new(SKFilterMode.Linear, SKMipmapMode.None);
 
     public static void Draw(SKCanvas canvas, SKImage bitmap, SKRect rect, float layerOpacity = 1f)
     {
         var skPaint = GetPaint(layerOpacity, out var dispose);
-        canvas.DrawImage(bitmap, rect, DefaultSamplingOptions, skPaint);
+        canvas.DrawImage(bitmap, rect, _defaultSamplingOptions, skPaint);
         if (dispose)
             skPaint.Dispose();
     }
@@ -81,6 +81,6 @@ internal class BitmapRenderer
             };
         }
         dispose = false;
-        return DefaultPaint;
+        return _defaultPaint;
     }
 }

--- a/Mapsui.Rendering.Skia/SkiaStyles/CustomPointStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/CustomPointStyleRenderer.cs
@@ -1,0 +1,29 @@
+﻿using Mapsui.Layers;
+using Mapsui.Logging;
+using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Styles;
+using SkiaSharp;
+using System;
+
+namespace Mapsui.Rendering.Skia.SkiaStyles;
+
+public class CustomPointStyleRenderer : ISkiaStyleRenderer
+{
+    public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, IStyle style, RenderService renderService, long iteration)
+    {
+        if (style is CustomPointStyle customPointStyle)
+        {
+            feature.CoordinateVisitor((x, y, setter) =>
+            {
+                var opacity = (float)(layer.Opacity * customPointStyle.Opacity);
+                if (MapRenderer.TryGetPointStyleRenderer(customPointStyle.RendererName, out var pointStyleRenderer))
+                    PointStyleRenderer.DrawPointStyle(canvas, viewport, x, y, customPointStyle, renderService, opacity, pointStyleRenderer);
+                else
+                    Logger.Log(LogLevel.Error, $"Could not find the point style renderer with name {customPointStyle.RendererName}");
+            });
+            return true;
+        }
+        else
+            throw new ArgumentException($"Parameter style is not a {nameof(CustomPointStyle)}");
+    }
+}

--- a/Mapsui.Rendering.Skia/SkiaStyles/PointStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/PointStyleRenderer.cs
@@ -1,0 +1,43 @@
+﻿using Mapsui.Extensions;
+using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Styles;
+using SkiaSharp;
+
+namespace Mapsui.Rendering.Skia.SkiaStyles;
+
+public abstract class PointStyleRenderer
+{
+    public delegate void PointStyleDrawer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity);
+
+    public static void DrawPointStyle(SKCanvas canvas, Viewport viewport, double x, double y, IPointStyle imageStyle,
+        RenderService renderService, float opacity, PointStyleDrawer drawPointStyle)
+    {
+        try
+        {
+            canvas.Save();
+
+            // Translate to the position
+            var (destinationX, destinationY) = viewport.WorldToScreenXY(x, y);
+            canvas.Translate((float)destinationX, (float)destinationY);
+
+            // Scale
+            canvas.Scale((float)imageStyle.SymbolScale, (float)imageStyle.SymbolScale);
+
+            // Rotate
+            var rotation = imageStyle.SymbolRotation;
+            if (imageStyle.RotateWithMap)
+                rotation += viewport.Rotation;
+            if (rotation != 0)
+                canvas.RotateDegrees((float)rotation);
+
+            // Translate to offset
+            canvas.Translate((float)imageStyle.Offset.X, (float)-imageStyle.Offset.Y);
+
+            drawPointStyle(canvas, imageStyle, renderService, opacity);
+        }
+        finally
+        {
+            canvas.Restore();
+        }
+    }
+}

--- a/Mapsui.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
@@ -31,7 +31,7 @@ public class VectorStyleRenderer : ISkiaStyleRenderer, IFeatureSize
                     }
                     break;
                 case Point point:
-                    SymbolStyleRenderer.DrawXY(canvas, viewport, layer, point.X, point.Y, CreateSymbolStyle(vectorStyle), renderService);
+                    SymbolStyleRenderer.DrawStatic(canvas, viewport, layer, point.X, point.Y, CreateSymbolStyle(vectorStyle), renderService);
                     break;
                 case Polygon polygon:
                     PolygonRenderer.Draw(canvas, viewport, vectorStyle, feature, polygon, opacity, renderService.VectorCache, position);
@@ -51,7 +51,7 @@ public class VectorStyleRenderer : ISkiaStyleRenderer, IFeatureSize
             switch (feature)
             {
                 case PointFeature pointFeature:
-                    SymbolStyleRenderer.DrawXY(canvas, viewport, layer, pointFeature.Point.X, pointFeature.Point.Y, CreateSymbolStyle(vectorStyle), renderService);
+                    SymbolStyleRenderer.DrawStatic(canvas, viewport, layer, pointFeature.Point.X, pointFeature.Point.Y, CreateSymbolStyle(vectorStyle), renderService);
                     break;
                 case GeometryFeature geometryFeature:
                     DrawGeometry(geometryFeature?.Geometry);

--- a/Mapsui.Tiling/Provider/RasterizingTileSource.cs
+++ b/Mapsui.Tiling/Provider/RasterizingTileSource.cs
@@ -1,21 +1,19 @@
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using BruTile;
 using BruTile.Cache;
 using BruTile.Predefined;
 using Mapsui.Extensions;
 using Mapsui.Layers;
-using Mapsui.Logging;
 using Mapsui.Manipulations;
 using Mapsui.Projections;
 using Mapsui.Providers;
 using Mapsui.Rendering;
 using Mapsui.Styles;
 using Mapsui.Tiling.Extensions;
-using Attribution = BruTile.Attribution;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Mapsui.Tiling.Provider;
 
@@ -180,8 +178,6 @@ public class RasterizingTileSource : ILocalTileSource, ILayerFeatureInfo
                         }
                     }
                 }
-                else
-                    Logger.Log(LogLevel.Warning, $"No StyleRenderer found for {style.GetType()}");
             }
 
             result = ConvertToCoordinates(tempSize, section.Resolution);

--- a/Mapsui/Styles/CustomPointStyle.cs
+++ b/Mapsui/Styles/CustomPointStyle.cs
@@ -1,0 +1,6 @@
+﻿namespace Mapsui.Styles;
+
+public class CustomPointStyle : BasePointStyle
+{
+    public required string RendererName { get; init; }
+}

--- a/Mapsui/Styles/IPointStyle.cs
+++ b/Mapsui/Styles/IPointStyle.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mapsui.Styles;
 
-public interface IPointStyle
+public interface IPointStyle : IStyle
 {
     Offset Offset { get; set; }
     RelativeOffset RelativeOffset { get; set; }

--- a/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
@@ -21,7 +21,7 @@ namespace Mapsui.Samples.Common.Maps.Styles;
 public class CustomCalloutStyleSample : IMapControlSample
 {
     public string Name => "Custom Callout Style";
-    public string Category => "Info";
+    public string Category => "MapInfo";
 
     private const string _customStyleLayerName = "Custom Callout Layer";
 

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/CustomPointStyleAdvancedSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/CustomPointStyleAdvancedSample.cs
@@ -1,0 +1,110 @@
+﻿using Mapsui.Extensions;
+using Mapsui.Layers;
+using Mapsui.Rendering.Skia;
+using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Rendering.Skia.Extensions;
+using Mapsui.Samples.Common.DataBuilders;
+using Mapsui.Styles;
+using Mapsui.Styles.Thematics;
+using Mapsui.Tiling;
+using Mapsui.Widgets.InfoWidgets;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Mapsui.Samples.Common.Maps.Styles;
+
+[SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP001:Dispose created")]
+public class CustomPointStyleAdvancedSample : ISample
+{
+    public string Name => $"{nameof(CustomPointStyle)} Advanced";
+    public string Category => $"{nameof(CustomPointStyle)}";
+
+    private static readonly Color _color1 = Color.FromString("#6A5ACD");
+    private static readonly Color _color2 = Color.FromString("#7B68EE");
+    private static readonly Color _color3 = Color.FromString("#9370DB");
+    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+
+    public static Map CreateMap()
+    {
+        var map = new Map();
+        map.Layers.Add(OpenStreetMap.CreateTileLayer());
+        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
+        {
+            Features = CreateFeatures(map.Extent!, 24).ToList(),
+            Style = new StyleCollection
+            {
+                Styles =
+                {
+                    CreateCustomRendererStyle(),
+                    new SymbolStyle() { SymbolScale = 0.2, Fill = new Brush(_color1) }, // Reference point at the center of the position
+                }
+            }
+        });
+        map.Widgets.Add(new MapInfoWidget(map, [map.Layers.Last()]));
+
+        MapRenderer.RegisterPointStyleRenderer("custom-style-advanced", MyCustomStyleRenderer);
+
+        return map;
+    }
+
+    private static void MyCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
+    {
+        var width = 30f;
+        var halfWidth = width * 0.5f;
+        var height = 30f;
+        var halfHeight = height * 0.5f;
+
+        // SymbolRotation, SymbolScale, RotateWithMap and Offset is already taken into account before this method is called.
+        // RelativeOffset needs to be set in user code because in the caller the width and height is not known.
+        var offset = style.RelativeOffset.GetAbsoluteOffset(width, height);
+        canvas.Translate((float)offset.X, -(float)offset.Y);
+
+        using var path = new SKPath();
+        path.AddRect(new SKRect(-halfWidth, -halfHeight, -halfWidth * 0.5f, halfHeight));
+        using var paint = new SKPaint { Color = _color1.ToSkia(), IsAntialias = true, Style = SKPaintStyle.StrokeAndFill, StrokeWidth = 0.5f };
+        canvas.DrawPath(path, paint);
+
+        using var path2 = new SKPath();
+        path2.AddRect(new SKRect(-halfWidth * 0.5f, -halfHeight, halfWidth * 0.5f, halfHeight));
+        using var paint2 = new SKPaint { Color = _color2.ToSkia(), IsAntialias = true, Style = SKPaintStyle.StrokeAndFill, StrokeWidth = 0.5f };
+        canvas.DrawPath(path2, paint2);
+
+        using var path3 = new SKPath();
+        path3.AddRect(new SKRect(halfWidth * 0.5f, -halfHeight, halfWidth, halfHeight));
+        using var paint3 = new SKPaint { Color = _color3.ToSkia(), IsAntialias = true, Style = SKPaintStyle.StrokeAndFill, StrokeWidth = 0.5f };
+        canvas.DrawPath(path3, paint3);
+    }
+
+    private static ThemeStyle CreateCustomRendererStyle()
+    {
+        return new ThemeStyle((f) =>
+        {
+            // Get the counter that we assigned in CreateFeatures.
+            var counter = (int)((PointFeature)f).Data!;
+
+            // Here we use the counter to assign different settings to different features
+            // to demonstrate that these are taken into account by the renderer.
+            return new CustomPointStyle
+            {
+                RendererName = "custom-style-advanced",
+                SymbolRotation = 90 * (counter % 4),
+                RotateWithMap = counter % 2 == 0,
+                SymbolScale = counter % 2 == 0 ? 0.8 : 1.2,
+                Offset = new Offset(counter % 2 == 0 ? 0 : 10, counter % 2 == 0 ? 0 : 10),
+                RelativeOffset = new RelativeOffset(counter % 2 == 0 ? -0.5 : 0.5, counter % 2 == 0 ? -0.5 : 0.5),
+            };
+        });
+    }
+
+    private static List<PointFeature> CreateFeatures(MRect envelope, int count)
+    {
+        var random = new Random(327);
+        var randomPoints = RandomPointsBuilder.GenerateRandomPoints(envelope, count, random);
+        var counter = 0;
+        return randomPoints.Select(p => new PointFeature(p) { Data = counter++ }).ToList();
+    }
+}

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/CustomPointStyleBasicSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/CustomPointStyleBasicSample.cs
@@ -1,0 +1,46 @@
+﻿using Mapsui.Layers;
+using Mapsui.Rendering.Skia;
+using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Samples.Common.DataBuilders;
+using Mapsui.Styles;
+using Mapsui.Tiling;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Mapsui.Samples.Common.Maps.Styles;
+
+[SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP001:Dispose created")]
+public class CustomPointStyleBasicSample : ISample
+{
+    public string Name => $"{nameof(CustomPointStyle)}";
+    public string Category => $"{nameof(CustomPointStyle)}";
+
+    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+
+    public static Map CreateMap()
+    {
+        var map = new Map();
+        map.Layers.Add(OpenStreetMap.CreateTileLayer());
+        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
+        {
+            Features = CreateFeatures(map.Extent!, 32).ToList(),
+            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
+        });
+        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
+        return map;
+    }
+
+    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
+    {
+        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
+        canvas.DrawCircle(0f, 0f, 10f, paint);
+    }
+
+    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
+        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
+            .Select(p => new PointFeature(p)).ToList();
+}

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/CustomPointStyleShaderSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/CustomPointStyleShaderSample.cs
@@ -1,0 +1,85 @@
+﻿using BruTile.Predefined;
+using Mapsui.Extensions;
+using Mapsui.Layers;
+using Mapsui.Rendering.Skia;
+using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Samples.Common.DataBuilders;
+using Mapsui.Styles;
+using Mapsui.Tiling.Fetcher;
+using Mapsui.Tiling.Layers;
+using Mapsui.Widgets.InfoWidgets;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Mapsui.Samples.Common.Maps.Styles;
+
+[SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP001:Dispose created")]
+public class CustomPointStyleShaderSample : ISample
+{
+    public string Name => $"{nameof(CustomPointStyle)} Shader";
+    public string Category => $"{nameof(CustomPointStyle)}";
+
+    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+
+    public static Map CreateMap()
+    {
+        var map = new Map();
+        map.Layers.Add(CreateLayer());
+        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
+        {
+            Features = CreateFeatures(map.Extent!, 32).ToList(),
+            Style = new CustomPointStyle() { RendererName = "custom-style-shader" },
+        });
+        map.Widgets.Add(new MapInfoWidget(map, [map.Layers.Last()]));
+
+        MapRenderer.RegisterPointStyleRenderer("custom-style-shader", MyBasicCustomStyleRenderer);
+        return map;
+    }
+
+    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
+        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
+        .Select(p => new PointFeature(p))
+        .ToList();
+
+    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
+    {
+        using var paint = new SKPaint { Color = SKColors.OliveDrab, IsAntialias = true };
+        canvas.DrawCircle(0f, 0f, 10f, paint);
+        DrawEllipseWithGradient(canvas, CreatePath());
+    }
+
+    private static SKRect CreatePath()
+    {
+        var halfWidth = 20;
+        var halfHeight = 20f;
+        return new SKRect(-halfWidth, -halfHeight, halfWidth, halfHeight);
+    }
+
+    private static TileLayer CreateLayer()
+    {
+        var tileSource = KnownTileSources.Create(KnownTileSource.BKGTopPlusGrey);
+        return new TileLayer(tileSource, dataFetchStrategy: new DataFetchStrategy()) // DataFetchStrategy prefetches tiles from higher levels
+        {
+            Name = "BKG Top Plus Grey",
+        };
+    }
+
+    private static void DrawEllipseWithGradient(SKCanvas canvas, SKRect rect)
+    {
+        // create the shader
+        var colors = new SKColor[] {
+            new(0, 255, 255),
+            new(255, 0, 255),
+            new(255, 255, 0),
+            new(0, 255, 255)
+        };
+        var shader = SKShader.CreateSweepGradient(new SKPoint(0, 0), colors, null);
+
+        using var paint = new SKPaint { Shader = shader, IsAntialias = true };
+        canvas.DrawOval(rect, paint);
+    }
+}

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SymbolsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SymbolsSample.cs
@@ -27,15 +27,12 @@ public class SymbolsSample : ISample
         return Task.FromResult(map);
     }
 
-    private static ILayer CreateStylesLayer(MRect? envelope)
+    private static ILayer CreateStylesLayer(MRect? envelope) => new MemoryLayer
     {
-        return new MemoryLayer
-        {
-            Name = "Styles Layer",
-            Features = CreateDiverseFeatures(RandomPointsBuilder.GenerateRandomPoints(envelope, 25)),
-            Style = null,
-        };
-    }
+        Name = "Styles Layer",
+        Features = CreateDiverseFeatures(RandomPointsBuilder.GenerateRandomPoints(envelope, 25)),
+        Style = null,
+    };
 
     private static IEnumerable<IFeature> CreateDiverseFeatures(IEnumerable<MPoint> randomPoints)
     {
@@ -50,7 +47,7 @@ public class SymbolsSample : ISample
             };
 
             feature.Styles.Add(styles[counter]);
-            feature.Styles.Add(SmalleDot());
+            feature.Styles.Add(CreateSmallDotStyle());
             features.Add(feature);
             counter++;
             if (counter == styles.Count) counter = 0;
@@ -60,10 +57,8 @@ public class SymbolsSample : ISample
         return features;
     }
 
-    private static IStyle SmalleDot()
-    {
-        return new SymbolStyle { SymbolScale = 0.2, Fill = new Brush(new Color(40, 40, 40)) };
-    }
+    private static SymbolStyle CreateSmallDotStyle() =>
+        new() { SymbolScale = 0.2, Fill = new Brush(new Color(40, 40, 40)) };
 
     private static IEnumerable<IStyle> CreateDiverseStyles()
     {


### PR DESCRIPTION
### Context
In Mapsui V4 it was possible to create an SKPicture and to register that in the BitmapRegistry. In V5 this part of the code was rewritten. One alternative is the svg-content that can be assigned to the ImageStyle.Image.Source merged last week. Another alternative is the CustomPointStyle added in this PR. 

### CustomPointStyle 
With CustomPointStyle it becomes possible for the user to do it's own SkiaSharp rendering, similar to the CustomStyleRenderer, but easier to use. This is code of a sample that is part of the PR:

```csharp
    public static Map CreateMap()
    {
        var map = new Map();
        map.Layers.Add(OpenStreetMap.CreateTileLayer());
        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
        {
            Features = CreateFeatures(map.Extent!, 32).ToList(),
            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
        });
        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
        return map;
    }

    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
    {
        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
        canvas.DrawCircle(0f, 0f, 10f, paint);
    }
```
The code can be this simple because the canvas transformations are done before the render method is called. These are: Rotating while taking into account RotateWithMap, Scaling, Translating to position, Translating to offset. 

### PointStyleRenderer
In this PR and the two previous ones preparations were made for this. There is now a PointStyleRenderer class that is used by SymbolStyle, ImageStyle and CustomPointStyle. Perhaps it should also be used by the label renderer and the callout renderer.

### Naming
I am not sure if I am happy with the naming of the PointStyleRendeder and the CustomPointStyle. The term 'Point' seems correct because it only applies to points and the users should know that, but when I read the names it does not seem that clear. There is so much called point in a mapping library. And 'Rendering' is not in the style name but perhaps is should, but then it should not get too long.

### Samples
Three samples were added in a new CustomPointStyle category. 
- A basic one, showing what you minimally need do to draw a simple dot.
- An advanced one, showing how the PointStyle fields are taken into account.
- A sample using a skia shader to show that now advanced SkiaSharp features, not used in the Mapsui renderers, become available.

The shader sample:

![image](https://github.com/user-attachments/assets/98609dec-f902-40af-95cc-eea5108cdc65)





