### PR TITLE
Make Mapsui.Samples.Maui.MapView work on phones again

### DIFF
--- a/Samples/Mapsui.Samples.Maui.MapView/App.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/App.xaml.cs
@@ -23,7 +23,7 @@ public partial class App : Application
     protected override Window CreateWindow(IActivationState? activationState)
     {
         if (DeviceInfo.Idiom == DeviceIdiom.Phone)
-            return new Window(new MainPage());
+            return new Window(new NavigationPage(new MainPage()));
 
         return new Window(new MainPageLarge());
     }


### PR DESCRIPTION
... fixing this exception (seen on an Android 14 device):

```
System.InvalidOperationException: PushAsync is not supported, please use a NavigationPage.
   at Microsoft.Maui.Controls.Window.NavigationImpl.OnPushAsync(Page page, Boolean animated) in /_/src/Controls/src/Core/Window/Window.cs:line 706
   at Microsoft.Maui.Controls.Internals.NavigationProxy.PushAsync(Page root, Boolean animated) in /_/src/Controls/src/Core/NavigationProxy.cs:line 135
   at Microsoft.Maui.Controls.Internals.NavigationProxy.OnPushAsync(Page page, Boolean animated) in /_/src/Controls/src/Core/NavigationProxy.cs:line 222
   at Microsoft.Maui.Controls.Internals.NavigationProxy.PushAsync(Page root, Boolean animated) in /_/src/Controls/src/Core/NavigationProxy.cs:line 135
   at Microsoft.Maui.Controls.Internals.NavigationProxy.PushAsync(Page root) in /_/src/Controls/src/Core/NavigationProxy.cs:line 127
   at Mapsui.Samples.Maui.MainPage.OnSelection(Object sender, SelectedItemChangedEventArgs e) in Mapsui/Samples/Mapsui.Samples.Maui.MapView/MainPage.xaml.cs:line 60
```