### PR TITLE
Move render loop and other rendering related code to RenderController

### DIFF
--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -284,13 +284,9 @@ public sealed class MapRenderer : IRenderer, IDisposable
 
     public MapInfo GetMapInfo(ScreenPosition screenPosition, Viewport viewport, IEnumerable<ILayer> layers, int margin = 0)
     {
-        // Todo: Use margin to increase the pixel area
-        // Todo: Select on style instead of layer
-
         var mapInfoLayers = layers
             .Select(l => l is ISourceLayer sl and not ILayerFeatureInfo ? sl.SourceLayer : l)
             .ToList();
-
 
         var list = new ConcurrentQueue<List<MapInfoRecord>>();
         var mapInfo = new MapInfo(screenPosition, viewport.ScreenToWorld(screenPosition), viewport.Resolution);

--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -38,10 +38,14 @@ public partial class MapControl : ViewGroup, IMapControl
         LocalConstructor();
     }
 
+
+    public void InvalidateCanvas()
+    {
+        RunOnUIThread(RefreshGraphicsWithTryCatch);
+    }
+
     private void LocalConstructor()
     {
-        _invalidate = () => RunOnUIThread(RefreshGraphicsWithTryCatch);
-
         SetBackgroundColor(Color.Transparent);
         _canvas?.Dispose();
         _canvas = RenderMode == SkiaRenderMode.Software ? StartSoftwareRenderMode() : StartHardwareRenderMode();
@@ -61,7 +65,7 @@ public partial class MapControl : ViewGroup, IMapControl
 
         canvas.Scale(pixelDensity, pixelDensity);
 
-        SharedDraw(canvas);
+        _renderController?.Render(canvas);
     }
 
     public SkiaRenderMode RenderMode
@@ -119,7 +123,7 @@ public partial class MapControl : ViewGroup, IMapControl
 
         canvas.Scale(pixelDensity, pixelDensity);
 
-        SharedDraw(canvas);
+        _renderController?.Render(canvas);
     }
 
     public void MapControl_Touch(object? sender, TouchEventArgs args)

--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -39,19 +39,19 @@ public partial class MapControl : ComponentBase, IMapControl
     public MapControl()
     {
         SharedConstructor();
+    }
 
-        _invalidate = () =>
-        {
-            if (!OperatingSystem.IsBrowser())
-                throw new InvalidOperationException("Only browser is supported");
+    public void InvalidateCanvas()
+    {
+        if (!OperatingSystem.IsBrowser())
+            throw new InvalidOperationException("Only browser is supported");
 
-            if (_viewCpu != null)
-                _viewCpu.Invalidate();
-            else if (_viewGpu != null)
-                _viewGpu?.Invalidate();
-            else
-                throw new InvalidOperationException("Both _viewCpu and _viewGpu are null");
-        };
+        if (_viewCpu != null)
+            _viewCpu.Invalidate();
+        else if (_viewGpu != null)
+            _viewGpu?.Invalidate();
+        else
+            throw new InvalidOperationException("Both _viewCpu and _viewGpu are null");
     }
 
     /// <summary>
@@ -112,7 +112,7 @@ public partial class MapControl : ComponentBase, IMapControl
             OnSizeChanged(info);
         }
 
-        SharedDraw(canvas);
+        _renderController?.Render(canvas);
     }
 
     private void OnLoadComplete()

--- a/Mapsui.UI.Eto/MapControl.cs
+++ b/Mapsui.UI.Eto/MapControl.cs
@@ -17,8 +17,12 @@ public partial class MapControl : SkiaDrawable, IMapControl
     public MapControl()
     {
         SharedConstructor();
-        _invalidate = () => RunOnUIThread(Invalidate);
         SizeChanged += MapControl_SizeChanged; ;
+    }
+
+    public void InvalidateCanvas()
+    {
+        RunOnUIThread(Invalidate);
     }
 
     private void MapControl_SizeChanged(object? sender, EventArgs e)
@@ -107,7 +111,7 @@ public partial class MapControl : SkiaDrawable, IMapControl
 
         var canvas = e.Surface.Canvas;
         canvas.Scale(pixelDensity, pixelDensity);
-        SharedDraw(canvas);
+        _renderController?.Render(canvas);
     }
 
     protected override void Dispose(bool disposing)

--- a/Mapsui.UI.Shared/Mapsui.UI.Shared.projitems
+++ b/Mapsui.UI.Shared/Mapsui.UI.Shared.projitems
@@ -10,5 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)MapControl.cs" />
+    <Compile Include="..\Mapsui.UI.Shared\RenderController.cs" />
   </ItemGroup>
 </Project>

--- a/Mapsui.UI.Shared/RenderController.cs
+++ b/Mapsui.UI.Shared/RenderController.cs
@@ -1,0 +1,152 @@
+﻿#pragma warning disable IDE0005 // Using directive is unnecessary.
+using Mapsui.Extensions;
+using Mapsui.Layers;
+using Mapsui.Logging;
+using Mapsui.Manipulations;
+using Mapsui.Rendering.Skia;
+using Mapsui.Styles;
+using Mapsui.Utilities;
+using Mapsui.Widgets;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+#pragma warning restore IDE0005 // Using directive is unnecessary.
+
+namespace Mapsui.Rendering;
+
+public sealed class RenderController : IDisposable
+{
+    private bool _disposed;
+    // Action to call for a redraw of the control
+    private readonly Action? _invalidateCanvas;
+    // The minimum time in between invalidate calls in ms.
+    private readonly int _minimumTimeBetweenInvalidates = 8;
+    // The minimum time in between the start of two draw calls in ms
+    private readonly int _minimumTimeBetweenStartOfDrawCall = 16;
+    private readonly AsyncAutoResetEvent _isDrawingDone = new();
+    private readonly AsyncAutoResetEvent _needsRefresh = new();
+    private static bool _firstDraw = true;
+    private bool _isRunning = true;
+    private int _timestampStartDraw;
+    // Stopwatch for measuring drawing times
+    private readonly System.Diagnostics.Stopwatch _stopwatch = new();
+#pragma warning disable IDISP002 // Is disposed in SharedDispose
+    private readonly IRenderer _renderer = new MapRenderer();
+#pragma warning restore IDISP002
+    private readonly Func<Map?> _getMap;
+
+    public RenderController(Func<Map?> getMap, Action InvalidateCanvas)
+    {
+        _getMap = getMap; // Using a callback to get the Map instead of a pointer because the Map field change later on.
+        _invalidateCanvas = InvalidateCanvas;
+        _timestampStartDraw = Environment.TickCount;
+        Catch.TaskRun(InvalidateLoopAsync);
+    }
+
+    public void RefreshGraphics()
+    {
+        _needsRefresh.Set();
+    }
+
+    public MemoryStream RenderToBitmapStream(Viewport viewport, IEnumerable<ILayer> layers,
+    Mapsui.Styles.Color? background = null, float pixelDensity = 1, IEnumerable<IWidget>? widgets = null, RenderFormat renderFormat = RenderFormat.Png, int quality = 100)
+    {
+        return _renderer.RenderToBitmapStream(viewport, layers, background, pixelDensity, widgets, renderFormat, quality);
+    }
+
+    public MapInfo GetMapInfo(ScreenPosition screenPosition, Viewport viewport, IEnumerable<ILayer> layers, int margin = 0)
+    {
+        return _renderer.GetMapInfo(screenPosition, viewport, layers, margin);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _isRunning = false;
+        _renderer.Dispose();
+
+        _disposed = true;
+    }
+
+    private async Task InvalidateLoopAsync()
+    {
+        while (_isRunning)
+        {
+            // What is happening here?
+            // - Always wait for the previous draw to finish, so there are no dropped frames anymore. By waiting the
+            // loop update frequency can adapt to longer drawing durations.
+            // - After that always wait for 8 ms so that the process is never 100% busy drawing, even when drawing 
+            // takes long.
+            // - Then depending on how long drawing took we either don't wait (when 16 ms have already passed)
+            // or wait until 16 ms have elapsed since the previous start of drawing. The previous delay is taken into account
+            // so the wait will be between 0 and 8 ms depending on how long the previous draw took.
+            // - Then wait for _needsRefresh to be Set. If it was already Set it won't wait.
+
+            await _isDrawingDone.WaitAsync().ConfigureAwait(false); // Wait for previous Draw to finish.
+            await Task.Delay(_minimumTimeBetweenInvalidates).ConfigureAwait(false); // Always wait at least some period in between Draw and Invalidate calls.
+            await Task.Delay(GetAdditionalTimeToDelay(_timestampStartDraw, _minimumTimeBetweenStartOfDrawCall)).ConfigureAwait(false); // Wait to enforce the _minimumTimeBetweenStartOfDrawCall.
+            await _needsRefresh.WaitAsync().ConfigureAwait(false); // Wait if there was no call to _needsRefresh.Set() yet.
+
+            var isAnimating = UpdateAnimations(_getMap());
+
+            _invalidateCanvas?.Invoke();
+
+            if (isAnimating)
+                _needsRefresh.Set(); // While still animating trigger another loop. 
+        }
+    }
+
+    public void Render(object canvas)
+    {
+        if (_renderer is null)
+            return;
+        if (_getMap() is not Map map)
+            return;
+        if (!map.Navigator.Viewport.HasSize())
+            return;
+
+        if (_firstDraw)
+        {
+            _firstDraw = false;
+            Logger.Log(LogLevel.Information, $"First call to the Mapsui renderer");
+        }
+
+        // Start stopwatch before updating animations and drawing control
+        _stopwatch.Restart();
+        _timestampStartDraw = Environment.TickCount;
+        // Fetch the image data for all image sources and call RefreshGraphics if new images were loaded.
+        _renderer.ImageSourceCache.FetchAllImageData(Mapsui.Styles.Image.SourceToSourceId, map.FetchMachine, RefreshGraphics);
+
+        _renderer.Render(canvas, map.Navigator.Viewport, map.Layers, map.Widgets, map.BackColor);
+
+        _isDrawingDone.Set();
+        _stopwatch.Stop();
+
+        // If we are interested in performance measurements, we save the new drawing time
+        map.Performance?.Add(_stopwatch.Elapsed.TotalMilliseconds);
+    }
+
+    private static int GetAdditionalTimeToDelay(int timestampStartDraw, int minimumTimeBetweenStartOfDrawCall)
+    {
+        var timeSinceLastDraw = Environment.TickCount - timestampStartDraw;
+        var additionalTimeToDelay = Math.Max(minimumTimeBetweenStartOfDrawCall - timeSinceLastDraw, 0);
+        return additionalTimeToDelay;
+    }
+
+    private static bool UpdateAnimations(Map? map)
+    {
+        var isAnimating = false;
+        if (map is Map localMap)
+        {
+            if (localMap.UpdateAnimations()) // Update animations on the Map
+                isAnimating = true;
+            if (localMap.Navigator.UpdateAnimations()) // Update animations on the Navigator
+                isAnimating = true;
+        }
+        return isAnimating; // Returns true if there are active animations.
+    }
+
+}

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -23,12 +23,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
     {
         SharedConstructor();
 
-        _invalidate = () =>
-        {
-            if (Dispatcher.CheckAccess()) InvalidateCanvas();
-            else RunOnUIThread(InvalidateCanvas);
-        };
-
         Children.Add(SkiaCanvas);
 
         SkiaCanvas.PaintSurface += SKElementOnPaintSurface;
@@ -55,6 +49,12 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         RefreshGraphics();
     }
 
+    public void InvalidateCanvas()
+    {
+        if (Dispatcher.CheckAccess()) SkiaCanvas.InvalidateVisual();
+        else RunOnUIThread(SkiaCanvas.InvalidateVisual);
+    }
+
     private static Rectangle CreateSelectRectangle() => new()
     {
         Fill = new SolidColorBrush(Colors.Red),
@@ -76,11 +76,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         VerticalAlignment = VerticalAlignment.Stretch,
         HorizontalAlignment = HorizontalAlignment.Stretch
     };
-
-    internal void InvalidateCanvas()
-    {
-        SkiaCanvas.InvalidateVisual();
-    }
 
     private void MapControlLoaded(object sender, RoutedEventArgs e)
     {
@@ -211,7 +206,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
         var canvas = args.Surface.Canvas;
         canvas.Scale(pixelDensity, pixelDensity);
-        SharedDraw(canvas);
+        _renderController?.Render(canvas);
     }
 
     public float? GetPixelDensity()

--- a/Mapsui/UI/IMapControl.cs
+++ b/Mapsui/UI/IMapControl.cs
@@ -20,8 +20,6 @@ public interface IMapControl : IDisposable
 
     void Unsubscribe();
 
-    IRenderer Renderer { get; }
-
     void OpenInBrowser(string url);  // Todo: Perhaps remove. This is only to force the platform specific implementation
 
     /// <summary>
@@ -68,4 +66,6 @@ public interface IMapControl : IDisposable
     /// <param name="quality">default quality is 90 is applicable for webp and jpg</param>
     /// <returns>Byte array with snapshot in png format. If there are any problems than returns null.</returns>
     byte[] GetSnapshot(IEnumerable<ILayer>? layers = null, RenderFormat renderFormat = RenderFormat.Png, int quality = 100);
+
+    void InvalidateCanvas();
 }

--- a/Mapsui/Utilities/AsyncAutoResetEvent.cs
+++ b/Mapsui/Utilities/AsyncAutoResetEvent.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 
 namespace Mapsui.Utilities;
 
-
 public class AsyncAutoResetEvent(bool initialState = false)
 {
     private static readonly Task _completed = Task.FromResult(true);

--- a/Tests/Mapsui.Rendering.Skia.Tests/RegressionMapControl.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/RegressionMapControl.cs
@@ -50,6 +50,8 @@ public sealed class RegressionMapControl : IMapControl
         throw new NotImplementedException();
     }
 
+    public void InvalidateCanvas() { }
+
     public void RefreshData(ChangeType changeType = ChangeType.Discrete)
     {
         throw new NotImplementedException();


### PR DESCRIPTION
The MapControl contains a lot of code. This PR moves code to the RenderController. This makes the remaining code in the MapControl easier to scan and makes the looping code within the RenderController easier to scan.

A follow up PR could move all the Touch/Mouse code to a ManipulationController (or PointerController?). UPDATE: This is problematic because all pointer events. This makes it harder to isolate.

There is also some code in MapControl that can be moved to the Map, like the property changed logic. The Map will just need to call refresh itself.

It may be possible to get rid of the shared MapControl code altogether. There will be some more code duplication, but it will be clearer for contributors that work on one platform. The IMapControl should enforce a common interface.