### PR TITLE
Remove stale touches

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Install workloads android wasm-tools wasm-tools-net8 maui-android
       run: dotnet workload install android wasm-tools wasm-tools-net8 maui-android
     - name: Install Uno Check
-      run: dotnet tool install -g Uno.Check
+      run: dotnet tool install -g Uno.Check --version 1.30.1
     - name: Uno Check
       run: uno-check -v --ci --non-interactive --fix --skip androidemulator --dotnet 9.0.202
     - name: Restore dependencies
@@ -212,7 +212,7 @@ jobs:
     - name: install maui macos android ios maccatalyst wasm-tools wasm-tools-net8
       run: dotnet workload install maui macos android ios maccatalyst wasm-tools wasm-tools-net8
     - name: Install Uno Check
-      run: dotnet tool install -g Uno.Check
+      run: dotnet tool install -g Uno.Check --version 1.30.1
     - name: Uno Check
       run: uno-check -v --ci --non-interactive --fix --skip vswin --skip androidemulator --skip androidsdk --skip psexecpolicy --dotnet 9.0.202
     - name: Restore dependencies (dotnet)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Install Uno Check
       run: dotnet tool install -g Uno.Check
     - name: Uno Check
-      run: uno-check -v --ci --non-interactive --fix --skip androidemulator
+      run: uno-check -v --ci --non-interactive --fix --skip androidemulator --dotnet 9.0.202
     - name: Restore dependencies
       run: dotnet restore Mapsui.Linux.slnf
     - name: Build Mapsui.Linux.slnf
@@ -132,11 +132,11 @@ jobs:
     - name: install Uno.Check 1.26.1
       run: dotnet tool install --global Uno.Check --version 1.26.1
     - name: install Android SDK 34
-      run: uno-check -v --ci --non-interactive --fix --target android --skip androidemulator  
+      run: uno-check -v --ci --non-interactive --fix --target android --skip androidemulator --dotnet 9.0.202
     - name: Install newest Uno Check
       run: dotnet tool update -g uno.check
     - name: Uno Check
-      run: uno-check -v --ci --non-interactive --fix --skip xcode --skip androidemulator    
+      run: uno-check -v --ci --non-interactive --fix --skip xcode --skip androidemulator --dotnet 9.0.202
     - name: Restore dependencies Mapsui.Mac
       run: dotnet restore Mapsui.Mac.slnf       
     # Build        
@@ -214,7 +214,7 @@ jobs:
     - name: Install Uno Check
       run: dotnet tool install -g Uno.Check
     - name: Uno Check
-      run: uno-check -v --ci --non-interactive --fix --skip vswin --skip androidemulator --skip androidsdk --skip psexecpolicy
+      run: uno-check -v --ci --non-interactive --fix --skip vswin --skip androidemulator --skip androidsdk --skip psexecpolicy --dotnet 9.0.202
     - name: Restore dependencies (dotnet)
       run: dotnet restore Mapsui.sln  
     - name: Run dotnet format

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -25,16 +25,24 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
 
     private readonly SKGLView? _glView;
     private readonly SKCanvasView? _canvasView;
-    private readonly ConcurrentDictionary<long, ScreenPosition> _positions = new();
+    private readonly ConcurrentDictionary<long, PointerRecording> _positions = new();
     private Size _size;
     private static List<WeakReference<MapControl>>? _listeners;
     private readonly ManipulationTracker _manipulationTracker = new();
     private Page? _page;
     private Element? _element;
 
+    /// <summary>
+    /// If finger position is not updated during the IsStaleTimeSpan period, the touch event is considered stale and is removed.
+    /// Touch input is not always reliable. This could be because of bugs in SkiaSharp, WinUI, iOS or Android, MAUI, 
+    /// in hardware drivers, or hardware. To work around this we remove the touch events if they did not change after 
+    /// some period. Making this period too short could remove valid events, making it too long would result in a longer 
+    /// period of dangling ghost touches. You might want to tweak this value to your needs.
+    /// </summary>
+    public TimeSpan IsStaleTimeSpan { get; set; } = TimeSpan.FromMilliseconds(500); // Even with a value of 100 I never see removal of a valid event, so I assume 500 is save. And perhaps it could be set even lower because if a valid event is removed sometimes I don't notice any change in the UI.
+
     private double ViewportWidth => _size.Width; // Used in shared code. Getting the this.Width too early can cause malfunctioning.
     private double ViewportHeight => _size.Height; // Used in shared code. Getting the this.Height too early can cause malfunctioning.
-
 
     public MapControl()
     {
@@ -152,15 +160,16 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
         Catch.Exceptions(() =>
         {
             e.Handled = true;
+            RemoveStale(_positions, IsStaleTimeSpan.TotalMilliseconds);
             var position = GetScreenPosition(e.Location);
 
             if (e.ActionType == SKTouchAction.Pressed)
             {
-                _positions[e.Id] = position;
+                _positions[e.Id] = new PointerRecording(position, Environment.TickCount);
                 if (_positions.Count == 1) // Not sure if this check is necessary.
-                    _manipulationTracker.Restart(_positions.Values.ToArray());
+                    _manipulationTracker.Restart(_positions.Values.Select(p => p.ScreenPosition).ToArray());
 
-                if (OnPointerPressed(_positions.Values.ToArray()))
+                if (OnPointerPressed(_positions.Values.Select(p => p.ScreenPosition).ToArray()))
                     return;
             }
             else if (e.ActionType == SKTouchAction.Moved)
@@ -175,12 +184,12 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
                 }
                 else
                 {
-                    _positions[e.Id] = position;
+                    _positions[e.Id] = new PointerRecording(position, Environment.TickCount);
 
-                    if (OnPointerMoved(_positions.Values.ToArray(), isHovering))
+                    if (OnPointerMoved(_positions.Values.Select(p => p.ScreenPosition).ToArray(), isHovering))
                         return;
 
-                    _manipulationTracker.Manipulate(_positions.Values.ToArray(), Map.Navigator.Manipulate);
+                    _manipulationTracker.Manipulate(_positions.Values.Select(p => p.ScreenPosition).ToArray(), Map.Navigator.Manipulate);
                 }
 
                 RefreshGraphics();
@@ -212,6 +221,18 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
                 OnZoomInOrOut(e.WheelDelta, position);
             }
         });
+    }
+
+    private static void RemoveStale(ConcurrentDictionary<long, PointerRecording> positions, double totalMilliseconds)
+    {
+        var currentTickCount = Environment.TickCount;
+        foreach (var position in positions)
+        {
+            if (currentTickCount - position.Value.timestamp > totalMilliseconds)
+            {
+                _ = positions.TryRemove(position.Key, out _);
+            }
+        }
     }
 
     private void OnGLPaintSurface(object? sender, SKPaintGLSurfaceEventArgs args)
@@ -380,5 +401,9 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
         }
 
         return GetPage(element.Parent);
+    }
+
+    private record struct PointerRecording(ScreenPosition ScreenPosition, int timestamp)
+    {
     }
 }


### PR DESCRIPTION
### The problem
When on MAUI running on Windows with a touch screen some touch events are not removed on Released, Exit or Cancelled. The persisting ghost positions disrupt following manipulation. 

### The  solution
This does not seem to be a bug in our logic. There is really no event that removes them. The fix is to remove touch positions if they have not been updated for a configurable number of milliseconds (default set to 500 ms).