### PR TITLE
Use ToArray instead of [.. myCollection] syntax

### DIFF
--- a/Mapsui.Nts/Editing/EditManager.cs
+++ b/Mapsui.Nts/Editing/EditManager.cs
@@ -42,7 +42,7 @@ public class EditManager
         if (EditMode == EditMode.DrawingLine)
         {
             _addInfo.Vertices.RemoveAt(_addInfo.Vertices.Count - 1); // Remove the last vertex, because it is the hover vertex
-            _addInfo.Feature.Geometry = new LineString([.. _addInfo.Vertices]);
+            _addInfo.Feature.Geometry = new LineString(_addInfo.Vertices.ToArray());
 
             _addInfo.Feature = null;
             _addInfo.Vertex = null;
@@ -56,7 +56,7 @@ public class EditManager
             _addInfo.Vertices.RemoveAt(_addInfo.Vertices.Count - 1); // Remove the last vertex, because it is the hover vertex
             var linearRing = _addInfo.Vertices.ToList();
             linearRing.Add(linearRing[0].Copy()); // Add first coordinate at end to close the ring.
-            _addInfo.Feature.Geometry = new Polygon(new LinearRing([.. linearRing]));
+            _addInfo.Feature.Geometry = new Polygon(new LinearRing(linearRing.ToArray()));
 
             _addInfo.Feature.Modified(); // You need to clear the cache to see changes.
             _addInfo.Feature = null;
@@ -106,7 +106,7 @@ public class EditManager
             _addInfo.Vertex.SetXY(worldPosition);
             _addInfo.Vertex = worldPosition.Copy(); // and create a new hover vertex
             _addInfo.Vertices.Add(_addInfo.Vertex);
-            _addInfo.Feature.Geometry = new LineString([.. _addInfo.Vertices]);
+            _addInfo.Feature.Geometry = new LineString(_addInfo.Vertices.ToArray());
 
             _addInfo.Feature?.Modified();
             Layer?.DataHasChanged();
@@ -146,7 +146,7 @@ public class EditManager
     {
         var linearRing = vertices.ToList();
         linearRing.Add(linearRing[0]); // Add first coordinate at end to close the ring.
-        return new LinearRing([.. linearRing]);
+        return new LinearRing(linearRing.ToArray());
     }
 
     private static Coordinate? FindVertexTouched(MapInfo mapInfo, IEnumerable<Coordinate> vertices, double screenDistance)

--- a/Mapsui.Nts/Providers/Shapefile/ShapeFile.cs
+++ b/Mapsui.Nts/Providers/Shapefile/ShapeFile.cs
@@ -781,7 +781,7 @@ public class ShapeFile : IProvider, IDisposable, IProviderExtended
             for (var i = 0; i < nPoints; i++)
                 points.Add(new Point(_brShapeFile.ReadDouble(), _brShapeFile.ReadDouble()));
 
-            return new MultiPoint([.. points]);
+            return new MultiPoint(points.ToArray());
         }
         if (_shapeType == ShapeType.PolyLine || _shapeType == ShapeType.Polygon ||
             _shapeType == ShapeType.PolyLineM || _shapeType == ShapeType.PolygonM ||
@@ -809,11 +809,11 @@ public class ShapeFile : IProvider, IDisposable, IProviderExtended
                     var coordinates = new List<Coordinate>();
                     for (var i = segments[lineId]; i < segments[lineId + 1]; i++)
                         coordinates.Add(new Coordinate(_brShapeFile.ReadDouble(), _brShapeFile.ReadDouble()));
-                    lineStrings.Add(new LineString([.. coordinates]));
+                    lineStrings.Add(new LineString(coordinates.ToArray()));
                 }
                 if (lineStrings.Count == 1)
                     return lineStrings[0];
-                return new MultiLineString([.. lineStrings]);
+                return new MultiLineString(lineStrings.ToArray());
             }
             else
             {
@@ -824,7 +824,7 @@ public class ShapeFile : IProvider, IDisposable, IProviderExtended
                     var ring = new List<Coordinate>();
                     for (var i = segments[ringId]; i < segments[ringId + 1]; i++)
                         ring.Add(new Coordinate(_brShapeFile.ReadDouble(), _brShapeFile.ReadDouble()));
-                    rings.Add(new LinearRing([.. ring]));
+                    rings.Add(new LinearRing(ring.ToArray()));
                 }
                 var isCounterClockWise = new bool[rings.Count];
                 var polygonCount = 0;
@@ -858,7 +858,7 @@ public class ShapeFile : IProvider, IDisposable, IProviderExtended
                     var p = CreatePolygon(linearRings);
                     if (p is not null) polygons.Add(p);
 
-                    return new MultiPolygon([.. polygons]);
+                    return new MultiPolygon(polygons.ToArray());
                 }
             }
         }

--- a/Mapsui.Nts/Providers/Wfs/Utilities/GeometryFactories.cs
+++ b/Mapsui.Nts/Providers/Wfs/Utilities/GeometryFactories.cs
@@ -433,7 +433,7 @@ internal class LineStringFactory : GeometryFactory
                     (GeometryReader = GetSubReaderOf(FeatureReader, labelValues, lineStringNode, CoordinatesNode)) !=
                     null)
                 {
-                    Geometries.Add(new LineString([.. ParseCoordinates(GeometryReader)]));
+                    Geometries.Add(new LineString(ParseCoordinates(GeometryReader).ToArray()));
                     geometryFound = true;
                 }
                 if (geometryFound) features.Add(AddLabel(labelValues, Geometries[^1]));
@@ -511,19 +511,19 @@ internal class PolygonFactory : GeometryFactory
                     XmlReader? outerBoundaryReader;
                     if ((outerBoundaryReader = GetSubReaderOf(
                             GeometryReader, null, outerBoundaryNodeAlt, linearRingNode, CoordinatesNode)) != null)
-                        exteriorRing = new LinearRing([.. ParseCoordinates(outerBoundaryReader)]);
+                        exteriorRing = new LinearRing(ParseCoordinates(outerBoundaryReader).ToArray());
 
                     var holes = new List<LinearRing>();
                     XmlReader? innerBoundariesReader;
                     while ((innerBoundariesReader = GetSubReaderOf(
                                GeometryReader, null, innerBoundaryNodeAlt, linearRingNode, CoordinatesNode)) != null)
                         holes.Add(
-                            new LinearRing([.. ParseCoordinates(innerBoundariesReader)]));
+                            new LinearRing(ParseCoordinates(innerBoundariesReader).ToArray()));
 
                     if (exteriorRing is not null)
                     {
                         if (holes.Any())
-                            Geometries.Add(new Polygon(exteriorRing, [.. holes]));
+                            Geometries.Add(new Polygon(exteriorRing, holes.ToArray()));
                         else
                             Geometries.Add(new Polygon(exteriorRing));
                         geometryFound = true;

--- a/Mapsui/Features/BaseFeature.cs
+++ b/Mapsui/Features/BaseFeature.cs
@@ -1,6 +1,7 @@
 ﻿using Mapsui.Styles;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace Mapsui.Layers;
@@ -40,7 +41,7 @@ public abstract class BaseFeature : IFeature
 
     private void Copy(BaseFeature baseFeature)
     {
-        Styles = [.. baseFeature.Styles];
+        Styles = baseFeature.Styles.ToArray();
         foreach (var field in baseFeature.Fields)
             this[field] = baseFeature[field];
     }

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -113,7 +113,7 @@ public class Map : INotifyPropertyChanged, IDisposable
                 }
             }
 
-            _oldWidgets = [.. Widgets];
+            _oldWidgets = Widgets.ToArray();
 
             foreach (var widget in Widgets)
             {
@@ -328,7 +328,7 @@ public class Map : INotifyPropertyChanged, IDisposable
     private static MMinMax? GetMinMaxResolution(IEnumerable<double>? resolutions)
     {
         if (resolutions == null || !resolutions.Any()) return null;
-        resolutions = [.. resolutions.OrderByDescending(r => r)];
+        resolutions = resolutions.OrderByDescending(r => r).ToArray();
         var mostZoomedOut = resolutions.First();
         var mostZoomedIn = resolutions.Last() * 0.5; // Divide by two to allow one extra level to zoom-in
         return new MMinMax(mostZoomedOut, mostZoomedIn);
@@ -365,7 +365,7 @@ public class Map : INotifyPropertyChanged, IDisposable
             }
         }
 
-        return [.. items.Select(i => i.Value).OrderByDescending(i => i)];
+        return items.Select(i => i.Value).OrderByDescending(i => i).ToArray();
     }
 
     private void LayerPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/Mapsui/MapInfo.cs
+++ b/Mapsui/MapInfo.cs
@@ -48,5 +48,5 @@ public class MapInfo(ScreenPosition screenPosition, MPoint worldPosition, double
     public double Resolution { get; } = resolution;
 
     /// <summary> List of MapInfo Records </summary>
-    public IEnumerable<MapInfoRecord> MapInfoRecords => _mapInfoRecords ??= [.. _records];
+    public IEnumerable<MapInfoRecord> MapInfoRecords => _mapInfoRecords ??= _records.ToArray();
 }

--- a/Mapsui/Providers/Wms/Client.cs
+++ b/Mapsui/Providers/Wms/Client.cs
@@ -426,7 +426,7 @@ public class Client
             var rootLayer = layers[0];
             rootLayer.Name = "__auto_generated_root_layer__";
             rootLayer.Title = "";
-            rootLayer.ChildLayers = [.. layers];
+            rootLayer.ChildLayers = layers.ToArray();
             _layer = rootLayer;
         }
         else
@@ -663,7 +663,7 @@ public class Client
         var crsList = new List<string>();
 
         if (_nsmgr == null)
-            return [.. crsList];
+            return crsList.ToArray();
 
         using var xnlSrs = xmlLayer.SelectNodes("sm:SRS", _nsmgr);
         if (xnlSrs != null)
@@ -679,6 +679,6 @@ public class Client
                 crsList.Add(xnlCrs[i]?.InnerText ?? string.Empty);
         }
 
-        return [.. crsList];
+        return crsList.ToArray();
     }
 }

--- a/Mapsui/Utilities/EmbeddedResourceLoader.cs
+++ b/Mapsui/Utilities/EmbeddedResourceLoader.cs
@@ -53,7 +53,7 @@ public static class EmbeddedResourceLoader
         if (similarNames.Length <= 0) return stringBuilder.ToString();
         var nameLength = assembly.GetAssemblyName()?.Length ?? 0;
         similarNames = similarNames.Select(fullName => fullName.Remove(0, nameLength + 1)).ToArray();
-        stringBuilder.Append(" Did you try to get any of these embedded resources: " + string.Join("\n ", [.. similarNames]) + ".");
+        stringBuilder.Append(" Did you try to get any of these embedded resources: " + string.Join("\n ", similarNames.ToArray()) + ".");
         return stringBuilder.ToString();
     }
 }

--- a/Samples/Mapsui.Samples.Common/Maps/Editing/EditingSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Editing/EditingSample.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using Mapsui.Extensions;
 using Mapsui.Layers;
 using Mapsui.Nts;
@@ -24,7 +23,7 @@ public class EditingSample : IMapControlSample
     private EditManager _editManager = new();
     private WritableLayer? _targetLayer;
     private IMapControl? _mapControl;
-    private List<IFeature>? _tempFeatures;
+    private IFeature[]? _tempFeatures;
 
     public string Name => "Editing";
     public string Category => "Editing";
@@ -224,7 +223,7 @@ public class EditingSample : IMapControlSample
             var features = _targetLayer?.GetFeatures().Copy() ?? [];
             foreach (var feature in features)
                 feature.Modified();
-            _tempFeatures = [.. features];
+            _tempFeatures = features.ToArray();
             _editManager.EditMode = EditMode.AddPolygon;
             e.Handled = true;
         }
@@ -245,7 +244,7 @@ public class EditingSample : IMapControlSample
             var features = _targetLayer?.GetFeatures().Copy() ?? [];
             foreach (var feature in features)
                 feature.Modified();
-            _tempFeatures = [.. features];
+            _tempFeatures = features.ToArray();
             _editManager.EditMode = EditMode.AddLine;
             e.Handled = true;
         }
@@ -266,7 +265,7 @@ public class EditingSample : IMapControlSample
             var features = _targetLayer?.GetFeatures().Copy() ?? [];
             foreach (var feature in features)
                 feature.Modified();
-            _tempFeatures = [.. features];
+            _tempFeatures = features.ToArray();
             _editManager.EditMode = EditMode.AddPoint;
             e.Handled = true;
         }
@@ -326,7 +325,7 @@ public class EditingSample : IMapControlSample
             foreach (var feature in features)
                 feature.Modified();
 
-            _tempFeatures = [.. features];
+            _tempFeatures = features.ToArray();
 
             _editManager.Layer?.AddRange(features);
             _targetLayer?.Clear();

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/CustomLayerRendererSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/CustomLayerRendererSample.cs
@@ -62,6 +62,6 @@ public class CustomLayerRendererSample : ISample
     }
 
     private static PointFeature[] CreateFeatures(MRect envelope, int count) =>
-        [.. RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
-        .Select(p => new PointFeature(p))];
+        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
+            .Select(p => new PointFeature(p)).ToArray();
 }


### PR DESCRIPTION
After working with it for a while I concluded that I prefer ToArray (or ToList). I like all the other variants of collection initializers but not this one. In a previous PR I disabled the suggestion for IDE0304. In this PR it is removed everywhere so that the code is consistent.