### PR TITLE
Try to fix blazor touch and wheel by disabling earlier

### DIFF
--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -71,6 +71,16 @@ public partial class MapControl : ComponentBase, IMapControl
         RefreshGraphics();
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+        if (firstRender)
+        {
+            await InitializingInteropAsync();
+            _ = UpdateBoundingRectAsync();
+        }
+    }
+
     protected void OnPaintSurfaceCPU(SKPaintSurfaceEventArgs e)
     {
         // the the canvas and properties


### PR DESCRIPTION
Touch on the map should not propagate to the rest of the website. There are ways to disable this is to use e.preventDefault(), that is what we do, but then it works locally but not on the samples website. Now trying to disable it earlier.