### PR TITLE
Fix white map on startup in MAUI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <Version>5.0.0-beta3.11</Version>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Copyright>Copyright © Mapsui Developers 2018-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+    <Version>5.0.0-beta3.11</Version>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Copyright>Copyright © Mapsui Developers 2018-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -163,7 +163,7 @@ public partial class MapControl : ComponentBase, IMapControl
             await Interop.DisableTouchAsync(_elementId);
             _pixelDensityFromInterop = await Interop.GetPixelDensityAsync();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             Console.WriteLine("An exception occurred in InitializingInteropAsync");
         }

--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -6,7 +6,6 @@ using Microsoft.JSInterop;
 using SkiaSharp;
 using SkiaSharp.Views.Blazor;
 using Microsoft.AspNetCore.Components;
-using System;
 
 namespace Mapsui.UI.Blazor;
 
@@ -158,7 +157,7 @@ public partial class MapControl : ComponentBase, IMapControl
             throw new ArgumentException("Interop is null");
         }
 
-        try 
+        try
         {
             await Interop.DisableMouseWheelAsync(_elementId);
             await Interop.DisableTouchAsync(_elementId);
@@ -166,7 +165,7 @@ public partial class MapControl : ComponentBase, IMapControl
         }
         catch (Exception ex)
         {
-             Console.WriteLine("An exception occurred in InitializingInteropAsync");
+            Console.WriteLine("An exception occurred in InitializingInteropAsync");
         }
     }
 

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -125,6 +125,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     private void SharedConstructor()
     {
         PlatformUtilities.SetOpenInBrowserFunc(OpenInBrowser);
+        Map = new Map();
         // Create timer for invalidating the control
         _invalidateTimer?.Dispose();
         _invalidateTimer = new (InvalidateTimerCallback, null, Timeout.Infinite, 16);
@@ -423,7 +424,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         var mapControl = (MapControl)bindable;
         mapControl.AfterSetMap((Map)newValue);
     }
-    
+
     public Map Map
     {
         get => (Map)GetValue(MapProperty);

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -423,21 +423,10 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         var mapControl = (MapControl)bindable;
         mapControl.AfterSetMap((Map)newValue);
     }
-
-
+    
     public Map Map
     {
-        get
-        {
-            if (GetValue(MapProperty) is not Map map)
-            {
-                _map ??= new DisposableWrapper<Map>(new Map(), true);
-                map = _map.WrappedObject;
-                SetValue(MapProperty, map);
-            }
-
-            return map;
-        }
+        get => (Map)GetValue(MapProperty);
         set => SetValue(MapProperty, value);
     }
 

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -537,10 +537,13 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private void SetViewportSize()
     {
-        var hadSize = Map.Navigator.Viewport.HasSize();
-        Map.Navigator.SetSize(ViewportWidth, ViewportHeight);
-        if (!hadSize && Map.Navigator.Viewport.HasSize()) Map.OnViewportSizeInitialized();
-        Refresh();
+        if (Map is Map map)
+        {
+            var hadSize = map.Navigator.Viewport.HasSize();
+            map.Navigator.SetSize(ViewportWidth, ViewportHeight);
+            if (!hadSize && map.Navigator.Viewport.HasSize()) map.OnViewportSizeInitialized();
+            Refresh();
+        }
     }
 
     private void CommonDispose(bool disposing)


### PR DESCRIPTION
- At startup the BindingProperty for Map could be set twice. Now simplifying back to the original code. 
- Also rewrote a workaround for size initialization to the regular way that is now possible.