### PR TITLE
Fix PointFeature extent projection

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaWidgets/ScaleBarWidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/ScaleBarWidgetRenderer.cs
@@ -83,7 +83,7 @@ public class ScaleBarWidgetRenderer : ISkiaWidgetRenderer, IDisposable
 
         if (!points.Any()) throw new NotImplementedException($"A {nameof(ScaleBarWidget)} can not be drawn without line positions");
 
-        var envelop = new MRect(points.Select(p => p.GetExtent()));
+        var envelop = new MRect(points.Select(p => new MRect(p.X, p.Y)));
         envelop = envelop.Grow(scaleBar.StrokeWidthHalo * 0.5f * scaleBar.Scale);
 
         // Draw text

--- a/Mapsui/Features/PointFeature.cs
+++ b/Mapsui/Features/PointFeature.cs
@@ -10,13 +10,13 @@ public class PointFeature : BaseFeature, IFeature
     public PointFeature(PointFeature pointFeature) : base(pointFeature)
     {
         Point = new MPoint(pointFeature.Point);
-        Extent = Point.GetExtent();
+        Extent = new MRect(Point.X, Point.Y);
     }
 
     public PointFeature(MPoint point)
     {
         Point = point ?? throw new ArgumentNullException(nameof(point));
-        Extent = Point.GetExtent();
+        Extent = new MRect(Point.X, Point.Y);
     }
 
     public PointFeature(double x, double y) : this(new MPoint(x, y))
@@ -49,6 +49,8 @@ public class PointFeature : BaseFeature, IFeature
             Extent.Min.Y = y;
             Extent.Max.X = x;
             Extent.Max.Y = y;
+            Extent.Centroid.X = x;
+            Extent.Centroid.Y = y;
         });
     }
 

--- a/Mapsui/Features/PointFeature.cs
+++ b/Mapsui/Features/PointFeature.cs
@@ -45,6 +45,10 @@ public class PointFeature : BaseFeature, IFeature
         {
             Point.X = x;
             Point.Y = y;
+            Extent.Min.X = x;
+            Extent.Min.Y = y;
+            Extent.Max.X = x;
+            Extent.Max.Y = y;
         });
     }
 

--- a/Mapsui/MPoint.cs
+++ b/Mapsui/MPoint.cs
@@ -8,6 +8,9 @@ namespace Mapsui;
 /// </summary>
 public class MPoint : IEquatable<MPoint>
 {
+    public double X { get; set; }
+    public double Y { get; set; }
+
     public MPoint() : this(0, 0) { }
 
     public MPoint(double x, double y)
@@ -26,16 +29,6 @@ public class MPoint : IEquatable<MPoint>
     {
         X = point.X;
         Y = point.Y;
-    }
-
-    public double X { get; set; }
-
-    public double Y { get; set; }
-
-    // Creates an MRect with the point as both the minimum and maximum
-    public MRect GetExtent()
-    {
-        return new MRect(X, Y, X, Y);
     }
 
     public MPoint Copy()


### PR DESCRIPTION
This fixes a bug in this PR: https://github.com/Mapsui/Mapsui/pull/2951. That PR prevents creating a new MRect on every intersect calculation by storing it in the PointFeature. As a consequence an update of the MPoint (which we do when projecting) should also do an update to the MRect. That is fixed in this PR.

This bug would show if you use a CalloutStyle on a Layer that is wrapped in a projecting layer. It showed in callout styles and not most (any?) other styles because the CalloutStyleRenderer uses the PointFeature.Extent.Center while others use the coordinateVisitor.

Also: Removed MPoint.GetExtent() because it was confusing that the MRect contained MPoints that had an MRect that had ... etc. 

The bigger problem is that MPoint is mutable. To make it immutable we would have to rewrite the projection logic. Projecting should then not be part of the rendering phase but should be done earlier, when converting from raw data to features or converting from features to skia drawables.