### PR TITLE
Issue 2926 - Allow Microsoft.Bcl.AsyncInterfaces >= 8.0.0 in Mapsui 4.x (.NET Framework)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,7 +58,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="7.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.5" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="[7.0.0,8.0.0)" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="[16.11.0,17.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[16.9.4,17.0.0)" />


### PR DESCRIPTION
The only change made is to remove the version range on Microsoft.Bcl.AsyncInterfaces in Directory.Packages.Props. 
I'm not sure why it's showing 99 files changed. This should be a branch off of the 4.1.8 tag, but I couldn't select that in the branches dropdown when creating the pull request.

To test this I built Mapsui.sln locally without the restriction. Then in my application I removed the Mapsui packages listed below and updated my project to directly reference the assemblies I built. I verified that was working with Microsoft.Bcl.AsyncInterfaces 7.0.0. Then I upgraded to v9.0.3 using NuGet Manager, which updated both the references and assembly binding redirects. (Prior to my Directory.Packages.Props change this is where the failure happened; NuGet complained that Mapsui wasn't compatible with Microsoft.Bcl.AsyncInterfaces 9.0.3)
After upgrading I built and ran my app and tested my maps, and everything appeared to be ok.

Whenever you upgrade Microsoft.Bcl.AsyncInterfaces, the package goes through all of your projects and updates the assembly binding redirects. It seems like Microsoft is pretty confident that there are no forward or backward incompatibilities to worry about. I suspect my change to Mapsui is pretty safe.
