### PR TITLE
Fix for TileLayer.Buzy not going to false

### DIFF
--- a/Mapsui.Tiling/Layers/TileLayer.cs
+++ b/Mapsui.Tiling/Layers/TileLayer.cs
@@ -55,7 +55,7 @@ public class TileLayer : BaseLayer, IAsyncDataFetcher, IDisposable
         Style = new RasterStyle();
         Attribution.Text = _tileSource.Attribution.Text;
         Attribution.Url = _tileSource.Attribution.Url;
-        _extent = _tileSource.Schema?.Extent.ToMRect();
+        _extent = _tileSource.Schema.Extent.ToMRect();
         dataFetchStrategy ??= new DataFetchStrategy(3);
         _renderFetchStrategy = renderFetchStrategy ?? new RenderFetchStrategy();
         _minExtraTiles = minExtraTiles;

--- a/Mapsui/Extensions/ConcurrentQueueExtensions.cs
+++ b/Mapsui/Extensions/ConcurrentQueueExtensions.cs
@@ -7,10 +7,9 @@ public static class ConcurrentQueueExtensions
 {
     // This method was added to make the api more compatible with the previous 
     // List based Widgets library
-    public static T Add<T>(this ConcurrentQueue<T> queue, T item)
+    public static void Add<T>(this ConcurrentQueue<T> queue, T item)
     {
         queue.Enqueue(item);
-        return item;
     }
 
     public static void Clear<T>(this ConcurrentQueue<T> queue)

--- a/Mapsui/Fetcher/Delayer.cs
+++ b/Mapsui/Fetcher/Delayer.cs
@@ -15,7 +15,7 @@ public class Delayer
     // if the method on the queue is not in progress yet the new call will replace the waiting one.
     // This is to avoid requests of an outdated extent.
     private readonly Channel<Func<Task>> _queue = Channel.CreateBounded<Func<Task>>(
-        new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropOldest });
+        new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropOldest, AllowSynchronousContinuations = true, SingleReader = true });
 
     public Delayer() => _ = AddConsumerAsync(_queue);
 

--- a/Mapsui/Fetcher/FetchMachine.cs
+++ b/Mapsui/Fetcher/FetchMachine.cs
@@ -6,17 +6,21 @@ namespace Mapsui.Fetcher;
 
 public class FetchMachine
 {
-    readonly Channel<Func<Task>> _queue = Channel.CreateUnbounded<Func<Task>>(new UnboundedChannelOptions { AllowSynchronousContinuations = true, SingleReader = false });
+    readonly Channel<Func<Task>> _channel = Channel.CreateUnbounded<Func<Task>>(new UnboundedChannelOptions { AllowSynchronousContinuations = true, SingleReader = false });
+
+    public int NumberOfWorkers { get; }
 
     public FetchMachine(int numberOfWorkers = 4)
     {
+        NumberOfWorkers = 4;
         for (var i = 0; i < numberOfWorkers; i++)
-            _ = AddConsumerAsync(_queue);
+            _ = AddConsumerAsync(_channel);
     }
 
-    public void Start(Func<Task> action) => _queue.Writer.TryWrite(action);
+    public void Enqueue(Func<Task> action) => _channel.Writer.TryWrite(action);
 
     public void Stop() { }
+
 
     private static async Task AddConsumerAsync(Channel<Func<Task>> queue)
     {

--- a/Mapsui/Fetcher/FetchMachine.cs
+++ b/Mapsui/Fetcher/FetchMachine.cs
@@ -6,7 +6,7 @@ namespace Mapsui.Fetcher;
 
 public class FetchMachine
 {
-    readonly Channel<Func<Task>> _queue = Channel.CreateUnbounded<Func<Task>>();
+    readonly Channel<Func<Task>> _queue = Channel.CreateUnbounded<Func<Task>>(new UnboundedChannelOptions { AllowSynchronousContinuations = true, SingleReader = false });
 
     public FetchMachine(int numberOfWorkers = 4)
     {

--- a/Mapsui/Fetcher/FetchMachine.cs
+++ b/Mapsui/Fetcher/FetchMachine.cs
@@ -12,7 +12,7 @@ public class FetchMachine
 
     public FetchMachine(int numberOfWorkers = 4)
     {
-        NumberOfWorkers = 4;
+        NumberOfWorkers = numberOfWorkers;
         for (var i = 0; i < numberOfWorkers; i++)
             _ = AddConsumerAsync(_channel);
     }

--- a/Mapsui/Layers/Layer.cs
+++ b/Mapsui/Layers/Layer.cs
@@ -104,7 +104,7 @@ public class Layer(string layerName) : BaseLayer(layerName), IAsyncDataFetcher, 
         if (fetchInfo.ChangeType == ChangeType.Continuous) return;
 
         Busy = true;
-        Delayer.ExecuteDelayed(() => _fetchMachine.Start(() => FetchAsync(fetchInfo, ++_refreshCounter)));
+        Delayer.ExecuteDelayed(() => _fetchMachine.Enqueue(() => FetchAsync(fetchInfo, ++_refreshCounter)));
     }
 
     public override bool UpdateAnimations()

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -189,9 +189,9 @@ public class Map : INotifyPropertyChanged, IDisposable
     /// </remarks>
     public event EventHandler<MapInfoEventArgs>? Info;
 
-    private void Navigator_RefreshDataRequest(object? sender, EventArgs e)
+    private void Navigator_RefreshDataRequest(object? sender, Navigator.RefreshDataRequestEventArgs e)
     {
-        RefreshData(ChangeType.Discrete);
+        RefreshData(e.ChangeType);
     }
 
     /// <summary>

--- a/Mapsui/Styles/ImageSourceCacheInitializer.cs
+++ b/Mapsui/Styles/ImageSourceCacheInitializer.cs
@@ -25,7 +25,7 @@ public static class ImageSourceCacheInitializer
             return; // Don't start a thread if there are no bitmap paths to initialize.
         }
 
-        _fetchMachine.Start(async () =>
+        _fetchMachine.Enqueue(async () =>
         {
             var needsRefresh = false;
             foreach (var imageSource in unregisteredImageSource)

--- a/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
@@ -114,7 +114,7 @@ public class LoggingWidget : TextBoxWidget
         }
     }
 
-    private int _maxNumberOfLogEntriesToKeep = 100;
+    private int _maxNumberOfLogEntriesToKeep = 10;
 
     public int MaxNumberOfLogEntriesToKeep
     {

--- a/Tests/Mapsui.Tests/Fetcher/FetchMachineTests.cs
+++ b/Tests/Mapsui.Tests/Fetcher/FetchMachineTests.cs
@@ -20,7 +20,7 @@ public class FetchMachineTests
     // a hang in some rare cases.
 
     [Test]
-    public void TileFetcherShouldRequestAllTilesJustOnes()
+    public async Task TileFetcherShouldRequestAllTilesJustOnesAsync()
     {
         // Arrange
         var tileSource = new CountingTileSource();
@@ -35,7 +35,7 @@ public class FetchMachineTests
         // Get all tiles of level 3
         fetchDispatcher.RefreshData(fetchInfo);
         // Assert
-        while (fetchDispatcher.Busy) { Thread.Sleep(1); }
+        while (fetchDispatcher.Busy) { await Task.Delay(10); }
 
         ClassicAssert.AreEqual(expectedTiles, tileSource.CountByTile.Keys.Count);
         ClassicAssert.AreEqual(expectedTiles, tileSource.CountByTile.Values.Sum());


### PR DESCRIPTION
Done:
- Started out to set AllowSynchronousContinuations to true for the Channels because this it can improve performance if you do not have to synchronize back. I have seen a significant performance because of this in another project.
- This change mentioned above exposed an existing bug. A unit test that tested on TileLayer.Buzy failed because Buzy did not go back to false. This turned out to be a flaw in the design. There is a form of recursion in the fetch logic, at the end of the recursively called methods Busy was updated, but it was not guaranteed that the last method in the chain was also the last one to update Busy.
- To fix the bug there was a substantial rewrite of the fetch logic. The flow is now this: In the DataChange calculates which tiles need to be fetched and puts their tileInfos in a ConcurrentHashSet. A fetch process is started witch will continue until all tileInfos in that set are fetched (or failed).
- Add ChangeType to OnRefreshDataRequest to be used in the future. I now think we should send more requests for ChangeType.Continuous and have a way to throttle the calls to the ILayer.DataChanged
- Unrelated: Make the Widgets.Add not return the added value because you have to explicitly ignore the result most of the time.
- Unrelated: Set the number of line in the logging widget to 10 because you could not see the new entries of it scrolled out of view.
