### PR TITLE
Prevent crash when following the quickstart guide with a MAUI 9 default project

### DIFF
--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -32,6 +32,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
 
     public MapControl()
     {
+        UseGPU = !IsMaui9();
         SharedConstructor();
 
         View view;
@@ -68,6 +69,12 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
         }
         view.SizeChanged += View_SizeChanged;
         Content = view;
+    }
+
+    private bool IsMaui9()
+    {
+        var frameworkDescription = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+        return frameworkDescription.Contains(".NET 9");
     }
 
     private void View_SizeChanged(object? sender, EventArgs e)

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -20,7 +20,7 @@ namespace Mapsui.UI.Maui;
 /// </summary>
 public partial class MapControl : ContentView, IMapControl, IDisposable
 {
-    public static bool UseGPU = true;
+    public static bool UseGPU = !IsMaui9();
 
     private readonly SKGLView? _glView;
     private readonly SKCanvasView? _canvasView;
@@ -32,7 +32,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
 
     public MapControl()
     {
-        UseGPU = !IsMaui9();
         SharedConstructor();
 
         View view;
@@ -71,7 +70,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
         Content = view;
     }
 
-    private bool IsMaui9()
+    private static bool IsMaui9()
     {
         var frameworkDescription = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
         return frameworkDescription.Contains(".NET 9");


### PR DESCRIPTION
When running in .NET 9 MapControl.UseGPU is false by default, so that users creating a MAUI 9 app and follow the quickstart don't get a crash, because of: https://github.com/Mapsui/Mapsui/issues/2970.

This PR changes the default. It is still possible have UseGPU = true in MAUI 9 if you have some other project setup, like we do in our sample project.