### PR TITLE
Improve invalidate loop

### DIFF
--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -137,11 +137,11 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             // What is happening here?
             // - Always wait for the previous draw to finish, so there are no dropped frames anymore. By waiting the
             // loop update frequency can adapt to longer drawing durations.
-            // - After that always wait for 8 ms so that the process is never 100% busy drawing, even when drawing 
+            // - After that always wait for 4 ms so that the process is never 100% busy drawing, even when drawing 
             // takes long.
-            // - Then depending on how long drawing took we either don't wait (when 16 ms have already passed)
+            // - Then depending on how long drawing took we either don't wait (when 8 ms have already passed)
             // or wait until 16 ms have elapsed since the previous start of drawing. The previous delay is taken into account
-            // so the wait will be between 0 and 8 ms depending on how long the previous draw took.
+            // so the wait will be between 0 and 4 ms depending on how long the previous draw took.
             // - Then wait for _needsRefresh to be Set. If it was already Set it won't wait.
 
             _isDrawingDone.WaitOne(); // Wait for previous Draw to finish.

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -67,7 +67,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     // Stopwatch for measuring drawing times
     private readonly Stopwatch _stopwatch = new();
 #pragma warning disable IDISP002 // Is disposed in SharedDispose
-    private readonly IRenderer _renderer = new MapRenderer();
+    private readonly MapRenderer _renderer = new();
 #pragma warning restore IDISP002
     private readonly TapGestureTracker _tapGestureTracker = new();
     private readonly FlingTracker _flingTracker = new();
@@ -171,8 +171,6 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
 
     private protected void SharedDraw(object canvas)
     {
-        if (Renderer is null)
-            return;
         if (Map is null)
             return;
         if (!Map.Navigator.Viewport.HasSize())
@@ -190,7 +188,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
         // Fetch the image data for all image sources and call RefreshGraphics if new images were loaded.
         _renderer.ImageSourceCache.FetchAllImageData(Mapsui.Styles.Image.SourceToSourceId, Map.FetchMachine, RefreshGraphics);
 
-        Renderer.Render(canvas, Map.Navigator.Viewport, Map.Layers, Map.Widgets, Map.BackColor);
+        _renderer.Render(canvas, Map.Navigator.Viewport, Map.Layers, Map.Widgets, Map.BackColor);
 
         _isDrawingDone.Set();
         _stopwatch.Stop();

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -183,8 +183,8 @@ public class Map : INotifyPropertyChanged, IDisposable
     public event EventHandler? RefreshGraphicsRequest;
 
     /// <summary>
-    /// Called whenever the map is clicked. The MapInfoEventArgs contain the features that were hit in
-    /// the layers that have IsMapInfoLayer set to true. 
+    /// Called whenever the map is tapped. The MapInfoEventArgs contain a GetMapInfo method that can be called to 
+    /// retrieve information on the features that were tapped.
     /// </summary>
     /// <remarks>
     /// The Tapped event is preferred over the Info event. This event is kept for backwards compatibility.


### PR DESCRIPTION
Improvements after recent changes to the invalidate loop: https://github.com/Mapsui/Mapsui/pull/2969

- Environment.TickCount is not precise enough in general and on my machine was chuncked into steps of ~15ms. That is not useful if you calculate within a 16ms iteration. I used Stopwatch instead. The difference was noticeable. 
- I also reduced the use of await because I feared scheduling of the threads would be a bit too much if it needs to be within such a small time scale. So, now i use a Regular AutoResetEvent to wait for the previous draw and Thread.Sleep to wait for the next iteration. There is only one await left in the loop, this is to make sure we do not block a thread when nothing is drawn. I did not verify that this actually improves things, it is just guessing.
- I reduced the interval van 16ms to 8ms. To me it looks calmer when I drag the map.

