### PR TITLE
MapView: fix InvalidCastExceptions with Pin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ packages/
 
 .vs/
 
+.mono/
+
 Release/
 
 *.ncrunchproject

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 
 *.userprefs
 
+*.orig
+*.rej
+
 Mapsui.Rendering.Android/obj/
 
 Samples/Mapsui.Samples.Silverlight.Web/ClientBin

--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -653,7 +653,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
                 var eventArgs = new MapClickedEventArgs(worldPosition.ToNative(), e.GestureType);
                 MapClicked?.Invoke(this, eventArgs);
 
-                if (e.Handled)
+                if (eventArgs.Handled)
                 {
                     handled = true;
                     return handled;

--- a/Mapsui.UI.MapView/Objects/Pin.cs
+++ b/Mapsui.UI.MapView/Objects/Pin.cs
@@ -535,39 +535,39 @@ public class Pin : IFeatureProvider, INotifyPropertyChanged
                 break;
             case nameof(Transparency):
                 if (Feature != null)
-                    ((SymbolStyle)Feature.Styles.First()).Opacity = 1 - Transparency;
+                    ((IPointStyle)Feature.Styles.First()).Opacity = 1 - Transparency;
                 break;
             case nameof(Anchor):
                 if (Feature != null)
-                    ((SymbolStyle)Feature.Styles.First()).Offset = new Offset(Anchor.X, Anchor.Y);
+                    ((IPointStyle)Feature.Styles.First()).Offset = new Offset(Anchor.X, Anchor.Y);
                 break;
             case nameof(Rotation):
                 if (Feature != null)
-                    ((SymbolStyle)Feature.Styles.First()).SymbolRotation = Rotation;
+                    ((IPointStyle)Feature.Styles.First()).SymbolRotation = Rotation;
                 break;
             case nameof(RotateWithMap):
                 if (Feature != null)
-                    ((SymbolStyle)Feature.Styles.First()).RotateWithMap = RotateWithMap;
+                    ((IPointStyle)Feature.Styles.First()).RotateWithMap = RotateWithMap;
                 break;
             case nameof(IsVisible):
                 if (!IsVisible)
                     HideCallout();
                 if (Feature != null)
-                    ((SymbolStyle)Feature.Styles.First()).Enabled = IsVisible;
+                    ((IPointStyle)Feature.Styles.First()).Enabled = IsVisible;
                 break;
             case nameof(MinVisible):
                 // TODO: Update callout MinVisble too
                 if (Feature != null)
-                    ((SymbolStyle)Feature.Styles.First()).MinVisible = MinVisible;
+                    ((IPointStyle)Feature.Styles.First()).MinVisible = MinVisible;
                 break;
             case nameof(MaxVisible):
                 // TODO: Update callout MaxVisble too
                 if (Feature != null)
-                    ((SymbolStyle)Feature.Styles.First()).MaxVisible = MaxVisible;
+                    ((IPointStyle)Feature.Styles.First()).MaxVisible = MaxVisible;
                 break;
             case nameof(Scale):
                 if (Feature != null)
-                    ((SymbolStyle)Feature.Styles.First()).SymbolScale = Scale;
+                    ((IPointStyle)Feature.Styles.First()).SymbolScale = Scale;
                 break;
             case nameof(Type):
             case nameof(Color):

--- a/Mapsui/Widgets/MapTappedWidget.cs
+++ b/Mapsui/Widgets/MapTappedWidget.cs
@@ -19,6 +19,7 @@ public class MapTappedWidget : InputOnlyWidget // Derived from InputOnlyWidget b
         if (e.Handled)
             return;
 
-        _handlerTap(e);
+        if (_handlerTap(e))
+            e.Handled = true;
     }
 }


### PR DESCRIPTION
This fixes #2923 by casting to the correct style class (a regression that was caused by PR #2904).

Note: There is a remaining problem with the callouts not appearing in "MapView / Add Pin Sample", which I could not fix, see https://github.com/Mapsui/Mapsui/issues/2923#issuecomment-2734127389. It seems to be caused by #2914, but I could not figure out how and why. @pauldendulk could you possibly help with that, please?
