### PR TITLE
Add all four events to BaseWidget and add the Map to the BaseEventArgs

### DIFF
--- a/Mapsui.Nts/Editing/EditManipulation.cs
+++ b/Mapsui.Nts/Editing/EditManipulation.cs
@@ -64,7 +64,7 @@ public static class EditManipulation
         return false;
     }
 
-    public static bool OnTapped(Navigator navigator, WidgetEventArgs e, EditManager editManager)
+    public static bool OnTapped(WidgetEventArgs e, EditManager editManager)
     {
         var editLayer = editManager.Layer;
         if (editLayer == null)
@@ -96,15 +96,15 @@ public static class EditManipulation
             if (e.ShiftPressed || e.GestureType == GestureType.DoubleTap || e.GestureType == GestureType.LongPress)
             {
                 if (e.GestureType != GestureType.DoubleTap) // Add last vertex but not on a double tap because it is preceded by a single tap.
-                    editManager.AddVertex(navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
+                    editManager.AddVertex(e.Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
                 return editManager.EndEdit();
             }
             else
-                editManager.AddVertex(navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
+                editManager.AddVertex(e.Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
         }
         else if (editManager.EditMode is EditMode.AddPoint or EditMode.AddLine or EditMode.AddPolygon)
             if (e.GestureType == GestureType.SingleTap)
-                editManager.AddVertex(navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
+                editManager.AddVertex(e.Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition).ToCoordinate());
 
         if (editManager.SelectMode)
         {

--- a/Mapsui.Nts/Widgets/EditingWidget.cs
+++ b/Mapsui.Nts/Widgets/EditingWidget.cs
@@ -13,15 +13,15 @@ public class EditingWidget : InputOnlyWidget // Derived from InputOnlyWidget bec
         InputAreaType = InputAreaType.Map;
     }
 
-    public override bool OnPointerPressed(Navigator navigator, WidgetEventArgs e)
+    public override bool OnPointerPressed(WidgetEventArgs e)
         => EditManipulation.OnPointerPressed(e, _editManager);
 
-    public override bool OnPointerMoved(Navigator navigator, WidgetEventArgs e) =>
+    public override bool OnPointerMoved(WidgetEventArgs e) =>
         EditManipulation.OnPointerMoved(e, _editManager);
 
-    public override bool OnPointerReleased(Navigator navigator, WidgetEventArgs e) =>
+    public override bool OnPointerReleased(WidgetEventArgs e) =>
         EditManipulation.OnPointerReleased(_editManager);
 
-    public override bool OnTapped(Navigator navigator, WidgetEventArgs e) =>
-        EditManipulation.OnTapped(navigator, e, _editManager);
+    public override bool OnTapped(WidgetEventArgs e) =>
+        EditManipulation.OnTapped(e, _editManager);
 }

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -801,7 +801,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     }
 
     private ImageButtonWidget CreateButton(
-        float x, float y, string imageSource, Func<ImageButtonWidget, WidgetEventArgs, bool> tapped) => new()
+        float x, float y, string imageSource, Func<IWidget, WidgetEventArgs, bool> tapped) => new()
         {
             Image = imageSource,
             HorizontalAlignment = Widgets.HorizontalAlignment.Absolute,

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -633,7 +633,6 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
     private bool HandlerTap(WidgetEventArgs e)
     {
-        var handled = false;
         var screenPosition = e.ScreenPosition;
 
         var map = Map;
@@ -642,11 +641,11 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             var worldPosition = map.Navigator.Viewport.ScreenToWorld(screenPosition);
             var getRemoteMapInfoAsync = () => RemoteMapInfoFetcher.GetRemoteMapInfoAsync(screenPosition, map.Navigator.Viewport, map.Layers);
             var mapInfoEventArgs = new MapInfoEventArgs(screenPosition, worldPosition,
-                e.GestureType, map.Navigator.Viewport, handled, GetMapInfo, GetRemoteMapInfoAsync);
+                e.GestureType, map, GetMapInfo, GetRemoteMapInfoAsync);
 
             HandlerInfo(mapInfoEventArgs);
 
-            handled = mapInfoEventArgs.Handled;
+            var handled = mapInfoEventArgs.Handled;
 
             if (!handled)
             {
@@ -667,7 +666,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             }
         }
 
-        return handled;
+        return false;
     }
 
     private void HandlerPinPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -547,7 +547,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private MapInfoEventArgs CreateMapInfoEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType)
     {
-        return new MapInfoEventArgs(screenPosition, worldPosition, gestureType, Map.Navigator.Viewport, false, GetMapInfo, GetRemoteMapInfoAsync);
+        return new MapInfoEventArgs(screenPosition, worldPosition, gestureType, Map, GetMapInfo, GetRemoteMapInfoAsync);
     }
 
     public MapInfo GetMapInfo(ScreenPosition screenPosition, IEnumerable<ILayer> layers)
@@ -586,7 +586,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnWidgetPointerPressed(ScreenPosition screenPosition, MPoint worldPosition, bool shiftPressed)
     {
-        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, GestureType.Press, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
+        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, GestureType.Press, Map, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
         
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
         {
@@ -599,7 +599,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnWidgetPointerMoved(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, bool shiftPressed)
     {
-        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, gestureType, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
+        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, gestureType, Map, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
 
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
             if (widget.OnPointerMoved(Map.Navigator, eventArgs))
@@ -609,7 +609,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnWidgetPointerReleased(ScreenPosition screenPosition, MPoint worldPosition, bool shiftPressed)
     {
-        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, GestureType.Release, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
+        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, GestureType.Release, Map, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
         
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
         {
@@ -622,7 +622,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnWidgetTapped(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, bool shiftPressed)
     {
-        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, gestureType, Map.Navigator.Viewport, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
+        var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, gestureType, Map, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
 
         var touchedWidgets = WidgetInput.GetWidgetsAtPosition(screenPosition, Map);
         foreach (var widget in touchedWidgets)
@@ -701,31 +701,34 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private bool OnMapPointerPressed(ScreenPosition screenPosition, MPoint worldPosition)
     {
-        Logger.Log(LogLevel.Information, $"Map.PointerPressed");
+        if (Logger.LoggerSettings.LogMapEvents)
+            Logger.Log(LogLevel.Information, $"Map.PointerPressed");
 
         return Map.OnPointerPressed(new MapEventArgs(screenPosition, worldPosition, GestureType.Press,
-            Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
+            Map, GetMapInfo, GetRemoteMapInfoAsync));
     }
 
     private bool OnMapPointerMoved(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType)
     {
         return Map.OnPointerMoved(new MapEventArgs(screenPosition, worldPosition, gestureType, 
-            Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
+            Map, GetMapInfo, GetRemoteMapInfoAsync));
     }
 
     private bool OnMapPointerReleased(ScreenPosition screenPosition, MPoint worldPosition)
     {
-        Logger.Log(LogLevel.Information, $"Map.PointerReleased");
+        if (Logger.LoggerSettings.LogMapEvents)
+            Logger.Log(LogLevel.Information, $"Map.PointerReleased");
 
         return Map.OnPointerReleased(new MapEventArgs(screenPosition, worldPosition, GestureType.Release, 
-            Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
+            Map, GetMapInfo, GetRemoteMapInfoAsync));
     }
 
     private bool OnMapTapped(ScreenPosition screenPosition, GestureType gestureType, MPoint worldPosition)
     {
-        Logger.Log(LogLevel.Information, $"Map.Tapped. {nameof(GestureType)}: {gestureType}");
+        if (Logger.LoggerSettings.LogMapEvents)
+            Logger.Log(LogLevel.Information, $"Map.Tapped. {nameof(GestureType)}: {gestureType}");
         return Map.OnTapped(new MapEventArgs(screenPosition, worldPosition, gestureType, 
-            Map.Navigator.Viewport, GetMapInfo, GetRemoteMapInfoAsync));
+            Map, GetMapInfo, GetRemoteMapInfoAsync));
     }
 
     private bool HasSize() => ViewportWidth > 0 && ViewportHeight > 0;

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -591,7 +591,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
         {
             Logger.Log(LogLevel.Information, $"Widget.PointerPressed: {widget.GetType().Name}");
-            if (widget.OnPointerPressed(Map.Navigator, eventArgs))
+            if (widget.OnPointerPressed(eventArgs))
                 return true;
         }
         return false;
@@ -602,7 +602,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, gestureType, Map, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
 
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
-            if (widget.OnPointerMoved(Map.Navigator, eventArgs))
+            if (widget.OnPointerMoved(eventArgs))
                 return true;
         return false;
     }
@@ -614,7 +614,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
         {
             Logger.Log(LogLevel.Information, $"Widget.Released: {widget.GetType().Name}");
-            if (widget.OnPointerReleased(Map.Navigator, eventArgs))
+            if (widget.OnPointerReleased(eventArgs))
                 return true;
         }
         return false;
@@ -628,7 +628,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         foreach (var widget in touchedWidgets)
         {
             Logger.Log(LogLevel.Information, $"Widget.Tapped: {widget.GetType().Name} {nameof(GestureType)}: {gestureType} KeyState: {shiftPressed}");
-            if (widget.OnTapped(Map.Navigator, eventArgs))
+            if (widget.OnTapped(eventArgs))
                 return true;
         }
 

--- a/Mapsui/BaseEventArgs.cs
+++ b/Mapsui/BaseEventArgs.cs
@@ -2,6 +2,7 @@
 using Mapsui.Manipulations;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Mapsui;
@@ -9,8 +10,8 @@ namespace Mapsui;
 public delegate Task<MapInfo> GetRemoteMapInfoAsyncDelegate(ScreenPosition screenPosition, Viewport viewport, IEnumerable<ILayer> layers);
 public delegate MapInfo GetMapInfoDelegate(ScreenPosition screenPosition, IEnumerable<ILayer> layers);
 
-public class BaseEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, Viewport viewport,
-    GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync) : EventArgs
+public class BaseEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, Map map,
+    GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync) : HandledEventArgs
 {
     /// <summary>
     /// Screen Position of touch in device independent units (or DIP or DP)
@@ -28,9 +29,9 @@ public class BaseEventArgs(ScreenPosition screenPosition, MPoint worldPosition, 
     public GestureType GestureType { get; } = gestureType;
 
     /// <summary>
-    /// Viewport of the map at the moment of the event
+    /// The map from which the event was triggered.
     /// </summary>
-    public Viewport Viewport { get; } = viewport;
+    public Map Map { get; } = map;
 
     /// <summary>
     /// Function to get the MapInfo
@@ -40,5 +41,5 @@ public class BaseEventArgs(ScreenPosition screenPosition, MPoint worldPosition, 
     /// <summary>
     /// Function to get the remote MapInfo
     /// </summary>
-    public Func<IEnumerable<ILayer>, Task<MapInfo>> GetRemoteMapInfoAsync { get; } = (l) => getRemoteMapInfoAsync(screenPosition, viewport, l);
+    public Func<IEnumerable<ILayer>, Task<MapInfo>> GetRemoteMapInfoAsync { get; } = (l) => getRemoteMapInfoAsync(screenPosition, map.Navigator.Viewport, l);
 }

--- a/Mapsui/Logging/Logger.cs
+++ b/Mapsui/Logging/Logger.cs
@@ -14,6 +14,7 @@ public enum LogLevel
 
 public static class Logger
 {
+    public static LoggerSettings Settings { get; } = new LoggerSettings();
     public static Action<LogLevel, string, Exception?>? LogDelegate
     {
         get;
@@ -46,6 +47,11 @@ public static class Logger
                 Debug.WriteLine(message);
                 break;
         }
+    }
+
+    public class LoggerSettings
+    {
+        public static bool LogMapEvents { get; set; }
     }
 }
 

--- a/Mapsui/MapEventArgs.cs
+++ b/Mapsui/MapEventArgs.cs
@@ -4,9 +4,9 @@ namespace Mapsui;
 
 public class MapEventArgs : BaseEventArgs
 {
-    public MapEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, Viewport viewport,
+    public MapEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, Map map,
         GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync)
-        : base(screenPosition, worldPosition, gestureType, viewport, getMapInfo, getRemoteMapInfoAsync)
+        : base(screenPosition, worldPosition, gestureType, map, getMapInfo, getRemoteMapInfoAsync)
     {
     }
 }

--- a/Mapsui/MapInfoEventArgs.cs
+++ b/Mapsui/MapInfoEventArgs.cs
@@ -3,11 +3,6 @@
 namespace Mapsui;
 
 public class MapInfoEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType,
-    Viewport viewport, bool handled, GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync)
-        : BaseEventArgs(screenPosition, worldPosition, gestureType, viewport, getMapInfo, getRemoteMapInfoAsync)
-{
-    /// <summary>
-    /// If the interaction was handled by the event subscriber
-    /// </summary>
-    public bool Handled { get; set; } = handled;
-}
+    Map map, GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync)
+        : BaseEventArgs(screenPosition, worldPosition, gestureType, map, getMapInfo, getRemoteMapInfoAsync)
+{ }

--- a/Mapsui/Widgets/BaseWidget.cs
+++ b/Mapsui/Widgets/BaseWidget.cs
@@ -154,6 +154,28 @@ public abstract class BaseWidget : IWidget
 
     public bool InputTransparent { get; init; }
 
+    /// <summary>
+    /// Event which is called if widget is tapped.
+    /// </summary>
+    public Func<IWidget, WidgetEventArgs, bool> Tapped { get; set; } = (s, e) => false;
+
+    /// <summary>
+    /// Event which is called if widget is pressed.
+    /// </summary>
+    public Func<IWidget, WidgetEventArgs, bool> PointerPressed { get; set; } = (s, e) => false;
+
+    /// <summary>
+    /// Event which is called if widget is moved.
+    /// </summary>
+    public Func<IWidget, WidgetEventArgs, bool> PointerMoved { get; set; } = (s, e) => false;
+
+    /// <summary>
+    /// Event which is called if widget is released.
+    /// </summary>
+    public Func<IWidget, WidgetEventArgs, bool> PointerReleased { get; set; } = (s, e) => false;
+
+
+
     public void UpdateEnvelope(double maxWidth, double maxHeight, double screenWidth, double screenHeight)
     {
         var minX = CalculatePositionX(0, screenWidth, maxWidth);
@@ -170,27 +192,27 @@ public abstract class BaseWidget : IWidget
     }
 
     /// <inheritdoc/>
-    public virtual bool OnTapped(Navigator navigator, WidgetEventArgs e)
+    public virtual bool OnTapped(WidgetEventArgs e)
     {
-        return false;
+        return Tapped(this, e);
     }
 
     /// <inheritdoc/>
-    public virtual bool OnPointerPressed(Navigator navigator, WidgetEventArgs e)
+    public virtual bool OnPointerPressed(WidgetEventArgs e)
     {
-        return false;
+        return PointerPressed(this, e);
     }
 
     /// <inheritdoc/>
-    public virtual bool OnPointerMoved(Navigator navigator, WidgetEventArgs e)
+    public virtual bool OnPointerMoved(WidgetEventArgs e)
     {
-        return false;
+        return PointerMoved(this, e);
     }
 
     /// <inheritdoc/>
-    public virtual bool OnPointerReleased(Navigator navigator, WidgetEventArgs e)
+    public virtual bool OnPointerReleased(WidgetEventArgs e)
     {
-        return false;
+        return PointerReleased(this, e);
     }
 
     private double CalculatePositionX(double left, double right, double width) => HorizontalAlignment switch

--- a/Mapsui/Widgets/ButtonWidgets/ButtonWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/ButtonWidget.cs
@@ -1,23 +1,5 @@
 ﻿using Mapsui.Widgets.BoxWidgets;
-using System;
 
 namespace Mapsui.Widgets.ButtonWidgets;
 
-public class ButtonWidget : TextBoxWidget
-{
-    /// <summary>
-    /// Event which is called if widget is touched
-    /// </summary>
-    public Func<ButtonWidget, WidgetEventArgs, bool> Tapped { get; set; } = (s, e) => false;
-
-    /// <summary>
-    /// Handle touch to Widget
-    /// </summary>
-    /// <param name="navigator">Navigator used by map</param>
-    /// <param name="e">Arguments for widget event</param>
-    /// <returns>True, if touch is handled</returns>
-    public override bool OnTapped(Navigator navigator, WidgetEventArgs e)
-    {
-        return Tapped(this, e);
-    }
-}
+public class ButtonWidget : TextBoxWidget { }

--- a/Mapsui/Widgets/ButtonWidgets/HyperlinkWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/HyperlinkWidget.cs
@@ -25,9 +25,9 @@ public class HyperlinkWidget : ButtonWidget
         }
     }
 
-    public override bool OnTapped(Navigator navigator, WidgetEventArgs e)
+    public override bool OnTapped(WidgetEventArgs e)
     {
-        if (base.OnTapped(navigator, e))
+        if (base.OnTapped(e))
             return true; // The user could override the behavior in the Tapped event.
 
         if (Url is null)

--- a/Mapsui/Widgets/ButtonWidgets/ImageButtonWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/ImageButtonWidget.cs
@@ -1,6 +1,5 @@
 ﻿using Mapsui.Styles;
 using Mapsui.Widgets.BoxWidgets;
-using System;
 
 namespace Mapsui.Widgets.ButtonWidgets;
 
@@ -13,11 +12,6 @@ public class ImageButtonWidget : BoxWidget, IHasImage
     {
         BackColor = Color.Transparent;
     }
-
-    /// <summary>
-    /// Event handler which is called, when the button is touched
-    /// </summary>
-    public Func<ImageButtonWidget, WidgetEventArgs, bool> Tapped = (s, e) => false;
 
     private MRect _padding = new(0);
 
@@ -70,10 +64,5 @@ public class ImageButtonWidget : BoxWidget, IHasImage
             _rotation = value;
             Invalidate();
         }
-    }
-
-    public override bool OnTapped(Navigator navigator, WidgetEventArgs e)
-    {
-        return Tapped(this, e);
     }
 }

--- a/Mapsui/Widgets/ButtonWidgets/ZoomInOutWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/ZoomInOutWidget.cs
@@ -124,11 +124,9 @@ public class ZoomInOutWidget : BaseWidget
         }
     }
 
-    public override bool OnTapped(Navigator navigator, WidgetEventArgs e)
+    public override bool OnTapped(WidgetEventArgs e)
     {
-        var result = base.OnTapped(navigator, e);
-
-        if (result)
+        if (base.OnTapped(e))
             return true;
 
         if (Envelope == null)
@@ -137,11 +135,11 @@ public class ZoomInOutWidget : BaseWidget
         if (Orientation == Orientation.Vertical && e.ScreenPosition.Y < Envelope.MinY + Envelope.Height * 0.5 ||
             Orientation == Orientation.Horizontal && e.ScreenPosition.X < Envelope.MinX + Envelope.Width * 0.5)
         {
-            navigator.ZoomIn(500);
+            e.Map.Navigator.ZoomIn(500);
         }
         else
         {
-            navigator.ZoomOut(500);
+            e.Map.Navigator.ZoomOut(500);
         }
 
         return true;

--- a/Mapsui/Widgets/IWidget.cs
+++ b/Mapsui/Widgets/IWidget.cs
@@ -57,32 +57,28 @@ public interface IWidget
     /// <summary>
     /// Function, which handles the widget tapped event
     /// </summary>
-    /// <param name="navigator">Navigator of MapControl</param>
     /// <param name="e">Arguments for this widget touch</param>
     /// <returns>True, if the Widget had handled the touch event</returns>
-    bool OnTapped(Navigator navigator, WidgetEventArgs e);
+    bool OnTapped(WidgetEventArgs e);
 
     /// <summary>
     /// Function, which handles the widget pointer pressed event
     /// </summary>
-    /// <param name="navigator">Navigator of MapControl</param>
     /// <param name="e">Arguments for this widget touch</param>
     /// <returns>True, if the Widget had handled the touch event</returns>
-    bool OnPointerPressed(Navigator navigator, WidgetEventArgs e);
+    bool OnPointerPressed(WidgetEventArgs e);
 
     /// <summary>
     /// Function, which handles the widget pointer moved event
     /// </summary>
-    /// <param name="navigator">Navigator of MapControl</param>
     /// <param name="e">Arguments for this widget touch</param>
     /// <returns>True, if the Widget had handled the touch event</returns>
-    bool OnPointerMoved(Navigator navigator, WidgetEventArgs e);
+    bool OnPointerMoved(WidgetEventArgs e);
 
     /// <summary>
     /// Function, which handles the widget pointer released event
     /// </summary>
-    /// <param name="navigator">Navigator of MapControl</param>
     /// <param name="e">Arguments for this widget touch</param>
     /// <returns>True, if the Widget had handled the touch event</returns>
-    bool OnPointerReleased(Navigator navigator, WidgetEventArgs e);
+    bool OnPointerReleased(WidgetEventArgs e);
 }

--- a/Mapsui/Widgets/InfoWidgets/MouseCoordinatesWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/MouseCoordinatesWidget.cs
@@ -16,9 +16,9 @@ public class MouseCoordinatesWidget : TextBoxWidget
         Text = "Mouse Position";
     }
 
-    public override bool OnPointerMoved(Navigator navigator, WidgetEventArgs e)
+    public override bool OnPointerMoved(WidgetEventArgs e)
     {
-        var worldPosition = navigator.Viewport.ScreenToWorld(e.ScreenPosition);
+        var worldPosition = e.Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
         // update the Mouse position
         Text = $"{worldPosition.X:F0}, {worldPosition.Y:F0}";
         return false;

--- a/Mapsui/Widgets/InfoWidgets/RulerWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/RulerWidget.cs
@@ -8,10 +8,8 @@ using Mapsui.Manipulations;
 
 namespace Mapsui.Widgets.InfoWidgets;
 
-public class RulerWidget(Map map) : BaseWidget
+public class RulerWidget() : BaseWidget
 {
-    private readonly Map _map = map;
-
     public Color Color { get; set; } = new Color(192, 30, 20, 255);
     public Color ColorOfBeginAndEndDots { get; set; } = new Color(192, 30, 20, 128);
     public MPoint? StartPosition { get; internal set; }
@@ -39,41 +37,41 @@ public class RulerWidget(Map map) : BaseWidget
 
     public event EventHandler<RulerWidgetUpdatedEventArgs>? DistanceUpdated = null;
 
-    public override bool OnPointerPressed(Navigator navigator, WidgetEventArgs e)
+    public override bool OnPointerPressed(WidgetEventArgs e)
     {
         CurrentPosition = null;
-        StartPosition = _map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
-        _map.RefreshGraphics();
+        StartPosition = e.Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
+        e.Map.RefreshGraphics();
         return true;
     }
 
-    public override bool OnPointerMoved(Navigator navigator, WidgetEventArgs e)
+    public override bool OnPointerMoved(WidgetEventArgs e)
     {
         if (e.GestureType == GestureType.Hover)
             return false; // Not dragging.
 
-        CurrentPosition = _map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
+        CurrentPosition = e.Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
         DistanceInKilometers = GetDistance(StartPosition, CurrentPosition);
         DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(GestureType.Drag));
-        _map.RefreshGraphics();
+        e.Map.RefreshGraphics();
         return true;
     }
 
-    public override bool OnPointerReleased(Navigator navigator, WidgetEventArgs e)
+    public override bool OnPointerReleased(WidgetEventArgs e)
     {
         DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(GestureType.Release));
-        _map.RefreshGraphics();
+        e.Map.RefreshGraphics();
         return true;
     }
 
-    public override bool OnTapped(Navigator navigator, WidgetEventArgs e)
+    public override bool OnTapped(WidgetEventArgs e)
     {
         if (e.GestureType == GestureType.SingleTap)
         {
-            StartPosition = _map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
+            StartPosition = e.Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
             CurrentPosition = null;
             DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(GestureType.SingleTap));
-            _map.RefreshGraphics();
+            e.Map.RefreshGraphics();
         }
         return true;
     }

--- a/Mapsui/Widgets/MapTappedWidget.cs
+++ b/Mapsui/Widgets/MapTappedWidget.cs
@@ -13,9 +13,9 @@ public class MapTappedWidget : InputOnlyWidget // Derived from InputOnlyWidget b
         InputAreaType = InputAreaType.Map;
     }
 
-    public override bool OnTapped(Navigator navigator, WidgetEventArgs e)
+    public override bool OnTapped(WidgetEventArgs e)
     {
-        var result = base.OnTapped(navigator, e);
+        var result = base.OnTapped(e);
         if (!result)
         {
             result = _handlerTap(e);

--- a/Mapsui/Widgets/WidgetEventArgs.cs
+++ b/Mapsui/Widgets/WidgetEventArgs.cs
@@ -5,9 +5,9 @@ namespace Mapsui.Widgets;
 /// <summary>
 /// Arguments for a touched event of a widget
 /// </summary>
-public class WidgetEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, Viewport viewport,
+public class WidgetEventArgs(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType, Map map,
     bool shiftPressed, GetMapInfoDelegate getMapInfo, GetRemoteMapInfoAsyncDelegate getRemoteMapInfoAsync)
-    : BaseEventArgs(screenPosition, worldPosition, gestureType, viewport, getMapInfo, getRemoteMapInfoAsync)
+    : BaseEventArgs(screenPosition, worldPosition, gestureType, map, getMapInfo, getRemoteMapInfoAsync)
 {
     /// <summary>
     /// Shift key pressed while touching

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportCenterAndZoomAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportCenterAndZoomAnimationSample.cs
@@ -25,7 +25,7 @@ public class ViewportCenterAndZoomAnimationSample : ISample
         map.Tapped += (m, e) =>
         {
             // Animate to the new center and new resolution
-            m.Navigator.CenterOnAndZoomTo(e.WorldPosition, e.Viewport.Resolution * 0.5, 500, Easing.CubicOut);
+            m.Navigator.CenterOnAndZoomTo(e.WorldPosition, e.Map.Navigator.Viewport.Resolution * 0.5, 500, Easing.CubicOut);
             return true;
         };
         return map;

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportFlyToAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportFlyToAnimationSample.cs
@@ -26,7 +26,7 @@ public class ViewportFlyToAnimationSample : ISample
         map.Tapped += (m, e) =>
         {
             // 'FlyTo' is a specific navigation that moves to a new center while moving in and out.
-            m.Navigator.FlyTo(e.WorldPosition, e.Viewport.Resolution * 1.5, 500);
+            m.Navigator.FlyTo(e.WorldPosition, e.Map.Navigator.Viewport.Resolution * 1.5, 500);
             return true;
         };
         return map;

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportZoomAroundLocationAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportZoomAroundLocationAnimationSample.cs
@@ -29,7 +29,7 @@ public class ViewportZoomAroundLocationAnimationSample : ISample
         {
             // Zoom in while keeping centerOfZoom at the same position. If you click somewhere to zoom in the mouse pointer
             // will still be above the same location in the map. This can be you used for mouse wheel zoom.
-            m.Navigator.ZoomTo(e.Viewport.Resolution * 0.5, e.ScreenPosition!, 500, Easing.CubicOut);
+            m.Navigator.ZoomTo(e.Map.Navigator.Viewport.Resolution * 0.5, e.ScreenPosition!, 500, Easing.CubicOut);
             return true;
         };
         return map;

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
@@ -29,7 +29,8 @@ public class ButtonWidgetSample : ISample
         {
             if (e.GestureType == GestureType.DoubleTap)
                 return false;
-            s.Text = $"Tapped {++_tapCount} times";
+            var button = (ButtonWidget)s;
+            button.Text = $"Tapped {++_tapCount} times";
             map.RefreshGraphics();
             return false;
         }));
@@ -41,7 +42,8 @@ public class ButtonWidgetSample : ISample
         }));
         map.Widgets.Add(CreateButtonWidget("Hello!", VerticalAlignment.Bottom, HorizontalAlignment.Right, (s, e) =>
         {
-            s.Text = $"{s.Text}!";
+            var button = (ButtonWidget)s;
+            button.Text = $"{button.Text}!";
             map.RefreshGraphics();
             return false;
         }));
@@ -49,7 +51,8 @@ public class ButtonWidgetSample : ISample
         {
             if (e.GestureType == GestureType.SingleTap)
                 return false;
-            s.Text = $"Double Tapped {++_doubleTapCount} times";
+            var button = (ButtonWidget)s;
+            button.Text = $"Double Tapped {++_doubleTapCount} times";
             map.RefreshGraphics();
             return false;
         }));
@@ -58,7 +61,7 @@ public class ButtonWidgetSample : ISample
     }
 
     private static ButtonWidget CreateButtonWidget(string text, VerticalAlignment verticalAlignment,
-        HorizontalAlignment horizontalAlignment, Func<ButtonWidget, WidgetEventArgs, bool> tapped) => new()
+        HorizontalAlignment horizontalAlignment, Func<IWidget, WidgetEventArgs, bool> tapped) => new()
         {
             Text = text,
             VerticalAlignment = verticalAlignment,
@@ -72,7 +75,7 @@ public class ButtonWidgetSample : ISample
         };
 
     private static ImageButtonWidget CreateImageButtonWidget(VerticalAlignment verticalAlignment,
-        HorizontalAlignment horizontalAlignment, Func<ImageButtonWidget, WidgetEventArgs, bool> tapped) => new()
+        HorizontalAlignment horizontalAlignment, Func<IWidget, WidgetEventArgs, bool> tapped) => new()
         {
             Image = "embedded://Mapsui.Resources.Images.MyLocationStill.svg",
             VerticalAlignment = verticalAlignment,

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
@@ -49,9 +49,9 @@ public class CustomWidget : BaseWidget
 
     public Color? Color { get; set; }
 
-    public override bool OnTapped(Navigator navigator, WidgetEventArgs e)
+    public override bool OnTapped(WidgetEventArgs e)
     {
-        base.OnTapped(navigator, e);
+        base.OnTapped(e);
 
         if (e.GestureType == GestureType.SingleTap)
             Color = GenerateRandomColor();

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/RulerWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/RulerWidgetSample.cs
@@ -30,7 +30,7 @@ public class RulerWidgetSample : ISample
         };
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Widgets.Add(CreateTextBox("Drag on the map to see the ruler widget in action."));
-        map.Widgets.Add(new RulerWidget(map) { IsActive = true }); // Active on startup. You need to set this value from a button in our own application.
+        map.Widgets.Add(new RulerWidget() { IsActive = true }); // Active on startup. You need to set this value from a button in our own application.
         return map;
     }
 


### PR DESCRIPTION
Done:
- Replace the Viewport with the Map in the EventArgs.
- Remove the Navigator parameter because now the EventArgs.Map can be used.
- Add all four events to the BaseWidget, so that all widgets now have all events. 
- Inherit the EventArgs from HandledEventArgs (to use it in a later PR).

Future:
- Turn the `Action<IWidget, WidgetEventsArgs, bool>` into a actual `event` type and don't return a bool. 