### PR TITLE
Rewrite the invalidate loop so it does not iterate when not animating

### DIFF
--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -143,10 +143,10 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             // so the wait will be between 0 and 8 ms depending on how long the previous draw took.
             // - Then wait for _needsRefresh to be Set. If it was already Set it won't wait.
 
-            await _isDrawingDone.WaitAsync(); // Wait for previous Draw to finish.
+            await _isDrawingDone.WaitAsync().ConfigureAwait(false); // Wait for previous Draw to finish.
             await Task.Delay(_minimumTimeBetweenInvalidates).ConfigureAwait(false); // Always wait at least some period in between Draw and Invalidate calls.
             await Task.Delay(GetAdditionalTimeToDelay(_timestampStartDraw, _minimumTimeBetweenStartOfDrawCall)).ConfigureAwait(false); // Wait to enforce the _minimumTimeBetweenStartOfDrawCall.
-            await _needsRefresh.WaitAsync(); // Wait if there was no call to _needsRefresh.Set() yet.
+            await _needsRefresh.WaitAsync().ConfigureAwait(false); // Wait if there was no call to _needsRefresh.Set() yet.
 
             var isAnimating = UpdateAnimations(Map);
             

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -136,7 +136,8 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             // What is happening here?
             // - Always wait for the previous draw to finish, so there are no dropped frames anymore. By waiting the
             // loop update frequency can adapt to longer drawing durations.
-            // - After that always wait for 8 ms so that the process is never 100% busy drawing.
+            // - After that always wait for 8 ms so that the process is never 100% busy drawing, even when drawing 
+            // takes long.
             // - Then depending on how long drawing took we either don't wait (when 16 ms have already passed)
             // or wait until the start of the previous draw is 16 ms ago. The previous delay is taken into account
             // so the wait will be between 0 and 8 ms depending on how long the previous draw took.
@@ -144,8 +145,8 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
             await _isDrawingDone.WaitAsync(); // Wait for previous Draw to finish.
             await Task.Delay(_minimumTimeBetweenInvalidates).ConfigureAwait(false); // Always wait at least some period in between Draw and Invalidate calls.
-            await Task.Delay(GetAdditionalTimeToDelay(_timestampStartDraw, _minimumTimeBetweenStartOfDrawCall)).ConfigureAwait(false); // Wait to enforce the _minimumTimeBetweenStartOfDrawCall
-            await _needsRefresh.WaitAsync();
+            await Task.Delay(GetAdditionalTimeToDelay(_timestampStartDraw, _minimumTimeBetweenStartOfDrawCall)).ConfigureAwait(false); // Wait to enforce the _minimumTimeBetweenStartOfDrawCall.
+            await _needsRefresh.WaitAsync(); // Wait if there was no call to _needsRefresh.Set() yet.
 
             if (UpdateAnimations(Map)) 
                 _needsRefresh.Set(); // While still animating trigger another loop. We want to update the animations before drawing. The next loop will wait for the current draw to finish.

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -139,7 +139,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             // - After that always wait for 8 ms so that the process is never 100% busy drawing, even when drawing 
             // takes long.
             // - Then depending on how long drawing took we either don't wait (when 16 ms have already passed)
-            // or wait until the start of the previous draw is 16 ms ago. The previous delay is taken into account
+            // or wait until 16 ms have elapsed since the previous start of drawing. The previous delay is taken into account
             // so the wait will be between 0 and 8 ms depending on how long the previous draw took.
             // - Then wait for _needsRefresh to be Set. If it was already Set it won't wait.
 

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -134,11 +134,13 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         while (_isRunning)
         {
             // What is happening here?
-            // Always wait for the previous Draw to finish, so there are no dropped frames. This is a way to adapt to the Draw duration.
-            // When done always wait for some small duration, currently 8 ms, so that the process is never 100% busy drawing.
-            // Then
-            // - either wait until the start of the previous Draw is 16 ms ago. The previous delay is taken into account, so the wait will be max 8 ms (16 - 8) with the current settings..
-            // - Or start right away if it is already more then 16 ms ago.
+            // - Always wait for the previous draw to finish, so there are no dropped frames anymore. By waiting the
+            // loop update frequency can adapt to longer drawing durations.
+            // - After that always wait for 8 ms so that the process is never 100% busy drawing.
+            // - Then depending on how long drawing took we either don't wait (when 16 ms have already passed)
+            // or wait until the start of the previous draw is 16 ms ago. The previous delay is taken into account
+            // so the wait will be between 0 and 8 ms depending on how long the previous draw took.
+            // - Then wait for _needsRefresh to be Set. If it was already Set it won't wait.
 
             await _isDrawingDone.WaitAsync(); // Wait for previous Draw to finish.
             await Task.Delay(_minimumTimeBetweenInvalidates).ConfigureAwait(false); // Always wait at least some period in between Draw and Invalidate calls.

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -148,24 +148,26 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             await Task.Delay(GetAdditionalTimeToDelay(_timestampStartDraw, _minimumTimeBetweenStartOfDrawCall)).ConfigureAwait(false); // Wait to enforce the _minimumTimeBetweenStartOfDrawCall.
             await _needsRefresh.WaitAsync(); // Wait if there was no call to _needsRefresh.Set() yet.
 
-            if (UpdateAnimations(Map)) 
-                _needsRefresh.Set(); // While still animating trigger another loop. We want to update the animations before drawing. The next loop will wait for the current draw to finish.
+            var isAnimating = UpdateAnimations(Map);
             
             _invalidate?.Invoke();
+
+            if (isAnimating)
+                _needsRefresh.Set(); // While still animating trigger another loop. 
         }
     }
 
-    // Returns true if there are active animations.
     private static bool UpdateAnimations(Map? map)
     {
+        var isAnimating = false;
         if (map is Map localMap)
         {
-            if (localMap.UpdateAnimations()) // Are there animations running on the Map
-                return true;
-            if (localMap.Navigator.UpdateAnimations()) // Are there animations running on the Navigator
-                return true;
+            if (localMap.UpdateAnimations()) // Update animations on the Map
+                isAnimating = true;
+            if (localMap.Navigator.UpdateAnimations()) // Update animations on the Navigator
+                isAnimating = true;
         }
-        return false;
+        return isAnimating; // Returns true if there are active animations.
     }
 
     private protected void SharedDraw(object canvas)

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -147,10 +147,10 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             await Task.Delay(GetAdditionalTimeToDelay(_timestampStartDraw, _minimumTimeBetweenStartOfDrawCall)).ConfigureAwait(false); // Wait to enforce the _minimumTimeBetweenStartOfDrawCall
             await _needsRefresh.WaitAsync();
 
-            _invalidate?.Invoke();
-
             if (UpdateAnimations(Map)) 
-                _needsRefresh.Set(); // While animating trigger another loop.
+                _needsRefresh.Set(); // While still animating trigger another loop. We want to update the animations before drawing. The next loop will wait for the current draw to finish.
+            
+            _invalidate?.Invoke();
         }
     }
 

--- a/Mapsui/Navigator.cs
+++ b/Mapsui/Navigator.cs
@@ -405,7 +405,7 @@ public class Navigator
     /// <param name="duration">Duration for animation in milliseconds.</param>
     public void FlyTo(MPoint center, double maxResolution, long duration = 500)
     {
-        _animations = FlyToAnimation.Create(Viewport, center, maxResolution, duration);
+        SetViewportAnimations(FlyToAnimation.Create(Viewport, center, maxResolution, duration));
     }
 
     /// <summary>
@@ -441,7 +441,7 @@ public class Navigator
         if (PanLock)
             return;
 
-        _animations = FlingAnimation.Create(velocityX, velocityY, maxDuration);
+        SetViewportAnimations(FlingAnimation.Create(velocityX, velocityY, maxDuration));
     }
 
     public void Manipulate(Manipulation? manipulation)
@@ -582,6 +582,7 @@ public class Navigator
     public void SetViewportAnimations(List<AnimationEntry<Viewport>> animations)
     {
         _animations = animations;
+        OnViewportChanged(Viewport); // Call OnViewportChanged with current Viewport to trigger the invalidate loop so animations will be updated.
     }
 
     private void SetViewportWithLimit(Viewport viewport)
@@ -676,7 +677,7 @@ public class Navigator
             // started to overload to the data refresh.
             if (_animations.Any())
                 OnRefreshDataRequest(ChangeType.Continuous);
-            _animations = ViewportAnimation.Create(Viewport, viewport, duration, easing);
+            SetViewportAnimations(ViewportAnimation.Create(Viewport, viewport, duration, easing));
         }
     }
 


### PR DESCRIPTION
This is a follow up of this one: https://github.com/Mapsui/Mapsui/pull/2969
Additional work was done here, removing the NeedsRedraw: https://github.com/Mapsui/Mapsui/pull/2972

- This implementation is close to what I was aiming for. We now wait for _needsRefesh (which is now an AsyncAutoResetEvent, just as _isDrawingDone). This is good because you do not have to iteratively check the _needsRefresh boolean.
- We update animations in the loop and trigger another loop if they are still running. What is nice about our animation design (already existing) is that the animation values correspond accurately with the moment of drawing because we update it in the loop. 
- If there are no animation updates the loop will be waiting at _needsRefresh and if RefreshGraphics is called it will immediately call invalide.

The only thing I can think of that could be improved is that we do not have to call the UpdateAnimation when no animation is running (so we do not have to iterated through the layers). This could be done if the RefreshGraphics calls gets the duration of the animation as a parameter (if one was started). If we store this duration in the MapControl we could skip the animation update. This is a performance optimization that I would only do if I could measure it's impact.

