### PR TITLE
Add coordinates to MapInfoWidget

### DIFF
--- a/Mapsui/Widgets/InfoWidgets/MapInfoWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/MapInfoWidget.cs
@@ -82,8 +82,16 @@ public class MapInfoWidget : TextBoxWidget
 
         result.Append("Info: ");
         foreach (var field in f.Fields)
-            result.Append($"{field}: {f[field]} - ");
+            result.Append($"{field}: {f[field]} | ");
+        result.Append($"{GetCoordinateString(f)}");
         result.Remove(result.Length - 2, 2);
         return result.ToString();
     };
+
+    private static string GetCoordinateString(IFeature f)
+    {
+        var builder = new StringBuilder();
+        f.CoordinateVisitor((x, y, setter) => builder.Append($"{x.ToString("f2")} {y.ToString("f2")} | ")); ;
+        return builder.ToString();
+    }
 }


### PR DESCRIPTION
A small change. Where there were no additional info fields, which is often the case, no info was shown at all. Now at least you see the coordinates. For polygons this will be a long string.

![image](https://github.com/user-attachments/assets/3489e622-ce2c-4911-a71c-6e229e0a9f18)
