### PR TITLE
Prevent touch and mouse wheel propagation in Blazor

### DIFF
--- a/Mapsui.UI.Blazor/MapControlComponent.razor
+++ b/Mapsui.UI.Blazor/MapControlComponent.razor
@@ -1,9 +1,13 @@
 ﻿@inherits MapControl
 
-<div @onmouseup=@OnMouseUp @onmousedown=@OnMouseDown 
-     @onmousewheel=@OnMouseWheel @onmousemove=@OnMouseMove 
-     @ontouchstart=@OnTouchStart @ontouchmove=@OnTouchMove @ontouchend=@OnTouchEnd
-     @onwheel="OnMouseWheel" 
+<div @onmouseup=@OnMouseUp @onmouseup:preventDefault="true"
+     @onmousedown=@OnMouseDown @onmousedown:preventDefault="true" 
+     @onmousewheel=@OnMouseWheel @onmousewheel:preventDefault="true"
+     @onmousemove=@OnMouseMove @onmousemove:preventDefault="true" 
+     @ontouchstart=@OnTouchStart @ontouchstart:preventDefault="true" 
+     @ontouchmove=@OnTouchMove @ontouchmove:preventDefault="true"
+     @ontouchend=@OnTouchEnd @ontouchend:preventDefault="true"
+     @onwheel="OnMouseWheel" @onwheel:preventDefault="true"
      name="@_elementId" id="@_elementId">
 @if (MapControl.UseGPU)
 {

--- a/Samples/Mapsui.Samples.Blazor/Pages/Index.razor
+++ b/Samples/Mapsui.Samples.Blazor/Pages/Index.razor
@@ -1,4 +1,4 @@
-﻿@page "/{CategoryInRoute?}/{SampleInRoute?}"
+﻿@page "/"
 
 <PageTitle>Mapsui</PageTitle>
    <div class="form-group row">
@@ -27,9 +27,6 @@
         </InputSelect>
     </div>
 </div>
-
-<p>Category in route: @CategoryInRoute</p>
-<p>Category in route: @SampleInRoute</p>
 
 <div class="tabs">
     <div class="tab @(_activeTab == 0 ? "active" : "")" @onclick="(() => SetActiveTab(0))">Map</div>


### PR DESCRIPTION
Done:
- Prevent touch and mouse wheel propagation in Blazor. The same code that worked in the previous version of Blazor somehow did not anymore. It is now fixed in a different way.
- Use UseContinuousMouseWheelZoom because without it it can unusable from a touch pad.
- Select a sample through query parameters instead of the route, because the route solution was blocked by the server.
- Fixed a bug that I introduced in the previous weeks in loading samples after selecting a category.
- Removed temp code introduced recently.