### PR TITLE
Turn map and widget pointer actions into events

### DIFF
--- a/.github/workflows/dotnet-docs.yml
+++ b/.github/workflows/dotnet-docs.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
          dotnet-version: |
-           9.0.x
+           9.0.200
     - name: install workloads
       run: dotnet workload install maui macos android ios maccatalyst wasm-tools wasm-tools-net8 
     - name: Run DocFx

--- a/.github/workflows/dotnet-release-nugets.yml
+++ b/.github/workflows/dotnet-release-nugets.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        filter: tree:0    
+        filter: tree:0
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
@@ -29,12 +29,11 @@ jobs:
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v2
 
-    # .Net 9 update     
     - name: Setup .NET 9 SDK
       uses: actions/setup-dotnet@v4
       with:
          dotnet-version: |
-           9.0.x         
+           9.0.200         
 
     # The version tag needs to be set before the release. If not if will fail on nuget publish.
     - name: Set VERSION_OF_RELEASE to last tag

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,7 +56,7 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
          dotnet-version: |
-           9.0.x     
+           9.0.200     
     # Open JDK
     - name: Install Open JDK 11
       uses: actions/setup-java@v4
@@ -124,7 +124,7 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
          dotnet-version: |
-           9.0.x
+           9.0.200
     - name: install workloads maui macos android ios maccatalyst wasm-tools wasm-tools-net8
       run: dotnet workload install maui macos android ios maccatalyst wasm-tools wasm-tools-net8
     - name: install Uno.Check 1.26.1
@@ -195,7 +195,7 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
          dotnet-version: |
-           9.0.x         
+           9.0.200         
     # Java Sdk install 11
     - name: Install Open JDK 11
       uses: actions/setup-java@v4

--- a/Mapsui.Nts/Widgets/EditingWidget.cs
+++ b/Mapsui.Nts/Widgets/EditingWidget.cs
@@ -13,15 +13,15 @@ public class EditingWidget : InputOnlyWidget // Derived from InputOnlyWidget bec
         InputAreaType = InputAreaType.Map;
     }
 
-    public override bool OnPointerPressed(WidgetEventArgs e)
-        => EditManipulation.OnPointerPressed(e, _editManager);
+    public override void OnPointerPressed(WidgetEventArgs e) =>
+        e.Handled = EditManipulation.OnPointerPressed(e, _editManager);
 
-    public override bool OnPointerMoved(WidgetEventArgs e) =>
-        EditManipulation.OnPointerMoved(e, _editManager);
+    public override void OnPointerMoved(WidgetEventArgs e) =>
+        e.Handled = EditManipulation.OnPointerMoved(e, _editManager);
 
-    public override bool OnPointerReleased(WidgetEventArgs e) =>
-        EditManipulation.OnPointerReleased(_editManager);
+    public override void OnPointerReleased(WidgetEventArgs e) =>
+        e.Handled = EditManipulation.OnPointerReleased(_editManager);
 
-    public override bool OnTapped(WidgetEventArgs e) =>
-        EditManipulation.OnTapped(e, _editManager);
+    public override void OnTapped(WidgetEventArgs e) =>
+        e.Handled = EditManipulation.OnTapped(e, _editManager);
 }

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -781,19 +781,19 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
     private void CreateButtons()
     {
-        _mapZoomInButton ??= CreateButton(0, 0, "embedded://Mapsui.UI.Maui.Images.ZoomIn.svg", (s, e) => { Map.Navigator.ZoomIn(); return true; });
+        _mapZoomInButton ??= CreateButton(0, 0, "embedded://Mapsui.UI.Maui.Images.ZoomIn.svg", (s, e) => { Map.Navigator.ZoomIn(); e.Handled = true; });
         _mapZoomInButton.Enabled = IsZoomButtonVisible;
         Map!.Widgets.Add(_mapZoomInButton);
 
-        _mapZoomOutButton ??= CreateButton(0, 40, "embedded://Mapsui.UI.Maui.Images.ZoomOut.svg", (s, e) => { Map.Navigator.ZoomOut(); return true; });
+        _mapZoomOutButton ??= CreateButton(0, 40, "embedded://Mapsui.UI.Maui.Images.ZoomOut.svg", (s, e) => { Map.Navigator.ZoomOut(); e.Handled = true; });
         _mapZoomOutButton.Enabled = IsZoomButtonVisible;
         Map!.Widgets.Add(_mapZoomOutButton);
 
-        _mapMyLocationButton ??= CreateButton(0, 88, "embedded://Mapsui.UI.Maui.Images.LocationCenter.svg", (s, e) => { MyLocationFollow = true; return true; });
+        _mapMyLocationButton ??= CreateButton(0, 88, "embedded://Mapsui.UI.Maui.Images.LocationCenter.svg", (s, e) => { MyLocationFollow = true; e.Handled = true; });
         _mapMyLocationButton.Enabled = IsMyLocationButtonVisible;
         Map!.Widgets.Add(_mapMyLocationButton);
 
-        _mapNorthingButton ??= CreateButton(0, 136, "embedded://Mapsui.UI.Maui.Images.RotationZero.svg", (s, e) => { RunOnUIThread(() => Map.Navigator.RotateTo(0)); return true; });
+        _mapNorthingButton ??= CreateButton(0, 136, "embedded://Mapsui.UI.Maui.Images.RotationZero.svg", (s, e) => { RunOnUIThread(() => { Map.Navigator.RotateTo(0); e.Handled = true; }); });
         _mapNorthingButton.Enabled = IsNorthingButtonVisible;
         Map!.Widgets.Add(_mapNorthingButton);
 
@@ -801,7 +801,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
     }
 
     private ImageButtonWidget CreateButton(
-        float x, float y, string imageSource, Func<IWidget, WidgetEventArgs, bool> tapped) => new()
+        float x, float y, string imageSource, EventHandler<WidgetEventArgs> tapped) => new()
         {
             Image = imageSource,
             HorizontalAlignment = Widgets.HorizontalAlignment.Absolute,
@@ -811,7 +811,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             Height = ButtonSize,
             Rotation = 0,
             Enabled = true,
-            Tapped = tapped
+            WithTappedEvent = tapped
         };
 
     protected override void Dispose(bool disposing)

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -650,10 +650,10 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             if (!handled)
             {
                 // if nothing else was hit, then we hit the map
-                var args = new MapClickedEventArgs(worldPosition.ToNative(), e.GestureType);
-                MapClicked?.Invoke(this, args);
+                var eventArgs = new MapClickedEventArgs(worldPosition.ToNative(), e.GestureType);
+                MapClicked?.Invoke(this, eventArgs);
 
-                if (args.Handled)
+                if (e.Handled)
                 {
                     handled = true;
                     return handled;

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -591,7 +591,8 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
         {
             Logger.Log(LogLevel.Information, $"Widget.PointerPressed: {widget.GetType().Name}");
-            if (widget.OnPointerPressed(eventArgs))
+            widget.OnPointerPressed(eventArgs);
+            if (eventArgs.Handled)
                 return true;
         }
         return false;
@@ -602,8 +603,11 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         var eventArgs = new WidgetEventArgs(screenPosition, worldPosition, gestureType, Map, shiftPressed, GetMapInfo, GetRemoteMapInfoAsync);
 
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
-            if (widget.OnPointerMoved(eventArgs))
+        {
+            widget.OnPointerMoved(eventArgs);
+            if (eventArgs.Handled)
                 return true;
+        }
         return false;
     }
 
@@ -614,7 +618,8 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         foreach (var widget in WidgetInput.GetWidgetsAtPosition(screenPosition, Map))
         {
             Logger.Log(LogLevel.Information, $"Widget.Released: {widget.GetType().Name}");
-            if (widget.OnPointerReleased(eventArgs))
+            widget.OnPointerReleased(eventArgs);
+            if (eventArgs.Handled)
                 return true;
         }
         return false;
@@ -628,10 +633,10 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         foreach (var widget in touchedWidgets)
         {
             Logger.Log(LogLevel.Information, $"Widget.Tapped: {widget.GetType().Name} {nameof(GestureType)}: {gestureType} KeyState: {shiftPressed}");
-            if (widget.OnTapped(eventArgs))
+            widget.OnTapped(eventArgs);
+            if (eventArgs.Handled)
                 return true;
         }
-
         return false;
     }
 

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -709,14 +709,20 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         if (Logger.LoggerSettings.LogMapEvents)
             Logger.Log(LogLevel.Information, $"Map.PointerPressed");
 
-        return Map.OnPointerPressed(new MapEventArgs(screenPosition, worldPosition, GestureType.Press,
-            Map, GetMapInfo, GetRemoteMapInfoAsync));
+        var eventArgs = new MapEventArgs(screenPosition, worldPosition, GestureType.Press, Map, GetMapInfo, 
+            GetRemoteMapInfoAsync);
+        Map.OnPointerPressed(eventArgs);
+
+        return eventArgs.Handled;
     }
 
     private bool OnMapPointerMoved(ScreenPosition screenPosition, MPoint worldPosition, GestureType gestureType)
     {
-        return Map.OnPointerMoved(new MapEventArgs(screenPosition, worldPosition, gestureType, 
-            Map, GetMapInfo, GetRemoteMapInfoAsync));
+        var eventArgs = new MapEventArgs(screenPosition, worldPosition, gestureType,
+            Map, GetMapInfo, GetRemoteMapInfoAsync);
+        Map.OnPointerMoved(eventArgs);
+
+        return eventArgs.Handled;
     }
 
     private bool OnMapPointerReleased(ScreenPosition screenPosition, MPoint worldPosition)
@@ -724,16 +730,23 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         if (Logger.LoggerSettings.LogMapEvents)
             Logger.Log(LogLevel.Information, $"Map.PointerReleased");
 
-        return Map.OnPointerReleased(new MapEventArgs(screenPosition, worldPosition, GestureType.Release, 
-            Map, GetMapInfo, GetRemoteMapInfoAsync));
+        var eventArgs = new MapEventArgs(screenPosition, worldPosition, GestureType.Release, Map, GetMapInfo, 
+            GetRemoteMapInfoAsync);
+        Map.OnPointerReleased(eventArgs);
+
+        return eventArgs.Handled;
     }
 
     private bool OnMapTapped(ScreenPosition screenPosition, GestureType gestureType, MPoint worldPosition)
     {
         if (Logger.LoggerSettings.LogMapEvents)
             Logger.Log(LogLevel.Information, $"Map.Tapped. {nameof(GestureType)}: {gestureType}");
-        return Map.OnTapped(new MapEventArgs(screenPosition, worldPosition, gestureType, 
-            Map, GetMapInfo, GetRemoteMapInfoAsync));
+
+        var eventArgs = new MapEventArgs(screenPosition, worldPosition, gestureType, Map, GetMapInfo, 
+            GetRemoteMapInfoAsync);
+        Map.OnTapped(eventArgs);
+
+        return eventArgs.Handled;
     }
 
     private bool HasSize() => ViewportWidth > 0 && ViewportHeight > 0;

--- a/Mapsui.UI.WinUI/MapControl.cs
+++ b/Mapsui.UI.WinUI/MapControl.cs
@@ -87,7 +87,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
         var orientationSensor = SimpleOrientationSensor.GetDefault();
         if (orientationSensor != null)
-            orientationSensor.OrientationChanged += (sender, args) => RunOnUIThread(() => Refresh());
+            orientationSensor.OrientationChanged += (s, e) => RunOnUIThread(() => Refresh());
     }
 
     private void MapControl_KeyUp(object sender, KeyRoutedEventArgs e)

--- a/Mapsui/Extensions/ConcurrentQueueExtensions.cs
+++ b/Mapsui/Extensions/ConcurrentQueueExtensions.cs
@@ -7,9 +7,10 @@ public static class ConcurrentQueueExtensions
 {
     // This method was added to make the api more compatible with the previous 
     // List based Widgets library
-    public static void Add<T>(this ConcurrentQueue<T> queue, T item)
+    public static T Add<T>(this ConcurrentQueue<T> queue, T item)
     {
         queue.Enqueue(item);
+        return item;
     }
 
     public static void Clear<T>(this ConcurrentQueue<T> queue)

--- a/Mapsui/Layers/BaseLayer.cs
+++ b/Mapsui/Layers/BaseLayer.cs
@@ -211,9 +211,9 @@ public abstract class BaseLayer : ILayer
         _eventMangerPropertyChanged?.RaiseEvent(this, new PropertyChangedEventArgs(name));
     }
 
-    protected void OnDataChanged(DataChangedEventArgs args)
+    protected void OnDataChanged(DataChangedEventArgs e)
     {
-        DataChanged?.Invoke(this, args);
+        DataChanged?.Invoke(this, e);
     }
 
     protected virtual void Dispose(bool disposing)

--- a/Mapsui/Layers/MyLocationLayer.cs
+++ b/Mapsui/Layers/MyLocationLayer.cs
@@ -497,14 +497,13 @@ public class MyLocationLayer : BaseLayer, IDisposable
         return modified;
     }
 
-    private bool MapTapped(Map map, MapEventArgs e)
+    private void MapTapped(object? s, MapEventArgs e)
     {
         var mapInfo = e.GetMapInfo([this]);
         if (mapInfo.Feature != null && mapInfo.Feature.Equals(_feature))
         {
             Tapped?.Invoke(this, e);
-            return true;
+            e.Handled = true;
         }
-        return false;
     }
 }

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -45,19 +45,19 @@ public class Map : INotifyPropertyChanged, IDisposable
     /// <summary>
     /// Event that is triggered when the map is tapped. Can be a single tap, double tap or long press.
     /// </summary>
-    public Func<Map, MapEventArgs, bool> Tapped { get; set; } = (s, e) => false;
+    public event EventHandler<MapEventArgs>? Tapped;
     /// <summary>
     /// Event that is triggered when on pointer down.
     /// </summary>
-    public Func<Map, MapEventArgs, bool> PointerPressed { get; set; } = (s, e) => false;
+    public event EventHandler<MapEventArgs>? PointerPressed;
     /// <summary>
     /// Event that is triggered when on pointer move. Can be a drag or hover.
     /// </summary>
-    public Func<Map, MapEventArgs, bool> PointerMoved { get; set; } = (s, e) => false;
+    public event EventHandler<MapEventArgs>? PointerMoved;
     /// <summary>
     /// Event that is triggered when on pointer up.
     /// </summary>
-    public Func<Map, MapEventArgs, bool> PointerReleased { get; set; } = (s, e) => false;
+    public event EventHandler<MapEventArgs>? PointerReleased;
 
     private void Navigator_ViewportChanged(object? sender, ViewportChangedEventArgs e)
     {
@@ -262,27 +262,27 @@ public class Map : INotifyPropertyChanged, IDisposable
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual bool OnTapped(MapEventArgs e)
+    public virtual void OnTapped(MapEventArgs e)
     {
-        return Tapped(this, e);
+        Tapped?.Invoke(this, e);
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual bool OnPointerPressed(MapEventArgs e)
+    public virtual void OnPointerPressed(MapEventArgs e)
     {
-        return PointerPressed(this, e);
+        PointerPressed?.Invoke(this, e);
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual bool OnPointerMoved(MapEventArgs e)
+    public virtual void OnPointerMoved(MapEventArgs e)
     {
-        return PointerMoved(this, e);
+        PointerMoved?.Invoke(this, e);
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual bool OnPointerReleased(MapEventArgs e)
+    public virtual void OnPointerReleased(MapEventArgs e)
     {
-        return PointerReleased(this, e);
+        PointerReleased?.Invoke(this, e);
     }
 
     private void LayersCollectionChanged(object sender, LayerCollectionChangedEventArgs args)

--- a/Mapsui/UI/DataChangedWeakEventManager.cs
+++ b/Mapsui/UI/DataChangedWeakEventManager.cs
@@ -7,7 +7,7 @@ namespace Mapsui.UI;
 // Custom event manager for demonstration purposes
 public class DataChangedWeakEventManager : MWeakEventManager
 {
-    public void RaiseEvent(object source, DataChangedEventArgs args)
+    public void RaiseEvent(object source, DataChangedEventArgs e)
     {
         if (EventHandlers.TryGetValue(source, out var handlers))
         {
@@ -16,7 +16,7 @@ public class DataChangedWeakEventManager : MWeakEventManager
             {
                 if (weakRef is { IsAlive: true, Target: DataChangedEventHandler handler })
                 {
-                    handler(source, args);
+                    handler(source, e);
                 }
                 else
                 {

--- a/Mapsui/UI/PropertyChangedWeakEventManager.cs
+++ b/Mapsui/UI/PropertyChangedWeakEventManager.cs
@@ -7,12 +7,12 @@ namespace Mapsui.UI;
 // Custom event manager for demonstration purposes
 public class PropertyChangedWeakEventManager : MWeakEventManager
 {
-    public void RaiseEvent(object source, PropertyChangedEventArgs args)
+    public void RaiseEvent(object source, PropertyChangedEventArgs e)
     {
-        RaiseEvent(source, source, args);
+        RaiseEvent(source, source, e);
     }
 
-    public void RaiseEvent(object source, object? sender, PropertyChangedEventArgs args)
+    public void RaiseEvent(object source, object? sender, PropertyChangedEventArgs e)
     {
         if (EventHandlers.TryGetValue(source, out var handlers))
         {
@@ -21,7 +21,7 @@ public class PropertyChangedWeakEventManager : MWeakEventManager
             {
                 if (weakRef is { IsAlive: true, Target: PropertyChangedEventHandler handler })
                 {
-                    handler(sender, args);
+                    handler(sender, e);
                 }
                 else
                 {

--- a/Mapsui/Widgets/BaseWidget.cs
+++ b/Mapsui/Widgets/BaseWidget.cs
@@ -155,26 +155,44 @@ public abstract class BaseWidget : IWidget
     public bool InputTransparent { get; init; }
 
     /// <summary>
+    /// This is an init only property to allow Tapped event initialization within an expression body method.
+    /// </summary>
+    public EventHandler<WidgetEventArgs>? WithTappedEvent { init { Tapped += value; } }
+
+    /// <summary>
+    /// This is an init only property to allow PointerPressed event initialization within an expression body method.
+    /// </summary>
+    public EventHandler<WidgetEventArgs>? WithPointerPressedEvent { init { PointerPressed += value; } }
+
+    /// <summary>
+    /// This is an init only property to allow PointerMoved event initialization within an expression body method.
+    /// </summary>
+    public EventHandler<WidgetEventArgs>? WithPointerMovedEvent { init { PointerMoved += value; } }
+
+    /// <summary>
+    /// This is an init only property to allow PointerReleased event initialization within an expression body method.
+    /// </summary>
+    public EventHandler<WidgetEventArgs>? WithPointerReleased { init { PointerReleased += value; } }
+
+    /// <summary>
     /// Event which is called if widget is tapped.
     /// </summary>
-    public Func<IWidget, WidgetEventArgs, bool> Tapped { get; set; } = (s, e) => false;
+    public event EventHandler<WidgetEventArgs>? Tapped;
 
     /// <summary>
     /// Event which is called if widget is pressed.
     /// </summary>
-    public Func<IWidget, WidgetEventArgs, bool> PointerPressed { get; set; } = (s, e) => false;
+    public event EventHandler<WidgetEventArgs>? PointerPressed;
 
     /// <summary>
     /// Event which is called if widget is moved.
     /// </summary>
-    public Func<IWidget, WidgetEventArgs, bool> PointerMoved { get; set; } = (s, e) => false;
+    public event EventHandler<WidgetEventArgs>? PointerMoved;
 
     /// <summary>
     /// Event which is called if widget is released.
     /// </summary>
-    public Func<IWidget, WidgetEventArgs, bool> PointerReleased { get; set; } = (s, e) => false;
-
-
+    public event EventHandler<WidgetEventArgs>? PointerReleased;
 
     public void UpdateEnvelope(double maxWidth, double maxHeight, double screenWidth, double screenHeight)
     {
@@ -192,27 +210,27 @@ public abstract class BaseWidget : IWidget
     }
 
     /// <inheritdoc/>
-    public virtual bool OnTapped(WidgetEventArgs e)
+    public virtual void OnTapped(WidgetEventArgs e)
     {
-        return Tapped(this, e);
+        Tapped?.Invoke(this, e);
     }
 
     /// <inheritdoc/>
-    public virtual bool OnPointerPressed(WidgetEventArgs e)
+    public virtual void OnPointerPressed(WidgetEventArgs e)
     {
-        return PointerPressed(this, e);
+        PointerPressed?.Invoke(this, e);
     }
 
     /// <inheritdoc/>
-    public virtual bool OnPointerMoved(WidgetEventArgs e)
+    public virtual void OnPointerMoved(WidgetEventArgs e)
     {
-        return PointerMoved(this, e);
+        PointerMoved?.Invoke(this, e);
     }
 
     /// <inheritdoc/>
-    public virtual bool OnPointerReleased(WidgetEventArgs e)
+    public virtual void OnPointerReleased(WidgetEventArgs e)
     {
-        return PointerReleased(this, e);
+        PointerReleased?.Invoke(this, e);
     }
 
     private double CalculatePositionX(double left, double right, double width) => HorizontalAlignment switch

--- a/Mapsui/Widgets/ButtonWidgets/HyperlinkWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/HyperlinkWidget.cs
@@ -25,18 +25,20 @@ public class HyperlinkWidget : ButtonWidget
         }
     }
 
-    public override bool OnTapped(WidgetEventArgs e)
+    public override void OnTapped(WidgetEventArgs e)
     {
-        if (base.OnTapped(e))
-            return true; // The user could override the behavior in the Tapped event.
+        base.OnTapped(e);
+        if (e.Handled)
+            return;
 
         if (Url is null)
         {
             Logger.Log(LogLevel.Warning, "HyperlinkWidget: URL is not set");
-            return true;
+            e.Handled = true;
+            return;
         }
 
         PlatformUtilities.OpenInBrowser(Url);
-        return true;
+        e.Handled = true;
     }
 }

--- a/Mapsui/Widgets/ButtonWidgets/ZoomInOutWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/ZoomInOutWidget.cs
@@ -124,13 +124,14 @@ public class ZoomInOutWidget : BaseWidget
         }
     }
 
-    public override bool OnTapped(WidgetEventArgs e)
+    public override void OnTapped(WidgetEventArgs e)
     {
-        if (base.OnTapped(e))
-            return true;
+        base.OnTapped(e);
+        if (e.Handled)
+            return;
 
         if (Envelope == null)
-            return false;
+            return;
 
         if (Orientation == Orientation.Vertical && e.ScreenPosition.Y < Envelope.MinY + Envelope.Height * 0.5 ||
             Orientation == Orientation.Horizontal && e.ScreenPosition.X < Envelope.MinX + Envelope.Width * 0.5)
@@ -142,6 +143,7 @@ public class ZoomInOutWidget : BaseWidget
             e.Map.Navigator.ZoomOut(500);
         }
 
-        return true;
+        e.Handled = true;
+        return;
     }
 }

--- a/Mapsui/Widgets/IWidget.cs
+++ b/Mapsui/Widgets/IWidget.cs
@@ -1,4 +1,6 @@
-﻿namespace Mapsui.Widgets;
+﻿using System;
+
+namespace Mapsui.Widgets;
 
 public interface IWidget
 {
@@ -55,30 +57,50 @@ public interface IWidget
     bool InputTransparent { get; init; }
 
     /// <summary>
+    /// Event which is called if widget is tapped.
+    /// </summary>
+    event EventHandler<WidgetEventArgs>? Tapped;
+
+    /// <summary>
+    /// Event which is called if widget is pressed.
+    /// </summary>
+    event EventHandler<WidgetEventArgs>? PointerPressed;
+
+    /// <summary>
+    /// Event which is called if widget is moved.
+    /// </summary>
+    event EventHandler<WidgetEventArgs>? PointerMoved;
+
+    /// <summary>
+    /// Event which is called if widget is released.
+    /// </summary>
+    event EventHandler<WidgetEventArgs>? PointerReleased;
+
+    /// <summary>
     /// Function, which handles the widget tapped event
     /// </summary>
     /// <param name="e">Arguments for this widget touch</param>
     /// <returns>True, if the Widget had handled the touch event</returns>
-    bool OnTapped(WidgetEventArgs e);
+    void OnTapped(WidgetEventArgs e);
 
     /// <summary>
     /// Function, which handles the widget pointer pressed event
     /// </summary>
     /// <param name="e">Arguments for this widget touch</param>
     /// <returns>True, if the Widget had handled the touch event</returns>
-    bool OnPointerPressed(WidgetEventArgs e);
+    void OnPointerPressed(WidgetEventArgs e);
 
     /// <summary>
     /// Function, which handles the widget pointer moved event
     /// </summary>
     /// <param name="e">Arguments for this widget touch</param>
     /// <returns>True, if the Widget had handled the touch event</returns>
-    bool OnPointerMoved(WidgetEventArgs e);
+    void OnPointerMoved(WidgetEventArgs e);
 
     /// <summary>
     /// Function, which handles the widget pointer released event
     /// </summary>
     /// <param name="e">Arguments for this widget touch</param>
     /// <returns>True, if the Widget had handled the touch event</returns>
-    bool OnPointerReleased(WidgetEventArgs e);
+    void OnPointerReleased(WidgetEventArgs e);
 }

--- a/Mapsui/Widgets/InfoWidgets/MapInfoWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/MapInfoWidget.cs
@@ -56,7 +56,7 @@ public class MapInfoWidget : TextBoxWidget
         TextColor = Color.White;
     }
 
-    private bool MapTapped(Map map, MapEventArgs e)
+    private void MapTapped(object? s, MapEventArgs e)
     {
         var mapInfo = e.GetMapInfo(_layers());
         Text = FeatureToText(mapInfo.Feature);
@@ -72,7 +72,6 @@ public class MapInfoWidget : TextBoxWidget
                 _map.RefreshGraphics();
             }
         });
-        return false;
     }
 
     public Func<IFeature?, string> FeatureToText { get; set; } = (f) =>

--- a/Mapsui/Widgets/InfoWidgets/MouseCoordinatesWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/MouseCoordinatesWidget.cs
@@ -16,11 +16,10 @@ public class MouseCoordinatesWidget : TextBoxWidget
         Text = "Mouse Position";
     }
 
-    public override bool OnPointerMoved(WidgetEventArgs e)
+    public override void OnPointerMoved(WidgetEventArgs e)
     {
         var worldPosition = e.Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
         // update the Mouse position
         Text = $"{worldPosition.X:F0}, {worldPosition.Y:F0}";
-        return false;
     }
 }

--- a/Mapsui/Widgets/InfoWidgets/RulerWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/RulerWidget.cs
@@ -37,34 +37,37 @@ public class RulerWidget() : BaseWidget
 
     public event EventHandler<RulerWidgetUpdatedEventArgs>? DistanceUpdated = null;
 
-    public override bool OnPointerPressed(WidgetEventArgs e)
+    public override void OnPointerPressed(WidgetEventArgs e)
     {
         CurrentPosition = null;
         StartPosition = e.Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
         e.Map.RefreshGraphics();
-        return true;
+        e.Handled = true;
+        return;
     }
 
-    public override bool OnPointerMoved(WidgetEventArgs e)
+    public override void OnPointerMoved(WidgetEventArgs e)
     {
         if (e.GestureType == GestureType.Hover)
-            return false; // Not dragging.
+            return; // Not dragging.
 
         CurrentPosition = e.Map.Navigator.Viewport.ScreenToWorld(e.ScreenPosition);
         DistanceInKilometers = GetDistance(StartPosition, CurrentPosition);
         DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(GestureType.Drag));
         e.Map.RefreshGraphics();
-        return true;
+        e.Handled = true;
+        return;
     }
 
-    public override bool OnPointerReleased(WidgetEventArgs e)
+    public override void OnPointerReleased(WidgetEventArgs e)
     {
         DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(GestureType.Release));
         e.Map.RefreshGraphics();
-        return true;
+        e.Handled = true;
+        return;
     }
 
-    public override bool OnTapped(WidgetEventArgs e)
+    public override void OnTapped(WidgetEventArgs e)
     {
         if (e.GestureType == GestureType.SingleTap)
         {
@@ -73,7 +76,8 @@ public class RulerWidget() : BaseWidget
             DistanceUpdated?.Invoke(this, new RulerWidgetUpdatedEventArgs(GestureType.SingleTap));
             e.Map.RefreshGraphics();
         }
-        return true;
+        e.Handled = true;
+        return;
     }
 
     public void Reset()

--- a/Mapsui/Widgets/MapTappedWidget.cs
+++ b/Mapsui/Widgets/MapTappedWidget.cs
@@ -13,14 +13,12 @@ public class MapTappedWidget : InputOnlyWidget // Derived from InputOnlyWidget b
         InputAreaType = InputAreaType.Map;
     }
 
-    public override bool OnTapped(WidgetEventArgs e)
+    public override void OnTapped(WidgetEventArgs e)
     {
-        var result = base.OnTapped(e);
-        if (!result)
-        {
-            result = _handlerTap(e);
-        }
+        base.OnTapped(e);
+        if (e.Handled)
+            return;
 
-        return result;
+        _handlerTap(e);
     }
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportCenterAndZoomAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportCenterAndZoomAnimationSample.cs
@@ -22,11 +22,11 @@ public class ViewportCenterAndZoomAnimationSample : ISample
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Widgets.Add(new ZoomInOutWidget { Margin = new MRect(20, 40) });
         map.Widgets.Add(CreateTextBox("Tap on the map to center on that location and zoom in on it"));
-        map.Tapped += (m, e) =>
+        map.Tapped += (s, e) =>
         {
             // Animate to the new center and new resolution
-            m.Navigator.CenterOnAndZoomTo(e.WorldPosition, e.Map.Navigator.Viewport.Resolution * 0.5, 500, Easing.CubicOut);
-            return true;
+            e.Map.Navigator.CenterOnAndZoomTo(e.WorldPosition, e.Map.Navigator.Viewport.Resolution * 0.5, 500, Easing.CubicOut);
+            e.Handled = true;
         };
         return map;
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportCenterOnAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportCenterOnAnimationSample.cs
@@ -24,11 +24,11 @@ public class ViewportCenterOnAnimationSample : ISample
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Widgets.Add(new ZoomInOutWidget { Margin = new MRect(20, 40) });
         map.Widgets.Add(CreateTextBox("Tap on the map to center on that location"));
-        map.Tapped += (m, e) =>
+        map.Tapped += (s, e) =>
         {
             // Animate to the new center.
-            m.Navigator.CenterOn(e.WorldPosition, 500, Easing.CubicOut);
-            return true;
+            e.Map.Navigator.CenterOn(e.WorldPosition, 500, Easing.CubicOut);
+            e.Handled = true;
         };
         return map;
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportFlyToAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportFlyToAnimationSample.cs
@@ -23,11 +23,11 @@ public class ViewportFlyToAnimationSample : ISample
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Widgets.Add(new ZoomInOutWidget { Margin = new MRect(20, 40) });
         map.Widgets.Add(CreateTextBox("Tap on the map to fly to that location. The fly-to animation zooms out and then in."));
-        map.Tapped += (m, e) =>
+        map.Tapped += (s, e) =>
         {
             // 'FlyTo' is a specific navigation that moves to a new center while moving in and out.
-            m.Navigator.FlyTo(e.WorldPosition, e.Map.Navigator.Viewport.Resolution * 1.5, 500);
-            return true;
+            e.Map.Navigator.FlyTo(e.WorldPosition, e.Map.Navigator.Viewport.Resolution * 1.5, 500);
+            e.Handled = true;
         };
         return map;
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportRotateAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportRotateAnimationSample.cs
@@ -23,18 +23,16 @@ public class ViewportRotateAnimationSample : ISample
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
 
         var rotateButton = CreateButton("Click to rotate clockwise", VerticalAlignment.Top);
-        rotateButton.Tapped = (s, e) =>
+        rotateButton.Tapped += (s, e) =>
         {
             map.Navigator.RotateTo(map.Navigator.Viewport.Rotation + 45, 500, Easing.CubicIn);
-            return false;
         };
         map.Widgets.Add(rotateButton);
 
         var rotateBackButton = CreateButton("Click to rotate counterclockwise", VerticalAlignment.Bottom);
-        rotateBackButton.Tapped = (s, e) =>
+        rotateBackButton.Tapped += (s, e) =>
         {
             map.Navigator.RotateTo(map.Navigator.Viewport.Rotation - 45, 500, Easing.CubicIn);
-            return false;
         };
         map.Widgets.Add(rotateBackButton);
 

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportZoomAroundLocationAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportZoomAroundLocationAnimationSample.cs
@@ -29,8 +29,8 @@ public class ViewportZoomAroundLocationAnimationSample : ISample
         {
             // Zoom in while keeping centerOfZoom at the same position. If you click somewhere to zoom in the mouse pointer
             // will still be above the same location in the map. This can be you used for mouse wheel zoom.
-            m.Navigator.ZoomTo(e.Map.Navigator.Viewport.Resolution * 0.5, e.ScreenPosition!, 500, Easing.CubicOut);
-            return true;
+            e.Map.Navigator.ZoomTo(e.Map.Navigator.Viewport.Resolution * 0.5, e.ScreenPosition!, 500, Easing.CubicOut);
+            e.Handled = true;
         };
         return map;
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportZoomToResolutionAnimationSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Animations/ViewportZoomToResolutionAnimationSample.cs
@@ -27,18 +27,16 @@ public class ViewportZoomToResolutionAnimationSample : ISample
         map.Widgets.Add(new ZoomInOutWidget { Margin = new MRect(20, 40) });
 
         var rotateButton = CreateButton("Zoom in", VerticalAlignment.Top);
-        rotateButton.Tapped = (s, e) =>
+        rotateButton.Tapped += (s, e) =>
         {
             map.Navigator.ZoomTo(map.Navigator.Viewport.Resolution * 0.5, 500, Easing.CubicOut);
-            return false;
         };
         map.Widgets.Add(rotateButton);
 
         var rotateBackButton = CreateButton("Zoom out", VerticalAlignment.Bottom);
-        rotateBackButton.Tapped = (s, e) =>
+        rotateBackButton.Tapped += (s, e) =>
         {
             map.Navigator.ZoomTo(map.Navigator.Viewport.Resolution * 2, 500, Easing.CubicOut);
-            return false;
         };
         map.Widgets.Add(rotateBackButton);
 

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSvgStyleSample.cs
@@ -26,11 +26,11 @@ public class DynamicSvgStyleSample : ISample
         var map = new Map();
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Layers.Add(CreateLayerWithDynamicSvgStyle(() => tapPosition, map)); // Use 'closure capture' to keep a reference to the tapPosition.
-        map.Tapped += (m, e) =>
+        map.Tapped += (s, e) =>
         {
             tapPosition = e.WorldPosition; // Assign a new tap position to modify the dynamic style.
-            m.Layers.First().DataHasChanged(); // Notify that the map needs to be redraw.
-            return true;
+            e.Map.Layers.First().DataHasChanged(); // Notify that the map needs to be redraw.
+            e.Handled = true;
         };
         return Task.FromResult(map);
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/WriteToLayerSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/WriteToLayerSample.cs
@@ -26,7 +26,7 @@ public class WriteToLayerSample : ISample
         map.Layers.Add(CreateGenericCollectionLayer());
         map.Tapped += (m, e) =>
         {
-            var layer = (GenericCollectionLayer<List<IFeature>>)m.Layers.First(l => l.Name == "GenericCollectionLayer");
+            var layer = (GenericCollectionLayer<List<IFeature>>)e.Map.Layers.First(l => l.Name == "GenericCollectionLayer");
             // Add a point to the layer using the Info position
             layer?.Features.Add(new GeometryFeature
             {
@@ -34,7 +34,7 @@ public class WriteToLayerSample : ISample
             });
             // To notify the map that a redraw is needed.
             layer?.DataHasChanged();
-            return true;
+            e.Handled = true;
         };
         return map;
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Editing/EditingSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Editing/EditingSample.cs
@@ -111,7 +111,7 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Delete",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             if (_editManager.SelectMode)
             {
@@ -120,8 +120,7 @@ public class EditingSample : IMapControlSample
                     _editManager.Layer?.TryRemove(selectedFeature);
                 _mapControl?.RefreshGraphics();
             }
-
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -135,10 +134,10 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Select (for delete)",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             _editManager.SelectMode = !_editManager.SelectMode;
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -152,10 +151,10 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "None",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             _editManager.EditMode = EditMode.None;
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -169,10 +168,10 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Scale",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             _editManager.EditMode = EditMode.Scale;
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -186,10 +185,10 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Rotate",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             _editManager.EditMode = EditMode.Rotate;
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -203,10 +202,10 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Modify",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             _editManager.EditMode = EditMode.Modify;
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -220,14 +219,14 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Add Polygon",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             var features = _targetLayer?.GetFeatures().Copy() ?? [];
             foreach (var feature in features)
                 feature.Modified();
-            _tempFeatures = new List<IFeature>(features);
+            _tempFeatures = [.. features];
             _editManager.EditMode = EditMode.AddPolygon;
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -241,14 +240,14 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Add Line",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             var features = _targetLayer?.GetFeatures().Copy() ?? [];
             foreach (var feature in features)
                 feature.Modified();
-            _tempFeatures = new List<IFeature>(features);
+            _tempFeatures = [.. features];
             _editManager.EditMode = EditMode.AddLine;
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -262,14 +261,14 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Add Point",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             var features = _targetLayer?.GetFeatures().Copy() ?? [];
             foreach (var feature in features)
                 feature.Modified();
-            _tempFeatures = new List<IFeature>(features);
+            _tempFeatures = [.. features];
             _editManager.EditMode = EditMode.AddPoint;
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -292,7 +291,7 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Cancel",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             if (_targetLayer != null && _tempFeatures != null)
             {
@@ -306,7 +305,7 @@ public class EditingSample : IMapControlSample
             _mapControl?.RefreshGraphics();
             _editManager.EditMode = EditMode.None;
             _tempFeatures = null;
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -320,20 +319,20 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Load",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             var features = _targetLayer?.GetFeatures().Copy() ?? [];
 
             foreach (var feature in features)
                 feature.Modified();
 
-            _tempFeatures = new List<IFeature>(features);
+            _tempFeatures = [.. features];
 
             _editManager.Layer?.AddRange(features);
             _targetLayer?.Clear();
 
             _mapControl?.RefreshGraphics();
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -347,13 +346,13 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Save",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             _targetLayer?.AddRange(_editManager.Layer?.GetFeatures().Copy() ?? []);
             _editManager.Layer?.Clear();
 
             _mapControl?.RefreshGraphics();
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -367,10 +366,10 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Layer 3",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             _targetLayer = map.Layers.FirstOrDefault(f => f.Name == "Layer 3") as WritableLayer;
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -384,10 +383,10 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Layer 2",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             _targetLayer = map.Layers.FirstOrDefault(f => f.Name == "Layer 2") as WritableLayer;
-            return true;
+            e.Handled = true;
         }
     };
 
@@ -401,10 +400,10 @@ public class EditingSample : IMapControlSample
         VerticalAlignment = VerticalAlignment.Absolute,
         Text = "Layer 1",
         BackColor = Color.LightGray,
-        Tapped = (_, e) =>
+        WithTappedEvent = (_, e) =>
         {
             _targetLayer = map.Layers.FirstOrDefault(f => f.Name == "Layer 1") as WritableLayer;
-            return true;
+            e.Handled = true;
         }
     };
 

--- a/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/CustomCalloutStyleSample.cs
@@ -46,18 +46,17 @@ public class CustomCalloutStyleSample : IMapControlSample
         return map;
     }
 
-    private static bool MapTapped(Map map, MapEventArgs e)
+    private static void MapTapped(object? s, MapEventArgs e)
     {
-        var feature = e.GetMapInfo(map.Layers.Where(l => l.Name == _customStyleLayerName)).Feature;
+        var feature = e.GetMapInfo(e.Map.Layers.Where(l => l.Name == _customStyleLayerName)).Feature;
         if (feature is not null)
         {
             if (feature["show-callout"]?.ToString() == "true")
                 feature["show-callout"] = "false";
             else
                 feature["show-callout"] = "true";
-            return true;
+            e.Handled = true;
         }
-        return false;
     }
 
     private static MemoryLayer CreateCalloutLayer(IEnumerable<IFeature> features) => new()

--- a/Samples/Mapsui.Samples.Common/Maps/Info/ImageCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/ImageCalloutSample.cs
@@ -42,17 +42,16 @@ public class ImageCalloutSample : ISample
         return map;
     }
 
-    private static bool MapTapped(Map map, MapEventArgs e)
+    private static void MapTapped(object? s, MapEventArgs e)
     {
-        var mapInfo = e.GetMapInfo(map.Layers.Where(l => l.Name == _pointLayerName));
+        var mapInfo = e.GetMapInfo(e.Map.Layers.Where(l => l.Name == _pointLayerName));
         var calloutStyle = mapInfo.Feature?.Styles.OfType<CalloutStyle>().FirstOrDefault();
         if (calloutStyle is not null)
         {
             calloutStyle.Enabled = !calloutStyle.Enabled;
             mapInfo.Layer?.DataHasChanged();
-            return true;
+            e.Handled = true;
         }
-        return false;
     }
 
     private static Layer CreatePointLayer()

--- a/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Info/SingleCalloutSample.cs
@@ -40,17 +40,16 @@ public class SingleCalloutSample : ISample
         return Task.FromResult(map);
     }
 
-    private static bool MapTapped(Map map, MapEventArgs e)
+    private static void MapTapped(object? s, MapEventArgs e)
     {
-        var mapInfo = e.GetMapInfo(map.Layers.Where(l => l.Name == _calloutLayerName));
+        var mapInfo = e.GetMapInfo(e.Map.Layers.Where(l => l.Name == _calloutLayerName));
         var calloutStyle = mapInfo.Feature?.Styles.OfType<CalloutStyle>().FirstOrDefault();
         if (calloutStyle is not null)
         {
             calloutStyle.Enabled = !calloutStyle.Enabled;
             mapInfo.Layer?.DataHasChanged(); // To trigger a refresh of graphics.
-            return true;
+            e.Handled = true;
         }
-        return false;
     }
 
     private static MemoryLayer CreatePointLayer()

--- a/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/MapBuilders/MapBuilderSample.cs
@@ -46,9 +46,8 @@ public static class SampleMapBuilderExtensions
             if (e.GetMapInfo([layer]).Feature?.Data is UserData data)
             {
                 data.CalloutEnabled = !data.CalloutEnabled;
-                return true;
+                e.Handled = true;
             }
-            return false;
         };
 
         layer.WithPinAndCallout(

--- a/Samples/Mapsui.Samples.Common/Maps/Navigation/MyLocationLayerSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Navigation/MyLocationLayerSample.cs
@@ -55,7 +55,7 @@ public class MyLocationLayerSample : ISample, IDisposable
             _myLocationLayer.UpdateMySpeed(points[_count].Item4);
 
             _count++;
-            return true;
+            e.Handled = true;
         };
 
         return Task.FromResult(map);

--- a/Samples/Mapsui.Samples.Common/Maps/Performance/ManyMutatingLayersSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Performance/ManyMutatingLayersSample.cs
@@ -63,7 +63,7 @@ public sealed class ManyMutatingLayersSample : ISample, IDisposable
     private void InitializeTimer(Timer timer, Map map, IEnumerable<PointFeature> features)
     {
         var random = new Random(38445);
-        timer.Elapsed += (sender, args) => MutateFeatures(features, () => map.Refresh());
+        timer.Elapsed += (s, e) => MutateFeatures(features, () => map.Refresh());
         timer.Start();
     }
 

--- a/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithThousandsOfPolygonsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Performance/RasterizingTileLayerWithThousandsOfPolygonsSample.cs
@@ -45,13 +45,13 @@ public sealed class RasterizingTileLayerWithThousandsOfPolygonsSample : IMapCont
             Text = "Change Color",
             HorizontalAlignment = HorizontalAlignment.Left,
             VerticalAlignment = VerticalAlignment.Top,
-            Tapped = ChangeColor
+            WithTappedEvent = ChangeColor
         });
 
         return _map;
     }
 
-    private bool ChangeColor(object? sender, WidgetEventArgs e)
+    private void ChangeColor(object? sender, WidgetEventArgs e)
     {
         var layer = (_map?.Layers)?.First(f => f is RasterizingTileLayer) as RasterizingTileLayer;
         var random = new Random();
@@ -62,7 +62,6 @@ public sealed class RasterizingTileLayerWithThousandsOfPolygonsSample : IMapCont
             Fill = new Brush(color),
         };
         layer.ClearCache();
-        return false;
     }
 
     public static ILayer CreatePolygonLayer()

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SelectionStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SelectionStyleSample.cs
@@ -29,14 +29,14 @@ internal class SelectionStyleSample : ISample
         return map;
     }
 
-    private static bool MapTapped(Map map, MapEventArgs e)
+    private static void MapTapped(object? s, MapEventArgs e)
     {
-        var feature = e.GetMapInfo(map.Layers.Where(l => l.Name == "Points")).Feature;
+        var feature = e.GetMapInfo(e.Map.Layers.Where(l => l.Name == "Points")).Feature;
         if (feature is null)
-            return false; ;
+            return; ;
         if (feature["selected"] is null) feature["selected"] = "true";
         else feature["selected"] = null;
-        return true;
+        e.Handled = true;
     }
 
     public static ILayer CreatePointLayer() => new Layer("Points")

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/ButtonWidgetSample.cs
@@ -28,40 +28,36 @@ public class ButtonWidgetSample : ISample
         map.Widgets.Add(CreateButtonWidget("Tap me", VerticalAlignment.Top, HorizontalAlignment.Left, (s, e) =>
         {
             if (e.GestureType == GestureType.DoubleTap)
-                return false;
-            var button = (ButtonWidget)s;
+                return;
+            var button = s as ButtonWidget ?? throw new InvalidCastException($"Expected {nameof(ButtonWidget)}");
             button.Text = $"Tapped {++_tapCount} times";
             map.RefreshGraphics();
-            return false;
         }));
         map.Widgets.Add(CreateImageButtonWidget(VerticalAlignment.Top, HorizontalAlignment.Right, (s, e) =>
         {
             Logger.Log(LogLevel.Information, $"Image Tapped {++_imageTapCount} times");
             map.RefreshGraphics();
-            return false;
         }));
         map.Widgets.Add(CreateButtonWidget("Hello!", VerticalAlignment.Bottom, HorizontalAlignment.Right, (s, e) =>
         {
-            var button = (ButtonWidget)s;
+            var button = s as ButtonWidget ?? throw new InvalidCastException($"Expected {nameof(ButtonWidget)}");
             button.Text = $"{button.Text}!";
             map.RefreshGraphics();
-            return false;
         }));
         map.Widgets.Add(CreateButtonWidget("Double Tap me", VerticalAlignment.Bottom, HorizontalAlignment.Left, (s, e) =>
         {
             if (e.GestureType == GestureType.SingleTap)
-                return false;
-            var button = (ButtonWidget)s;
+                return;
+            var button = s as ButtonWidget ?? throw new InvalidCastException($"Expected {nameof(ButtonWidget)}");
             button.Text = $"Double Tapped {++_doubleTapCount} times";
             map.RefreshGraphics();
-            return false;
         }));
 
         return Task.FromResult(map);
     }
 
     private static ButtonWidget CreateButtonWidget(string text, VerticalAlignment verticalAlignment,
-        HorizontalAlignment horizontalAlignment, Func<IWidget, WidgetEventArgs, bool> tapped) => new()
+        HorizontalAlignment horizontalAlignment, EventHandler<WidgetEventArgs> tapped) => new()
         {
             Text = text,
             VerticalAlignment = verticalAlignment,
@@ -71,11 +67,11 @@ public class ButtonWidgetSample : ISample
             CornerRadius = 8,
             BackColor = new Color(0, 123, 255),
             TextColor = Color.White,
-            Tapped = tapped
+            WithTappedEvent = tapped
         };
 
     private static ImageButtonWidget CreateImageButtonWidget(VerticalAlignment verticalAlignment,
-        HorizontalAlignment horizontalAlignment, Func<IWidget, WidgetEventArgs, bool> tapped) => new()
+        HorizontalAlignment horizontalAlignment, EventHandler<WidgetEventArgs> tapped) => new()
         {
             Image = "embedded://Mapsui.Resources.Images.MyLocationStill.svg",
             VerticalAlignment = verticalAlignment,
@@ -84,6 +80,6 @@ public class ButtonWidgetSample : ISample
             Padding = new MRect(10, 8),
             CornerRadius = 8,
             Envelope = new MRect(0, 0, 64, 64),
-            Tapped = tapped
+            WithTappedEvent = tapped
         };
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/CustomWidgetSample.cs
@@ -49,7 +49,7 @@ public class CustomWidget : BaseWidget
 
     public Color? Color { get; set; }
 
-    public override bool OnTapped(WidgetEventArgs e)
+    public override void OnTapped(WidgetEventArgs e)
     {
         base.OnTapped(e);
 
@@ -57,7 +57,6 @@ public class CustomWidget : BaseWidget
             Color = GenerateRandomColor();
         else
             Color = Mapsui.Styles.Color.Transparent;
-        return false;
     }
 
     public static Color GenerateRandomColor()

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/PerformanceWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/PerformanceWidgetSample.cs
@@ -60,11 +60,11 @@ public class PerformanceWidgetSample : IMapControlSample
         TextSize = 12,
         TextColor = Color.Black,
         BackColor = Color.White,
-        Tapped = (s, e) =>
+        WithTappedEvent = (s, e) =>
         {
             _mapControl?.Performance?.Clear();
             _mapControl?.RefreshGraphics();
-            return true;
+            e.Handled = true;
         }
     };
 }

--- a/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
+++ b/Samples/Mapsui.Samples.MapView/ManyPinsSample.cs
@@ -132,11 +132,11 @@ public class ManyPinsSample : IMapViewSample
         ArgumentNullException.ThrowIfNull(mapControl.Performance);
         return new PerformanceWidget(mapControl.Performance)
         {
-            Tapped = (sender, args) =>
+            WithTappedEvent = (s, e) =>
             {
                 mapControl?.Performance.Clear();
                 mapControl?.RefreshGraphics();
-                return true;
+                e.Handled = true;
             }
         };
     }

--- a/Tests/Mapsui.Tests.Common/Maps/TouchPointSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/TouchPointSample.cs
@@ -68,12 +68,12 @@ public sealed class TouchPointSample : ISample, IDisposable
         SymbolScale = scale
     };
 
-    private bool MapTapped(Map map, MapEventArgs e)
+    private void MapTapped(object? s, MapEventArgs e)
     {
-        var mapInfo = e.GetMapInfo(map.Layers.Where(l => l.Name == "Layer"));
+        var mapInfo = e.GetMapInfo(e.Map.Layers.Where(l => l.Name == "Layer"));
         _mousePosition!.Text = $"X: {Convert.ToInt32(mapInfo.ScreenPosition.X)}, Y: {Convert.ToInt32(mapInfo.ScreenPosition.Y)}";
         _mousePosition.NeedsRedraw = true;
-        var clickLayer = map.Layers.OfType<MemoryLayer>().First(l => l.Name == "Click Layer");
+        var clickLayer = e.Map.Layers.OfType<MemoryLayer>().First(l => l.Name == "Click Layer");
         var features = (List<IFeature>)clickLayer.Features;
         features.Add(new PointFeature(mapInfo.WorldPosition.X, mapInfo.WorldPosition.Y));
         clickLayer.DataHasChanged();
@@ -81,9 +81,8 @@ public sealed class TouchPointSample : ISample, IDisposable
         {
             _label!.Text = _label.Text == "Not Selected" ? "Selected" : "Not Selected";
             _label.NeedsRedraw = true;
-            return true;
+            e.Handled = true;
         }
-        return false;
     }
 
     private static TextBoxWidget CreateLabel(

--- a/Tests/Mapsui.Tests/Fetcher/FeatureFetcherTests.cs
+++ b/Tests/Mapsui.Tests/Fetcher/FeatureFetcherTests.cs
@@ -30,9 +30,9 @@ public class FeatureFetcherTests
         // Because we use weak references for the PropertyChanged event handler it can get
         // garbage collected if use a lambda directly assigned to the layer.PropertyChanged.
         // So we need to create the variable below to prevent garbage collection.
-        PropertyChangedEventHandler propertyChanged = (_, args) =>
+        PropertyChangedEventHandler propertyChanged = (s, e) =>
         {
-            if (args.PropertyName == nameof(Layer.Busy))
+            if (e.PropertyName == nameof(Layer.Busy))
             {
                 notifications.Add(layer.Busy);
             }

--- a/Tests/Mapsui.Tests/Layers/ImageLayerTests.cs
+++ b/Tests/Mapsui.Tests/Layers/ImageLayerTests.cs
@@ -40,9 +40,9 @@ public class ImageLayerTests
         using var waitHandle = new AutoResetEvent(false);
         Exception? exception = null;
 
-        imageLayer.DataChanged += (_, args) =>
+        imageLayer.DataChanged += (s, e) =>
         {
-            exception = args.Error;
+            exception = e.Error;
             waitHandle.Go();
         };
 

--- a/Tests/Mapsui.Tests/NavigatorTests.cs
+++ b/Tests/Mapsui.Tests/NavigatorTests.cs
@@ -68,9 +68,9 @@ public class NavigatorTests
         navigator.SetSize(10, 10);
 
         // Save changes to old viewport
-        navigator.ViewportChanged += (sender, args) =>
+        navigator.ViewportChanged += (s, e) =>
         {
-            oldViewport = args.OldViewport;
+            oldViewport = e.OldViewport;
         };
 
         // Test size change


### PR DESCRIPTION
Decided to use a regular `event`. In the past we had some problems with memory leaks that seemed to be related to events. I wrote some code to test this and could not reproduce it.

This is **breaking change**. Instead of returning a bool you now have to use e.Handled. 
- Instead of `return true` you set `e.Handled = true`. 
- Instead of `return false` you now can just do `return`, or remove the line if it is at the end of a method. 
 
Look at the diff to see how we solved it in our samples and widgets.

Introduced a init only `WithTappedEvent` to allow initialization within an expression body. I have never seen this anywhere else, hope this is not too confusing. For our sample code it made things a lot simpler and more clear.

```csharp
public EventHandler<WidgetEventArgs>? WithTappedEvent { init { Tapped += value; } }
```

It looks like this:
```csharp
private ButtonWidget CreateRotateButton() => new()
{
	Position = new MPoint(5, 250),
	Height = 18,
	Width = 120,
	CornerRadius = 2,
	HorizontalAlignment = HorizontalAlignment.Absolute,
	VerticalAlignment = VerticalAlignment.Absolute,
	Text = "Rotate",
	BackColor = Color.LightGray,
	WithTappedEvent = (_, e) =>
	{
		_editManager.EditMode = EditMode.Rotate;
		e.Handled = true;
	}
};
```
