### PR TITLE
Add option to select sample through the route in the Blazor sample

### DIFF
--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -89,6 +89,21 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 #endif
     public bool UseFling { get; set; } = true;
 
+    public float PixelDensity => (float)GetPixelDensity();
+
+    /// <summary>
+    /// Renderer that is used from this MapControl
+    /// </summary>
+    public IRenderer Renderer => _renderer;
+
+    /// <summary>
+    /// Called whenever the map is clicked. The MapInfoEventArgs contain the features that were hit in
+    /// the layers that have IsMapInfoLayer set to true. 
+    /// </summary>
+    /// <remarks>
+    /// The Map.Tapped event is preferred over the Info event. This event is kept for backwards compatibility.
+    /// </remarks>
+    public event EventHandler<MapInfoEventArgs>? Info;
     /// <summary>
     /// Event that is triggered when the map is tapped. Can be a single tap, double tap or long press.
     /// </summary>
@@ -265,22 +280,6 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             }
         }
     }
-
-    public float PixelDensity => (float)GetPixelDensity();
-
-    /// <summary>
-    /// Renderer that is used from this MapControl
-    /// </summary>
-    public IRenderer Renderer => _renderer;
-
-    /// <summary>
-    /// Called whenever the map is clicked. The MapInfoEventArgs contain the features that were hit in
-    /// the layers that have IsMapInfoLayer set to true. 
-    /// </summary>
-    /// <remarks>
-    /// The Map.Tapped event is preferred over the Info event. This event is kept for backwards compatibility.
-    /// </remarks>
-    public event EventHandler<MapInfoEventArgs>? Info;
 
     /// <summary>
     /// Called whenever a property is changed

--- a/Samples/Mapsui.Samples.Blazor/Pages/Index.razor
+++ b/Samples/Mapsui.Samples.Blazor/Pages/Index.razor
@@ -1,4 +1,4 @@
-﻿@page "/"
+﻿@page "/{CategoryInRoute?}/{SampleInRoute?}"
 
 <PageTitle>Mapsui</PageTitle>
    <div class="form-group row">
@@ -28,6 +28,8 @@
     </div>
 </div>
 
+<p>Category in route: @CategoryInRoute</p>
+<p>Category in route: @SampleInRoute</p>
 
 <div class="tabs">
     <div class="tab @(_activeTab == 0 ? "active" : "")" @onclick="(() => SetActiveTab(0))">Map</div>


### PR DESCRIPTION
Done:
- Add option to select sample through the route in the Blazor sample so that you can point to a specific sample through a url.
- Unrelated: Updated the selection sample to a V5 way of doing things
- Unrelated: Moved the events in the shared MapControl together.