### PR TITLE
Remove IWidget.NeedsRedraw

### DIFF
--- a/Mapsui.Rendering.Skia/SkiaWidgets/WidgetRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaWidgets/WidgetRenderer.cs
@@ -42,9 +42,6 @@ public static class WidgetRenderer
             }
 
             ((ISkiaWidgetRenderer)renderer).Draw(canvas, viewport, widget, renderService, layerOpacity);
-
-            // Widget is redrawn
-            widget.NeedsRedraw = false;
         }
     }
 }

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -151,13 +151,6 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
                 if (map.Navigator.UpdateAnimations()) // Are there animations running on the Navigator
                     _needsRefresh = true;
-
-                if (map.Widgets.Any(w => w.NeedsRedraw)) // Do the widgets require a redraw
-                {
-                    var w = (map.Widgets.Where(w => w.NeedsRedraw).FirstOrDefault());
-                    Console.WriteLine(w);
-                    _needsRefresh = true;
-                }
             }
 
             if (_needsRefresh)

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -40,7 +40,7 @@ public class Map : INotifyPropertyChanged, IDisposable
     {
         BackColor = Color.White;
         Layers = [];
-        Widgets.Add(CreateLoggingWidget());
+        Widgets.Add(CreateLoggingWidget(RefreshGraphics));
         Widgets.Add(CreatePerformanceWidget(this));
         Navigator.RefreshDataRequest += Navigator_RefreshDataRequest;
         Navigator.ViewportChanged += Navigator_ViewportChanged;
@@ -440,7 +440,7 @@ public class Map : INotifyPropertyChanged, IDisposable
         return areAnimationsRunning;
     }
 
-    private static LoggingWidget CreateLoggingWidget() => new()
+    private static LoggingWidget CreateLoggingWidget(Action refreshGraphics) => new(refreshGraphics)
     {
         Margin = new MRect(10),
         VerticalAlignment = VerticalAlignment.Stretch,

--- a/Mapsui/Widgets/BaseWidget.cs
+++ b/Mapsui/Widgets/BaseWidget.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 
 namespace Mapsui.Widgets;
 
 public abstract class BaseWidget : IWidget
 {
-    private HorizontalAlignment _horizontalAlignment = HorizontalAlignment.Right;
-
     /// <summary>
     /// Type of area to use for touch events. The default is WidgetArea. This needs to be set to 
     /// 'Map' in the constructor if widget want to receive manipulation events from all over the map.
@@ -16,141 +13,42 @@ public abstract class BaseWidget : IWidget
     /// <summary>
     /// Horizontal alignment of Widget
     /// </summary>
-    public HorizontalAlignment HorizontalAlignment
-    {
-        get => _horizontalAlignment;
-        set
-        {
-            if (_horizontalAlignment == value)
-                return;
-            _horizontalAlignment = value;
-            Invalidate();
-        }
-    }
-
-    private VerticalAlignment _verticalAlignment { get; set; } = VerticalAlignment.Bottom;
+    public HorizontalAlignment HorizontalAlignment { get; set; } = HorizontalAlignment.Right;
 
     /// <summary>
     /// Vertical alignment of Widget
     /// </summary>
-    public VerticalAlignment VerticalAlignment
-    {
-        get => _verticalAlignment;
-        set
-        {
-            if (_verticalAlignment == value)
-                return;
-            _verticalAlignment = value;
-            Invalidate();
-        }
-    }
-
-    private MRect _margin = new MRect(2);
+    public VerticalAlignment VerticalAlignment { get; set; } = VerticalAlignment.Bottom;
 
     /// <summary>
     /// Margin outside of the widget
     /// </summary>
-    public MRect Margin
-    {
-        get => _margin;
-        set
-        {
-            if (_margin == value)
-                return;
-            _margin = value;
-            Invalidate();
-        }
-    }
-
-    private MPoint _position = new MPoint(0, 0);
+    public MRect Margin { get; set; } = new(2);
 
     /// <summary>
     /// Position for absolute alignment
     /// </summary>
-    public MPoint Position
-    {
-        get => _position;
-        set
-        {
-            if (_position.Equals(value))
-                return;
-            _position = value;
-            Invalidate();
-        }
-    }
-
-    private double _width;
+    public MPoint Position { get; set; } = new MPoint(0, 0);
 
     /// <summary>
     /// Width of Widget
     /// </summary>
-    public double Width
-    {
-        get => _width;
-        set
-        {
-            if (_width == value)
-                return;
-            _width = value;
-            Invalidate();
-        }
-    }
-
-    private double _height;
+    public double Width { get; set; }
 
     /// <summary>
     /// Height of Widget
     /// </summary>
-    public double Height
-    {
-        get => _height;
-        set
-        {
-            if (_height == value)
-                return;
-            _height = value;
-            Invalidate();
-        }
-    }
-
-    private MRect? _envelope;
+    public double Height { get; set; }
 
     /// <summary>
     /// Envelope of Widget
     /// </summary>
-    public MRect? Envelope
-    {
-        get => _envelope;
-        set
-        {
-            if (_envelope == value)
-                return;
-            _envelope = value;
-            Invalidate();
-        }
-    }
-
-    private bool _enabled = true;
+    public MRect? Envelope { get; set; }
 
     /// <summary>
     /// Is Widget visible on screen
     /// </summary>
-    public bool Enabled
-    {
-        get => _enabled;
-        set
-        {
-            if (_enabled == value)
-                return;
-            _enabled = value;
-            Invalidate();
-        }
-    }
-
-    /// <summary>
-    /// Flag for redrawing widget in the next drawing cycle
-    /// </summary>
-    public bool NeedsRedraw { get; set; } = false;
+    public bool Enabled { get; set; } = true;
 
     public bool InputTransparent { get; init; }
 
@@ -202,11 +100,6 @@ public abstract class BaseWidget : IWidget
         var maxY = VerticalAlignment == VerticalAlignment.Stretch ? screenHeight - Margin.Bottom : minY + maxHeight;
 
         Envelope = new MRect(minX, minY, maxX, maxY);
-    }
-
-    public virtual void Invalidate([CallerMemberName] string name = "")
-    {
-        NeedsRedraw = true;
     }
 
     /// <inheritdoc/>

--- a/Mapsui/Widgets/BoxWidgets/BoxWidget.cs
+++ b/Mapsui/Widgets/BoxWidgets/BoxWidget.cs
@@ -7,54 +7,18 @@ namespace Mapsui.Widgets.BoxWidgets;
 /// </summary>
 public class BoxWidget : BaseWidget
 {
-    private double _cornerRadius = 8;
-
     /// <summary>
     /// Corner radius of box
     /// </summary>
-    public double CornerRadius
-    {
-        get => _cornerRadius;
-        set
-        {
-            if (_cornerRadius == value)
-                return;
-            _cornerRadius = value;
-            Invalidate();
-        }
-    }
-
-    private Color? _backColor = new(255, 255, 255, 128);
+    public double CornerRadius { get; set; } = 8;
 
     /// <summary>
     /// Background color of box
     /// </summary>
-    public Color? BackColor
-    {
-        get => _backColor;
-        set
-        {
-            if (_backColor == value)
-                return;
-            _backColor = value;
-            Invalidate();
-        }
-    }
-
-    private double _opacity = 0.8f;
+    public Color? BackColor { get; set; } = new(255, 255, 255, 128);
 
     /// <summary>
     /// Opacity of background, frame and signs
     /// </summary>
-    public double Opacity
-    {
-        get => _opacity;
-        set
-        {
-            if (_opacity == value)
-                return;
-            _opacity = value;
-            Invalidate();
-        }
-    }
+    public double Opacity { get; set; } = 0.8f;
 }

--- a/Mapsui/Widgets/BoxWidgets/TextBoxWidget.cs
+++ b/Mapsui/Widgets/BoxWidgets/TextBoxWidget.cs
@@ -7,71 +7,23 @@ namespace Mapsui.Widgets.BoxWidgets;
 /// </summary>
 public class TextBoxWidget : BoxWidget
 {
-    private MRect _padding = new(3);
-
     /// <summary>
     /// Padding for left, top, right and bottom for text inside the Widget
     /// </summary>
-    public MRect Padding
-    {
-        get => _padding;
-        set
-        {
-            if (_padding == value)
-                return;
-            _padding = value;
-            Invalidate();
-        }
-    }
-
-    private string? _text = string.Empty;
+    public MRect Padding { get; set; } = new(3);
 
     /// <summary>
     /// Text inside of box
     /// </summary>
-    public string? Text
-    {
-        get => _text;
-        set
-        {
-            if (_text == value)
-                return;
-            _text = value;
-            Invalidate();
-        }
-    }
-
-    private double _textSize = 12.0;
+    public string? Text { get; set; } = string.Empty;
 
     /// <summary>
     /// Font size of text inside of box
     /// </summary>
-    public double TextSize
-    {
-        get => _textSize;
-        set
-        {
-            if (_textSize == value)
-                return;
-            _textSize = value;
-            Invalidate();
-        }
-    }
-
-    private Color _textColor = new(0, 0, 0);
+    public double TextSize { get; set; } = 12.0;
 
     /// <summary>
     /// Text color of text inside of box
     /// </summary>
-    public Color TextColor
-    {
-        get => _textColor;
-        set
-        {
-            if (_textColor == value)
-                return;
-            _textColor = value;
-            Invalidate();
-        }
-    }
+    public Color TextColor { get; set; } = new(0, 0, 0);
 }

--- a/Mapsui/Widgets/ButtonWidgets/HyperlinkWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/HyperlinkWidget.cs
@@ -8,22 +8,10 @@ namespace Mapsui.Widgets.ButtonWidgets;
 /// </summary>
 public class HyperlinkWidget : ButtonWidget
 {
-    private string? _url = string.Empty;
-
     /// <summary>
     /// URL to open when Widget is clicked
     /// </summary>
-    public string? Url
-    {
-        get => _url;
-        set
-        {
-            if (_url == value)
-                return;
-            _url = value ?? string.Empty;
-            Invalidate();
-        }
-    }
+    public string? Url { get; set; } = string.Empty;
 
     public override void OnTapped(WidgetEventArgs e)
     {

--- a/Mapsui/Widgets/ButtonWidgets/ImageButtonWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/ImageButtonWidget.cs
@@ -13,56 +13,18 @@ public class ImageButtonWidget : BoxWidget, IHasImage
         BackColor = Color.Transparent;
     }
 
-    private MRect _padding = new(0);
-
     /// <summary>
     /// Padding left and right for icon inside the Widget
     /// </summary>
-    public MRect Padding
-    {
-        get => _padding;
-        set
-        {
-            if (_padding == value)
-                return;
-
-            _padding = value;
-            Invalidate();
-        }
-    }
-
-    private Image? _image;
+    public MRect Padding { get; set; } = new(0);
 
     /// <summary>
     /// The image to show as button
     /// </summary>
-    public Image? Image
-    {
-        get => _image;
-        set
-        {
-            if (_image == value)
-                return;
-
-            _image = value;
-            Invalidate();
-        }
-    }
-
-    private double _rotation;
+    public Image? Image { get; set; }
 
     /// <summary>
     /// Rotation of the SVG image
     /// </summary>
-    public double Rotation
-    {
-        get => _rotation;
-        set
-        {
-            if (_rotation == value)
-                return;
-            _rotation = value;
-            Invalidate();
-        }
-    }
+    public double Rotation { get; set; }
 }

--- a/Mapsui/Widgets/ButtonWidgets/ZoomInOutWidget.cs
+++ b/Mapsui/Widgets/ButtonWidgets/ZoomInOutWidget.cs
@@ -22,107 +22,35 @@ namespace Mapsui.Widgets.ButtonWidgets;
 /// </summary>
 public class ZoomInOutWidget : BaseWidget
 {
-    private double _size = 40;
-
     /// <summary>
     /// Width and height of buttons
     /// </summary>
-    public double Size
-    {
-        get => _size;
-        set
-        {
-            if (_size == value)
-                return;
-            _size = value;
-            Invalidate();
-        }
-    }
-
-    private Orientation _orientation = Orientation.Vertical;
+    public double Size { get; set; } = 40;
 
     /// <summary>
     /// Orientation of buttons
     /// </summary>
-    public Orientation Orientation
-    {
-        get => _orientation;
-        set
-        {
-            if (_orientation == value)
-                return;
-            _orientation = value;
-            Invalidate();
-        }
-    }
-
-    private Color _strokeColor = new(192, 192, 192);
+    public Orientation Orientation { get; set; } = Orientation.Vertical;
 
     /// <summary>
     /// Color of button frames
     /// </summary>
-    public Color StrokeColor
-    {
-        get => _strokeColor;
-        set
-        {
-            if (_strokeColor == value)
-                return;
-            _strokeColor = value;
-            Invalidate();
-        }
-    }
-
-    private Color _textColor = new(192, 192, 192);
+    public Color StrokeColor { get; set; } = new(192, 192, 192);
 
     /// <summary>
     /// Color of "+" and "-" sign
     /// </summary>
-    public Color TextColor
-    {
-        get => _textColor;
-        set
-        {
-            if (_textColor == value)
-                return;
-            _textColor = value;
-            Invalidate();
-        }
-    }
-
-    private Color _backColor = new(224, 224, 224);
+    public Color TextColor { get; set; } = new(192, 192, 192);
 
     /// <summary>
     /// Color of background
     /// </summary>
-    public Color BackColor
-    {
-        get => _backColor;
-        set
-        {
-            if (_backColor == value)
-                return;
-            _backColor = value;
-            Invalidate();
-        }
-    }
-
-    private double _opacity = 0.8f;
+    public Color BackColor { get; set; } = new(224, 224, 224);
 
     /// <summary>
     /// Opacity of background, frame and signs
     /// </summary>
-    public double Opacity
-    {
-        get => _opacity;
-        set
-        {
-            if (_opacity == value)
-                return;
-            _opacity = value;
-            Invalidate();
-        }
-    }
+    public double Opacity { get; set; } = 0.8f;
 
     public override void OnTapped(WidgetEventArgs e)
     {

--- a/Mapsui/Widgets/IWidget.cs
+++ b/Mapsui/Widgets/IWidget.cs
@@ -45,11 +45,6 @@ public interface IWidget
     bool Enabled { get; set; }
 
     /// <summary>
-    /// Flag for redrawing widget in the next drawing cycle
-    /// </summary>
-    bool NeedsRedraw { get; set; }
-
-    /// <summary>
     /// Type of area used for  manipulation (e.g. touch, mouse) input events.
     /// </summary>
     InputAreaType InputAreaType { get; }

--- a/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
@@ -22,7 +22,7 @@ public class LoggingWidget : TextBoxWidget
         public string FormattedLogLine;
     }
 
-    public LoggingWidget()
+    public LoggingWidget(Action refreshGraphics)
     {
         _listOfLogEntries = new ConcurrentQueue<LogEntry>();
 
@@ -32,6 +32,7 @@ public class LoggingWidget : TextBoxWidget
         Width = 250;
         Height = 142;
         InputTransparent = true;
+        _refreshGraphics = refreshGraphics;
     }
 
     /// <summary>
@@ -55,12 +56,12 @@ public class LoggingWidget : TextBoxWidget
 
         _listOfLogEntries.Enqueue(entry);
 
-        while (_listOfLogEntries.Count > _maxNumberOfLogEntriesToKeep)
+        while (_listOfLogEntries.Count > MaxNumberOfLogEntriesToKeep)
         {
             _listOfLogEntries.TryDequeue(out var _);
         }
 
-        Invalidate(nameof(Text));
+        _refreshGraphics();
     }
 
     private string ToFormattedLogLine(LogLevel level, string description, Exception? exception)
@@ -89,95 +90,36 @@ public class LoggingWidget : TextBoxWidget
             _listOfLogEntries.TryDequeue(out var _);
         }
 
-        Invalidate(nameof(Text));
+        _refreshGraphics();
     }
 
     private readonly ConcurrentQueue<LogEntry> _listOfLogEntries;
+    private readonly Action _refreshGraphics;
 
     public ConcurrentQueue<LogEntry> ListOfLogEntries => _listOfLogEntries;
-
-    private LogLevel _logLevelFilter = LogLevel.Information;
 
     /// <summary>
     /// Filter for LogLevel
     /// Only this or higher levels are printed
     /// </summary>
-    public LogLevel LogLevelFilter
-    {
-        get => _logLevelFilter;
-        set
-        {
-            if (_logLevelFilter == value)
-                return;
-            _logLevelFilter = value;
-            Invalidate();
-        }
-    }
+    public LogLevel LogLevelFilter { get; set; } = LogLevel.Information;
 
-    private int _maxNumberOfLogEntriesToKeep = 10;
-
-    public int MaxNumberOfLogEntriesToKeep
-    {
-        get => _maxNumberOfLogEntriesToKeep;
-        set
-        {
-            if (_maxNumberOfLogEntriesToKeep == value)
-                return;
-            _maxNumberOfLogEntriesToKeep = value;
-            Invalidate();
-        }
-    }
-
-    private Color _errorTextColor = Color.Red;
+    public int MaxNumberOfLogEntriesToKeep { get; set; } = 10;
 
     /// <summary>
     /// Color for errors
     /// </summary>
-    public Color ErrorTextColor
-    {
-        get => _errorTextColor;
-        set
-        {
-            if (_errorTextColor == value)
-                return;
-            _errorTextColor = value;
-            Invalidate();
-        }
-    }
-
-    private Color _warningTextColor = Color.Orange;
+    public Color ErrorTextColor = Color.Red;
 
     /// <summary>
     /// Color for warnings
     /// </summary>
-    public Color WarningTextColor
-    {
-        get => _warningTextColor;
-        set
-        {
-            if (_warningTextColor == value)
-                return;
-            _warningTextColor = value;
-            Invalidate();
-        }
-    }
-
-    private Color _informationTextColor = Color.Black;
+    public Color WarningTextColor { get; set; } = Color.Orange;
 
     /// <summary>
     /// Color for information text
     /// </summary>
-    public Color InformationTextColor
-    {
-        get => _informationTextColor;
-        set
-        {
-            if (_informationTextColor == value)
-                return;
-            _informationTextColor = value;
-            Invalidate();
-        }
-    }
+    public Color InformationTextColor { get; set; } = Color.Black;
 
     private static bool GetIsActive(bool enabled, ActiveMode activeMode) =>
         enabled && activeMode switch

--- a/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
+++ b/Mapsui/Widgets/InfoWidgets/LoggingWidget.cs
@@ -32,7 +32,7 @@ public class LoggingWidget : TextBoxWidget
         Width = 250;
         Height = 142;
         InputTransparent = true;
-        _refreshGraphics = refreshGraphics;
+        _weakReferenceToRefreshGraphics = new WeakReference<Action>(refreshGraphics);
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ public class LoggingWidget : TextBoxWidget
             _listOfLogEntries.TryDequeue(out var _);
         }
 
-        _refreshGraphics();
+        RefreshGraphics(_weakReferenceToRefreshGraphics);
     }
 
     private string ToFormattedLogLine(LogLevel level, string description, Exception? exception)
@@ -90,11 +90,17 @@ public class LoggingWidget : TextBoxWidget
             _listOfLogEntries.TryDequeue(out var _);
         }
 
-        _refreshGraphics();
+        RefreshGraphics(_weakReferenceToRefreshGraphics);
+    }
+
+    private static void RefreshGraphics(WeakReference<Action> refreshGraphics)
+    {
+        if (refreshGraphics.TryGetTarget(out var target))
+            target?.Invoke();
     }
 
     private readonly ConcurrentQueue<LogEntry> _listOfLogEntries;
-    private readonly Action _refreshGraphics;
+    private readonly WeakReference<Action> _weakReferenceToRefreshGraphics;
 
     public ConcurrentQueue<LogEntry> ListOfLogEntries => _listOfLogEntries;
 
@@ -109,7 +115,7 @@ public class LoggingWidget : TextBoxWidget
     /// <summary>
     /// Color for errors
     /// </summary>
-    public Color ErrorTextColor = Color.Red;
+    public Color ErrorTextColor { get; set; } = Color.Red;
 
     /// <summary>
     /// Color for warnings

--- a/Mapsui/Widgets/ScaleBar/ScaleBarWidget.cs
+++ b/Mapsui/Widgets/ScaleBar/ScaleBarWidget.cs
@@ -57,67 +57,29 @@ public class ScaleBarWidget : BaseWidget
         HorizontalAlignment = _defaultScaleBarHorizontalAlignment;
         VerticalAlignment = _defaultScaleBarVerticalAlignment;
 
-        _maxWidth = 100;
+        MaxWidth = 100;
         Height = 100;
-        _textAlignment = _defaultScaleBarAlignment;
-        _scaleBarMode = _defaultScaleBarMode;
+        TextAlignment = _defaultScaleBarAlignment;
+        ScaleBarMode = _defaultScaleBarMode;
 
-        _unitConverter = MetricUnitConverter.Instance;
+        UnitConverter = MetricUnitConverter.Instance;
     }
-
-    private double _maxWidth;
 
     /// <summary>
     /// Maximum usable width for scalebar. The real used width could be less, because we 
     /// want only integers as text.
     /// </summary>
-    public double MaxWidth
-    {
-        get => _maxWidth;
-        set
-        {
-            // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (_maxWidth == value)
-                return;
-
-            _maxWidth = value;
-            Invalidate();
-        }
-    }
-
-    private Color _textColor = new(0, 0, 0);
+    public double MaxWidth { get; set; }
 
     /// <summary>
     /// Foreground color of scalebar and text
     /// </summary>
-    public Color TextColor
-    {
-        get => _textColor;
-        set
-        {
-            if (_textColor == value)
-                return;
-            _textColor = value;
-            Invalidate();
-        }
-    }
-
-    private Color _haloColor = new(255, 255, 255);
+    public Color TextColor { get; set; } = new(0, 0, 0);
 
     /// <summary>
     /// Halo color of scalebar and text, so that it is better visible
     /// </summary>
-    public Color Halo
-    {
-        get => _haloColor;
-        set
-        {
-            if (_haloColor == value)
-                return;
-            _haloColor = value;
-            Invalidate();
-        }
-    }
+    public Color Halo { get; set; } = new(255, 255, 255);
 
     public double Scale { get; } = 1;
 
@@ -136,105 +98,36 @@ public class ScaleBarWidget : BaseWidget
     /// </summary>
     public double TickLength { get; set; } = 3;
 
-    private Alignment _textAlignment;
-
     /// <summary>
     /// Alignment of text of scalebar
     /// </summary>
-    public Alignment TextAlignment
-    {
-        get => _textAlignment;
-        set
-        {
-            if (_textAlignment == value)
-                return;
-
-            _textAlignment = value;
-            Invalidate();
-        }
-    }
+    public Alignment TextAlignment { get; set; }
 
     /// <summary>
     /// Margin between end of tick and text
     /// </summary>
     public static double TextMargin => 1;
 
-    private Font? _font = _defaultFont;
-
     /// <summary>
     /// Font to use for drawing text
     /// </summary>
-    public Font? Font
-    {
-        get => _font ?? _defaultFont;
-        set
-        {
-            if (_font == value)
-                return;
-
-            _font = value;
-            Invalidate();
-        }
-    }
-
-    private IUnitConverter _unitConverter;
+    public Font? Font { get; set; }
 
     /// <summary>
     /// Normal unit converter for upper text. Default is MetricUnitConverter.
     /// </summary>
-    public IUnitConverter UnitConverter
-    {
-        get => _unitConverter;
-        set
-        {
-            ArgumentNullException.ThrowIfNull(value);
-            if (_unitConverter == value)
-                return;
-
-            _unitConverter = value;
-            Invalidate();
-        }
-    }
-
-    private IUnitConverter? _secondaryUnitConverter;
+    public IUnitConverter UnitConverter { get; set; }
 
     /// <summary>
     /// Secondary unit converter for lower text if ScaleBarMode is Both. Default is ImperialUnitConverter.
     /// </summary>
-    public IUnitConverter? SecondaryUnitConverter
-    {
-        get => _secondaryUnitConverter;
-        set
-        {
-            if (_secondaryUnitConverter == value)
-            {
-                return;
-            }
-
-            _secondaryUnitConverter = value;
-            Invalidate();
-        }
-    }
-
-    private ScaleBarMode _scaleBarMode;
+    public IUnitConverter? SecondaryUnitConverter { get; set; }
 
     /// <summary>
     /// ScaleBarMode of scalebar. Could be Single to show only one or Both for showing two units.
     /// </summary>
-    public ScaleBarMode ScaleBarMode
-    {
-        get => _scaleBarMode;
-        set
-        {
-            if (_scaleBarMode == value)
-            {
-                return;
-            }
+    public ScaleBarMode ScaleBarMode { get; set; }
 
-            _scaleBarMode = value;
-            Invalidate();
-        }
-    }
 
     /// <summary>
     /// Draw a rectangle around the scale bar for testing
@@ -287,15 +180,15 @@ public class ScaleBarWidget : BaseWidget
 
         var maxScaleBarLength = Math.Max(scaleBarLength1, scaleBarLength2);
 
-        UpdateEnvelope(_maxWidth, Height, viewport.Width, viewport.Height);
+        UpdateEnvelope(MaxWidth, Height, viewport.Width, viewport.Height);
 
         var posX = (float)(Envelope?.MinX ?? 0.0);
         var posY = (float)(Envelope?.MinY ?? 0.0);
 
         var left = posX + stroke * 0.5f * Scale;
-        var right = posX + _maxWidth - stroke * 0.5f * Scale;
-        var center1 = posX + (_maxWidth - scaleBarLength1) / 2;
-        var center2 = posX + (_maxWidth - scaleBarLength2) / 2;
+        var right = posX + MaxWidth - stroke * 0.5f * Scale;
+        var center1 = posX + (MaxWidth - scaleBarLength1) / 2;
+        var center2 = posX + (MaxWidth - scaleBarLength2) / 2;
         // Top position is Y in the middle of scale bar line
         var top = posY + (drawNoSecondScaleBar ? Height - stroke * 0.5f * Scale : Height * 0.5f);
 
@@ -395,14 +288,14 @@ public class ScaleBarWidget : BaseWidget
     {
         var drawNoSecondScaleBar = ScaleBarMode == ScaleBarMode.Single || (ScaleBarMode == ScaleBarMode.Both && SecondaryUnitConverter == null);
 
-        UpdateEnvelope(_maxWidth, Height, viewport.Width, viewport.Height);
+        UpdateEnvelope(MaxWidth, Height, viewport.Width, viewport.Height);
 
         var posX = Envelope?.MinX ?? 0.0;
         var posY = Envelope?.MinY ?? 0.0;
 
         var left = posX + (stroke + TextMargin) * Scale;
-        var right1 = posX + _maxWidth - (stroke + TextMargin) * Scale - textSize1.Width;
-        var right2 = posX + _maxWidth - (stroke + TextMargin) * Scale - textSize2.Width;
+        var right1 = posX + MaxWidth - (stroke + TextMargin) * Scale - textSize1.Width;
+        var right2 = posX + MaxWidth - (stroke + TextMargin) * Scale - textSize2.Width;
         var top = posY;
         var bottom = posY + Height - textSize2.Height;
 

--- a/Mapsui/Widgets/ScaleBar/ScaleBarWidget.cs
+++ b/Mapsui/Widgets/ScaleBar/ScaleBarWidget.cs
@@ -111,7 +111,7 @@ public class ScaleBarWidget : BaseWidget
     /// <summary>
     /// Font to use for drawing text
     /// </summary>
-    public Font? Font { get; set; }
+    public Font? Font { get; set; } = _defaultFont;
 
     /// <summary>
     /// Normal unit converter for upper text. Default is MetricUnitConverter.

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/LoggingWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/LoggingWidgetSample.cs
@@ -23,7 +23,7 @@ public class LoggingWidgetSample : ISample
         };
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
 
-        var widget = new LoggingWidget()
+        var widget = new LoggingWidget(map.RefreshGraphics)
         {
             LogLevelFilter = LogLevel.Trace,
             TextSize = 11,

--- a/Samples/Mapsui.Samples.Common/Maps/Widgets/RulerWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Widgets/RulerWidgetSample.cs
@@ -49,6 +49,7 @@ public class RulerWidgetSample : ISample
         {
             var rulerWidget = e.Map.Widgets.OfType<RulerWidget>().Single();
             rulerWidget.IsActive = !rulerWidget.IsActive;
+            e.Map.RefreshGraphics();
         }
     };
 

--- a/Tests/Mapsui.Tests.Common/Maps/TouchPointSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/TouchPointSample.cs
@@ -72,7 +72,7 @@ public sealed class TouchPointSample : ISample, IDisposable
     {
         var mapInfo = e.GetMapInfo(e.Map.Layers.Where(l => l.Name == "Layer"));
         _mousePosition!.Text = $"X: {Convert.ToInt32(mapInfo.ScreenPosition.X)}, Y: {Convert.ToInt32(mapInfo.ScreenPosition.Y)}";
-        _mousePosition.NeedsRedraw = true;
+        e.Map.RefreshGraphics();
         var clickLayer = e.Map.Layers.OfType<MemoryLayer>().First(l => l.Name == "Click Layer");
         var features = (List<IFeature>)clickLayer.Features;
         features.Add(new PointFeature(mapInfo.WorldPosition.X, mapInfo.WorldPosition.Y));
@@ -80,7 +80,7 @@ public sealed class TouchPointSample : ISample, IDisposable
         if (mapInfo is { Feature: PointFeature, Layer: MemoryLayer })
         {
             _label!.Text = _label.Text == "Not Selected" ? "Selected" : "Not Selected";
-            _label.NeedsRedraw = true;
+            e.Map.RefreshGraphics();
             e.Handled = true;
         }
     }


### PR DESCRIPTION
⚠️ This is a silent breaking change. If you update changes to widgets may not update unless you add a call to Map.RefreshGraphics().

If you change the fields of the widgets you need to explicitly call map.RefreshGraphics(). 
- This is easy in the pointer events with e.Map.RefreshGraphics(). 
- If the refresh is needed on a non-pointer-event, for instance like in the logging widget when a new log line comes in, the widget needs a pointer to the RefreshGraphics method of the map.

Motivation for this change:
- It simplifies the code.
- The widget implementations become less verbose. 
- Adding new widgets does not require 11 lines of code for each property.
- The InvalidateLoop becomes slightly simpler. 
- If we improve our animation logic as well it becomes possible to not iterate all the time in the InvalidationLoop.

Alternative:
- I am considering a NeedsRefreshGraphics event so that you do not need a pointer. I would not call this method on every property change but only in the case where we currently call the RefreshGraphics callback.


