### PR TITLE
MapView: Fix an image URL

### DIFF
--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -365,7 +365,7 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
             }
             else
             {
-                _mapMyLocationButton!.Image = "embedded://Mapsui.UI.Maui.Resources.Images.LocationNoCenter.svg";
+                _mapMyLocationButton!.Image = "embedded://Mapsui.UI.Maui.Images.LocationNoCenter.svg";
             }
 
             Refresh();


### PR DESCRIPTION
This PR is supposed to fix exceptions that I see in my application when using MapView at version 5.0.0-beta.14:

```
System.Exception: Could not find the embedded resource in the current assemblies.
ImageSource: 'embedded://mapsui.ui.maui.resources.images.locationnocenter.svg/'.
```

(I found no way to reproduce it with the sample apps so far.)

It seems the respective image is used for one of the buttons in the MapView. This was last touched in commit 61eafeddd32a1b3aefc520c2733bf7471e0de773 (between beta.8 and beta.9), but I think the actual breakage happened earlier, namely in commit b3a7aec696351aa4ccf831a312f4b56d00f9115e (between beta.1 and beta.2), cf. PR #2671.

All the other images have "Mapsui.UI.Maui.Images" as a prefix in their URL, and `LocationNoCenter` is the only one which has an extra "Resources" in there (which apparently crept in by mistake).