### PR TITLE
Fix error in logging the MaxTilesInOneRequest check

### DIFF
--- a/Mapsui.Tiling/Fetcher/TileFetchDispatcher.cs
+++ b/Mapsui.Tiling/Fetcher/TileFetchDispatcher.cs
@@ -142,11 +142,12 @@ public class TileFetchDispatcher(
 
         if (tilesToFetch.Count() > MaxTilesInOneRequest)
         {
-            tilesToFetch = tilesToFetch.Take(MaxTilesInOneRequest).ToList();
             Logger.Log(LogLevel.Warning,
                 $"The number tiles requested is '{tilesToFetch.Count()}' which exceeds the maximum " +
                 $"of '{MaxTilesInOneRequest}'. The number of tiles will be limited to the maximum. Note, " +
                 $"that this may indicate a bug or configuration error");
+
+            tilesToFetch = tilesToFetch.Take(MaxTilesInOneRequest).ToList();
         }
 
         var hashSet = new ConcurrentHashSet<TileInfo>();


### PR DESCRIPTION
I still see this log message in some apps, but the number of tiles requested is not shown, just the maximized number. It is not impossible that you sometimes need 128 tiles (this depends on screen size but also the data fetch strategy), but it could be a flaw in the calculation, if it is a really big number that is more likely.