### PR TITLE
Add Image.RasterizeSvg option to improve performance

### DIFF
--- a/Mapsui.Rendering.Skia/Images/SvgDrawableImage.cs
+++ b/Mapsui.Rendering.Skia/Images/SvgDrawableImage.cs
@@ -2,6 +2,9 @@
 using SkiaSharp;
 using Svg.Skia;
 
+#pragma warning disable IDISP008 // SvgDrawableImage is responsible for disposing
+#pragma warning disable IDISP007 // SvgDrawableImage is responsible for disposing
+
 namespace Mapsui.Rendering.Skia.Images;
 
 public sealed class SvgDrawableImage : IDrawableImage
@@ -17,9 +20,22 @@ public sealed class SvgDrawableImage : IDrawableImage
         OriginalStream = bytes;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SvgDrawableImage"/> class with the specified SKPicture.
+    /// </summary>
+    /// <param name="picture">The SKPicture to be used for the image. SvgDrawableImage will dispose it.</param>
     public SvgDrawableImage(SKPicture picture)
     {
         _picture = picture;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SvgDrawableImage"/> class with the specified SKPicture.
+    /// </summary>
+    /// <param name="skSvg">The SKSvg to be used for the image. SvgDrawableImage will dispose it. </param>
+    public SvgDrawableImage(SKSvg skSvg)
+    {
+        _skSvg = skSvg;
     }
 
     public SKPicture Picture => _skSvg?.Picture is null ? _picture! : _skSvg.Picture!;
@@ -31,12 +47,8 @@ public sealed class SvgDrawableImage : IDrawableImage
     {
         if (_disposed)
             return;
-
         _skSvg?.Dispose();
-#pragma warning disable IDISP007
         _picture?.Dispose();
-#pragma warning restore IDISP007
-
         _disposed = true;
     }
 }

--- a/Mapsui/Styles/Image.cs
+++ b/Mapsui/Styles/Image.cs
@@ -40,6 +40,13 @@ public class Image
     public Color? SvgStrokeColor { get; set; }
 
     /// <summary>
+    /// When set to true an SVG image will be rasterized to a bitmap. This can improve performance but could affect 
+    /// the quality.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)] // Experimental feature
+    public bool RasterizeSvg { get; set; }
+
+    /// <summary>
     /// This allows for the automatic conversion of a string to an Image object. This was added to make the creation 
     /// code simpler.
     /// </summary>

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/SvgSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/SvgSample.cs
@@ -12,7 +12,8 @@ namespace Mapsui.Samples.Common.Maps.Styles;
 
 public class SvgSample : ISample
 {
-    public string Name => "Svg";
+    private static readonly int _numberOfSvgs = 2000;
+    public string Name => $"Many SVGs ({_numberOfSvgs})";
     public string Category => "Styles";
 
     public Task<Map> CreateMapAsync()
@@ -32,7 +33,7 @@ public class SvgSample : ISample
         return new MemoryLayer
         {
             Name = "Svg Layer",
-            Features = CreateSvgFeatures(RandomPointsBuilder.GenerateRandomPoints(envelope, 2000)),
+            Features = CreateSvgFeatures(RandomPointsBuilder.GenerateRandomPoints(envelope, _numberOfSvgs)),
             Style = null,
         };
     }


### PR DESCRIPTION
Svg:
![image](https://github.com/user-attachments/assets/cbcaead9-0c03-4907-8d3d-d46af3abd765)

Svg converted to bitmap before drawing:
![image](https://github.com/user-attachments/assets/9f95cbfc-5690-4c95-a315-9b6d0b789767)

This implements it for custom color SVGs, not for regular SVGs. 

