### PR TITLE
Make the BitmapDrawableImage class public

### DIFF
--- a/Mapsui.Rendering.Skia/Images/BitmapDrawableImage.cs
+++ b/Mapsui.Rendering.Skia/Images/BitmapDrawableImage.cs
@@ -2,7 +2,7 @@
 
 namespace Mapsui.Rendering.Skia.Images;
 
-internal sealed class BitmapDrawableImage : IDrawableImage
+public sealed class BitmapDrawableImage : IDrawableImage
 {
     private bool _disposed;
     private readonly SKImage _image;


### PR DESCRIPTION
Make BitmapDrawableImage a public class  so that it can be used in the CustomStyleRenderer
