### PR TITLE
Add CustomLayerRenderer

### DIFF
--- a/Mapsui.Rendering.Skia/CustomLayerRenderer.cs
+++ b/Mapsui.Rendering.Skia/CustomLayerRenderer.cs
@@ -1,0 +1,15 @@
+﻿using Mapsui.Layers;
+using Mapsui.Rendering.Skia.Cache;
+using SkiaSharp;
+
+namespace Mapsui.Rendering.Skia;
+
+public class CustomLayerRenderer
+{
+    public delegate void RenderHandler(SKCanvas canvas, Viewport viewport, ILayer layer, RenderService renderService);
+
+    public static void RenderLayer(SKCanvas canvas, Viewport viewport, ILayer layer, RenderService renderService, RenderHandler renderHandler)
+    {
+        renderHandler(canvas, viewport, layer, renderService);
+    }
+}

--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -28,7 +28,7 @@ public sealed class MapRenderer : IRenderer, IDisposable
     private long _currentIteration;
     private static readonly Dictionary<Type, IWidgetRenderer> _widgetRenderers = [];
     private static readonly Dictionary<Type, IStyleRenderer> _styleRenderers = [];
-    private static readonly Dictionary<string, PointStyleRenderer.PointStyleDrawer> _pointStyleRenderers = [];
+    private static readonly Dictionary<string, PointStyleRenderer.RenderHandler> _pointStyleRenderers = [];
 
     static MapRenderer()
     {
@@ -192,14 +192,14 @@ public sealed class MapRenderer : IRenderer, IDisposable
         return false;
     }
 
-    public static bool TryGetPointStyleRenderer(string rendererName, [NotNullWhen(true)] out PointStyleRenderer.PointStyleDrawer? pointStyleDrawer)
+    public static bool TryGetPointStyleRenderer(string rendererName, [NotNullWhen(true)] out PointStyleRenderer.RenderHandler? renderHandler)
     {
-        if (_pointStyleRenderers.TryGetValue(rendererName, out var outPointStyleDrawer))
+        if (_pointStyleRenderers.TryGetValue(rendererName, out var outRenderHandler))
         {
-            pointStyleDrawer = outPointStyleDrawer;
+            renderHandler = outRenderHandler;
             return true;
         }
-        pointStyleDrawer = null;
+        renderHandler = null;
         return false;
     }
 
@@ -213,9 +213,9 @@ public sealed class MapRenderer : IRenderer, IDisposable
         _widgetRenderers[type] = renderer;
     }
 
-    public static void RegisterPointStyleRenderer(string rendererName, PointStyleRenderer.PointStyleDrawer renderer)
+    public static void RegisterPointStyleRenderer(string rendererName, PointStyleRenderer.RenderHandler rendererHandler)
     {
-        _pointStyleRenderers[rendererName] = renderer;
+        _pointStyleRenderers[rendererName] = rendererHandler;
     }
 
     private void RenderTo(Viewport viewport, IEnumerable<ILayer> layers, Color? background, float pixelDensity,

--- a/Mapsui.Rendering.Skia/SkiaStyles/PointStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/PointStyleRenderer.cs
@@ -7,10 +7,10 @@ namespace Mapsui.Rendering.Skia.SkiaStyles;
 
 public abstract class PointStyleRenderer
 {
-    public delegate void PointStyleDrawer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity);
+    public delegate void RenderHandler(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity);
 
     public static void DrawPointStyle(SKCanvas canvas, Viewport viewport, double x, double y, IPointStyle imageStyle,
-        RenderService renderService, float opacity, PointStyleDrawer drawPointStyle)
+        RenderService renderService, float opacity, RenderHandler renderHandler)
     {
         try
         {
@@ -33,7 +33,7 @@ public abstract class PointStyleRenderer
             // Translate to offset
             canvas.Translate((float)imageStyle.Offset.X, (float)-imageStyle.Offset.Y);
 
-            drawPointStyle(canvas, imageStyle, renderService, opacity);
+            renderHandler(canvas, imageStyle, renderService, opacity);
         }
         finally
         {

--- a/Mapsui/Layers/BaseLayer.cs
+++ b/Mapsui/Layers/BaseLayer.cs
@@ -1,12 +1,12 @@
 using Mapsui.Fetcher;
 using Mapsui.Logging;
 using Mapsui.Styles;
+using Mapsui.UI;
 using Mapsui.Widgets.ButtonWidgets;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
-using Mapsui.UI;
 
 namespace Mapsui.Layers;
 
@@ -195,6 +195,9 @@ public abstract class BaseLayer : ILayer
 
     /// <inheritdoc/>
     public virtual Func<IEnumerable<IFeature>, IEnumerable<IFeature>> SortFeatures { get; set; } = (feature) => feature;
+
+    /// <inheritdoc />
+    public string? CustomLayerRendererName { get; set; }
 
     public void DataHasChanged()
     {

--- a/Mapsui/Layers/ILayer.cs
+++ b/Mapsui/Layers/ILayer.cs
@@ -4,13 +4,13 @@
 
 // This file was originally created by Morten Nielsen (www.iter.dk) as part of SharpMap
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using Mapsui.Animations;
 using Mapsui.Fetcher;
 using Mapsui.Styles;
 using Mapsui.Widgets.ButtonWidgets;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Mapsui.Layers;
 
@@ -91,6 +91,11 @@ public interface ILayer : IAnimatable, INotifyPropertyChanged, IDisposable
     /// List of native resolutions
     /// </summary>
     IReadOnlyList<double> Resolutions { get; }
+
+    /// <summary>
+    /// Name of the custom layer renderer. Set this value if you want to use a custom renderer for this layer.
+    /// </summary>
+    string? CustomLayerRendererName { get; set; }
 
     /// <summary>
     /// Event called when the data within the layer has changed allowing

--- a/Mapsui/Rendering/VisibleFeatureIterator.cs
+++ b/Mapsui/Rendering/VisibleFeatureIterator.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Mapsui.Extensions;
 using Mapsui.Layers;
 using Mapsui.Logging;
 using Mapsui.Styles;
 using Mapsui.Styles.Thematics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Mapsui.Rendering;
 
@@ -14,7 +14,7 @@ public static class VisibleFeatureIterator
     private static readonly object _iterationLock = new();
 
     public static void IterateLayers(Viewport viewport, IEnumerable<ILayer> layers, long iteration,
-        Action<Viewport, ILayer, IStyle, IFeature, float, long> callback)
+        Action<Viewport, ILayer, IStyle, IFeature, float, long> callback, Action<ILayer>? customLayerRendererCallback = null)
     {
         foreach (var layer in layers)
         {
@@ -26,7 +26,10 @@ public static class VisibleFeatureIterator
             // TODO: find out which Caching path causes this. Because when the caching is disabled it works.
             lock (_iterationLock)
             {
-                IterateLayer(viewport, layer, iteration, callback);
+                if (layer.CustomLayerRendererName is not null && customLayerRendererCallback is not null)
+                    customLayerRendererCallback(layer);
+                else
+                    IterateLayer(viewport, layer, iteration, callback);
             }
         }
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/CustomLayerRendererSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/CustomLayerRendererSample.cs
@@ -1,0 +1,67 @@
+﻿using Mapsui.Extensions;
+using Mapsui.Layers;
+using Mapsui.Rendering.Skia;
+using Mapsui.Rendering.Skia.Cache;
+using Mapsui.Rendering.Skia.SkiaStyles;
+using Mapsui.Samples.Common.DataBuilders;
+using Mapsui.Styles;
+using Mapsui.Tiling;
+using Mapsui.Widgets.InfoWidgets;
+using SkiaSharp;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Mapsui.Samples.Common.Maps.Styles;
+
+[SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP001:Dispose created")]
+public class CustomLayerRendererSample : ISample
+{
+    public string Name => $"{nameof(Rendering.Skia.CustomLayerRenderer)}";
+    public string Category => $"{nameof(Rendering.Skia.CustomLayerRenderer)}";
+
+    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+
+    public static Map CreateMap()
+    {
+        var map = new Map();
+        map.Layers.Add(OpenStreetMap.CreateTileLayer());
+        map.Layers.Add(CreatePointLayer(map));
+        MapRenderer.RegisterLayerRenderer("custom-layer-renderer", CustomLayerRenderer);
+        map.Widgets.Add(new MapInfoWidget(map, map.Layers.OfType<MemoryLayer>));
+        return map;
+    }
+
+    private static MemoryLayer CreatePointLayer(Map map)
+    {
+        return new MemoryLayer($"{nameof(CustomLayerRenderer)}")
+        {
+            Features = CreateFeatures(map.Extent!, 1_000).ToList(),
+            Style = new SymbolStyle(),
+            CustomLayerRendererName = "custom-layer-renderer"
+        };
+    }
+
+    private static void CustomLayerRenderer(SKCanvas canvas, Viewport viewport, ILayer layer, RenderService renderService)
+    {
+        foreach (var feature in layer.GetFeatures(viewport.ToExtent(), viewport.Resolution))
+        {
+            var point = ((PointFeature)feature).Point;
+            var style = new SymbolStyle { SymbolType = SymbolType.Rectangle };
+            var opacity = (float)(layer.Opacity * style.Opacity);
+            // Here the PointStyleRenderer is reused but you don't have to. You can also draw the point directly.
+            PointStyleRenderer.DrawPointStyle(canvas, viewport, point.X, point.Y, style, renderService, opacity, DrawSymbolStyle);
+        }
+    }
+
+    private static void DrawSymbolStyle(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
+    {
+        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
+        canvas.DrawCircle(0f, 0f, 10f, paint);
+    }
+
+    private static PointFeature[] CreateFeatures(MRect envelope, int count) =>
+        [.. RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
+        .Select(p => new PointFeature(p))];
+}

--- a/Tests/Mapsui.Tests/Rendering/VisibleFeatureIteratorTests.cs
+++ b/Tests/Mapsui.Tests/Rendering/VisibleFeatureIteratorTests.cs
@@ -3,8 +3,8 @@ using Mapsui.Rendering;
 using Mapsui.Styles;
 using Mapsui.Styles.Thematics;
 using NUnit.Framework;
-using System.Collections.Generic;
 using NUnit.Framework.Legacy;
+using System.Collections.Generic;
 
 namespace Mapsui.Tests.Rendering;
 
@@ -20,14 +20,14 @@ internal class VisibleFeatureIteratorTests
         var vectorStyle2 = new VectorStyle();
         using var memoryLayer = new MemoryLayer { Style = new ThemeStyle(f => new StyleCollection { Styles = { vectorStyle1, vectorStyle2 } }) };
         var feature = new PointFeature(0, 0);
-        memoryLayer.Features = new List<IFeature> { feature };
+        memoryLayer.Features = [feature];
         var result = new Dictionary<IFeature, List<IStyle>>();
 
         // Act
         VisibleFeatureIterator.IterateLayers(viewport, [memoryLayer], 0, (v, l, s, f, o, i) =>
         {
-            if (result.ContainsKey(f))
-                result[f].Add(s);
+            if (result.TryGetValue(f, out var value))
+                value.Add(s);
             else
                 result[f] = [s];
         });


### PR DESCRIPTION
This is an early version of the CustomLayerRenderer. The idea is that you can assign a custom renderer to a layer. This way you could optimize for performance, or implement [world wrap](https://github.com/Mapsui/Mapsui/issues/518). 

Rendering is what we will focus on in Mapsui V6, but by adding custom rendering to V5 we can start preparing for V6 without introducing breaking changes.

There is also a downsides to this. Because renderers can now have completely different implementation some generic functionality may not work. I am sure it is worth it, but something to keep in mind.

![image](https://github.com/user-attachments/assets/f4c4bbba-5a96-47e1-8b00-c570f33de6ef)
