### PR TITLE
Refactoring as follow up on the cache bug

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaStyles/RasterStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/RasterStyleRenderer.cs
@@ -24,9 +24,9 @@ public class RasterStyleRenderer : ISkiaStyleRenderer
                 return false;
 
             if (style is not RasterStyle)
-                return false;
+                throw new ArgumentException("Excepted a RasterStyle in the RasterStyleRenderer");
 
-            var tileCache = (TileCache)renderService.TileCache;
+            var tileCache = renderService.TileCache;
             tileCache.UpdateCache(currentIteration);
 
             var tile = tileCache.GetOrCreate(raster, currentIteration);

--- a/Mapsui.Tiling/Layers/RasterizingTileLayer.cs
+++ b/Mapsui.Tiling/Layers/RasterizingTileLayer.cs
@@ -61,7 +61,7 @@ public class RasterizingTileLayer : TileLayer, ISourceLayer, IAsyncDataFetcher, 
         Name = layer.Name;
         SourceLayer.DataChanged += (s, e) =>
         {
-            ClearCache();
+            ClearCache(); // It would cause less flicker if we could invalidate the tiles so that they could still be used by the renderer but would be replaced by the fetcher.
             DataHasChanged();
             if (_currentExtent != null && _currentResolution != null)
             {

--- a/Mapsui/Features/RasterFeature.cs
+++ b/Mapsui/Features/RasterFeature.cs
@@ -25,7 +25,7 @@ public class RasterFeature : BaseFeature, IFeature
     /// <summary>
     /// Extent of feature
     /// </summary>
-    public override MRect? Extent => Raster;
+    public override MRect? Extent => Raster?.Extent;
 
     /// <summary>
     /// Implementation of visitor pattern for coordinates
@@ -34,7 +34,7 @@ public class RasterFeature : BaseFeature, IFeature
     public override void CoordinateVisitor(Action<double, double, CoordinateSetter> visit)
     {
         if (Raster != null)
-            foreach (var point in new[] { Raster.Min, Raster.Max })
+            foreach (var point in new[] { Raster.Extent.Min, Raster.Extent.Max })
                 visit(point.X, point.Y, (x, y) =>
                 {
                     point.X = x;

--- a/Mapsui/Layers/RasterizingLayer.cs
+++ b/Mapsui/Layers/RasterizingLayer.cs
@@ -117,7 +117,7 @@ public class RasterizingLayer : BaseLayer, IAsyncDataFetcher, ISourceLayer
         // Use a larger extent so that symbols partially outside of the extent are included
         var biggerBox = box.Grow(resolution * SymbolSize * 0.5);
 
-        return features.Where(f => f.Raster != null && f.Raster.Intersects(biggerBox)).ToList();
+        return features.Where(f => f.Raster != null && f.Raster.Extent.Intersects(biggerBox)).ToList();
     }
 
     public void AbortFetch()

--- a/Mapsui/MRaster.cs
+++ b/Mapsui/MRaster.cs
@@ -2,20 +2,23 @@ using System;
 
 namespace Mapsui;
 
-public class MRaster : MRect
+public class MRaster
 {
-    public MRaster(MRaster raster) : base(raster.Min.X, raster.Min.Y, raster.Max.X, raster.Max.Y)
+    public byte[] Data { get; }
+    public long TickFetched { get; }
+    public MRect Extent { get; }
+
+    public MRaster(MRaster raster)
     {
         Data = raster.Data;
         TickFetched = raster.TickFetched;
+        Extent = raster.Extent.Copy();
     }
 
-    public MRaster(byte[] data, MRect rect) : base(rect)
+    public MRaster(byte[] data, MRect extent)
     {
         Data = data;
         TickFetched = DateTime.Now.Ticks;
+        Extent = extent.Copy();
     }
-
-    public byte[] Data { get; }
-    public long TickFetched { get; }
 }

--- a/Mapsui/MRect.cs
+++ b/Mapsui/MRect.cs
@@ -5,6 +5,29 @@ namespace Mapsui;
 
 public class MRect : IEquatable<MRect>
 {
+    public MPoint Max { get; }
+    public MPoint Min { get; }
+
+    public double MaxX => Max.X;
+    public double MaxY => Max.Y;
+    public double MinX => Min.X;
+    public double MinY => Min.Y;
+
+    public MPoint Centroid => new(Min.X + Width * 0.5, Min.Y + Height * 0.5);
+
+    public double Width => Max.X - Min.X;
+    public double Height => Max.Y - Min.Y;
+
+    public double Bottom => Min.Y;
+    public double Left => Min.X;
+    public double Top => Max.Y;
+    public double Right => Max.X;
+
+    public MPoint TopLeft => new(Left, Top);
+    public MPoint TopRight => new(Right, Top);
+    public MPoint BottomLeft => new(Left, Bottom);
+    public MPoint BottomRight => new(Right, Bottom);
+
     public MRect(double minX, double minY, double maxX, double maxY)
     {
         Min = new MPoint(minX, minY);
@@ -22,8 +45,8 @@ public class MRect : IEquatable<MRect>
     {
         foreach (var rect in rects)
         {
-            if (Min is null) Min = rect.Min.Copy();
-            if (Max is null) Max = rect.Max.Copy();
+            Min ??= rect.Min.Copy();
+            Max ??= rect.Max.Copy();
 
             Min.X = Math.Min(Min.X, rect.Min.X);
             Min.Y = Math.Min(Min.Y, rect.Min.Y);
@@ -35,28 +58,6 @@ public class MRect : IEquatable<MRect>
         if (Max == null) throw new ArgumentException("Empty Collection", nameof(rects));
     }
 
-    public MPoint Max { get; }
-    public MPoint Min { get; }
-
-    public double MaxX => Max.X;
-    public double MaxY => Max.Y;
-    public double MinX => Min.X;
-    public double MinY => Min.Y;
-
-    public MPoint Centroid => new MPoint(Min.X + Width * 0.5, Min.Y + Height * 0.5);
-
-    public double Width => Max.X - Min.X;
-    public double Height => Max.Y - Min.Y;
-
-    public double Bottom => Min.Y;
-    public double Left => Min.X;
-    public double Top => Max.Y;
-    public double Right => Max.X;
-
-    public MPoint TopLeft => new MPoint(Left, Top);
-    public MPoint TopRight => new MPoint(Right, Top);
-    public MPoint BottomLeft => new MPoint(Left, Bottom);
-    public MPoint BottomRight => new MPoint(Right, Bottom);
 
     /// <summary>
     ///     Returns the vertices in clockwise order from bottom left around to bottom right
@@ -129,7 +130,6 @@ public class MRect : IEquatable<MRect>
         return grownBox;
     }
 
-
     public bool Intersects(MRect? rect)
     {
         if (rect is null) return false;
@@ -193,18 +193,6 @@ public class MRect : IEquatable<MRect>
         return quad.Rotate(degrees, center.X, center.Y);
     }
 
-    private void SwapMinAndMaxIfNeeded()
-    {
-        if (Min.X > Max.X)
-        {
-            (Min.X, Max.X) = (Max.X, Min.X);
-        }
-        if (Min.Y > Max.Y)
-        {
-            (Min.Y, Max.Y) = (Max.Y, Min.Y);
-        }
-    }
-
     /// <summary>
     ///     Returns a string representation of the vertices from bottom-left and top-right
     /// </summary>
@@ -250,5 +238,17 @@ public class MRect : IEquatable<MRect>
     public static bool operator !=(MRect? left, MRect? right)
     {
         return !Equals(left, right);
+    }
+
+    private void SwapMinAndMaxIfNeeded()
+    {
+        if (Min.X > Max.X)
+        {
+            (Min.X, Max.X) = (Max.X, Min.X);
+        }
+        if (Min.Y > Max.Y)
+        {
+            (Min.Y, Max.Y) = (Max.Y, Min.Y);
+        }
     }
 }


### PR DESCRIPTION
When debugging the ['repeated cache misses bug'](https://github.com/Mapsui/Mapsui/pull/2947) I initially through it was caused by a bug in the Equals and GetHashCode implementation. This was hard to follow because the base class of MRaster (which was used as cache key) was inherited from MRect. 

In this PR I changed this to make MRect a field (called Extent), this makes it easier to understand for me, and as they say, you should favor composition over inheritance. 