### PR TITLE
Allow Dynamic Symbol Scale Style by adding Viewport to ThemeStyle function

### DIFF
--- a/Mapsui.Nts/Providers/StackedLabelProvider.cs
+++ b/Mapsui.Nts/Providers/StackedLabelProvider.cs
@@ -14,9 +14,9 @@ public class StackedLabelProvider(IProvider provider, LabelStyle labelStyle, Pen
 {
     private const int _symbolSize = 32; // todo: determine margin by symbol size
     private const int _boxMargin = _symbolSize / 2;
-
     private readonly IProvider _provider = provider;
     private readonly LabelStyle _labelStyle = labelStyle;
+    private const double _clusterMargin = 50;
 
     public string? CRS { get; set; }
 
@@ -41,7 +41,7 @@ public class StackedLabelProvider(IProvider provider, LabelStyle labelStyle, Pen
         if (features == null)
             return [];
 
-        var margin = fetchInfo.Resolution * LabelMarginFactor;
+        var margin = fetchInfo.Resolution * _clusterMargin;
         var clusters = ClusterFeatures(fetchInfo, features, margin, labelStyle);
 
         const int textHeight = 18;

--- a/Mapsui.Nts/Providers/StackedLabelProvider.cs
+++ b/Mapsui.Nts/Providers/StackedLabelProvider.cs
@@ -41,7 +41,7 @@ public class StackedLabelProvider(IProvider provider, LabelStyle labelStyle, Pen
         if (features == null)
             return [];
 
-        var margin = fetchInfo.Resolution * 50;
+        var margin = fetchInfo.Resolution * LabelMarginFactor;
         var clusters = ClusterFeatures(fetchInfo, features, margin, labelStyle);
 
         const int textHeight = 18;

--- a/Mapsui/Rendering/VisibleFeatureIterator.cs
+++ b/Mapsui/Rendering/VisibleFeatureIterator.cs
@@ -51,7 +51,7 @@ public static class VisibleFeatureIterator
             {
                 if (layerStyle is IThemeStyle themeStyle)
                 {
-                    var stylesFromThemeStyle = themeStyle.GetStyle(feature).GetStylesToApply(viewport.Resolution);
+                    var stylesFromThemeStyle = themeStyle.GetStyle(feature, viewport).GetStylesToApply(viewport.Resolution);
                     foreach (var styleFromThemeStyle in stylesFromThemeStyle)
                     {
                         callback(viewport, layer, styleFromThemeStyle, feature, (float)layer.Opacity, iteration);

--- a/Mapsui/Styles/Thematics/GradientTheme.cs
+++ b/Mapsui/Styles/Thematics/GradientTheme.cs
@@ -76,7 +76,7 @@ public class GradientTheme : Style, IThemeStyle
     /// </summary>
     /// <param name="row">Feature</param>
     /// <returns>A <see cref="IStyle">Style</see> calculated by a linear interpolation between the min/max styles</returns>
-    public IStyle? GetStyle(IFeature row)
+    public IStyle? GetStyle(IFeature row, Viewport _)
     {
         double attr;
         try { attr = Convert.ToDouble(row[ColumnName]); }

--- a/Mapsui/Styles/Thematics/IThemeStyle.cs
+++ b/Mapsui/Styles/Thematics/IThemeStyle.cs
@@ -16,5 +16,5 @@ public interface IThemeStyle : IStyle
     /// </summary>
     /// <param name="feature">Feature to calculate color from</param>
     /// <returns>Color</returns>
-    IStyle? GetStyle(IFeature feature);
+    IStyle? GetStyle(IFeature feature, Viewport viewport);
 }

--- a/Mapsui/Styles/Thematics/ThemeStyle.cs
+++ b/Mapsui/Styles/Thematics/ThemeStyle.cs
@@ -4,15 +4,27 @@ namespace Mapsui.Styles.Thematics;
 
 public class ThemeStyle : Style, IThemeStyle
 {
-    private readonly Func<IFeature, IStyle?> _method;
+    private readonly Func<IFeature, Viewport, IStyle?> _method;
 
     public ThemeStyle(Func<IFeature, IStyle?> method)
+    {
+        _method = (f, v) => GetStyle(method, f, v);
+    }
+
+    public ThemeStyle(Func<IFeature, Viewport, IStyle?> method)
     {
         _method = method;
     }
 
-    public IStyle? GetStyle(IFeature attribute)
+    public IStyle? GetStyle(IFeature attribute, Viewport viewport)
     {
-        return _method(attribute);
+        return _method(attribute, viewport);
     }
+
+    public override string ToString()
+    {
+        return $"ThemeStyle: {GetType().Name}";
+    }
+
+    private static IStyle? GetStyle(Func<IFeature, IStyle?> method, IFeature feature, Viewport _) => method(feature);
 }

--- a/Samples/Mapsui.Samples.Common/DataBuilders/RandomPointsBuilder.cs
+++ b/Samples/Mapsui.Samples.Common/DataBuilders/RandomPointsBuilder.cs
@@ -8,9 +8,9 @@ namespace Mapsui.Samples.Common.DataBuilders;
 
 public static class RandomPointsBuilder
 {
-    public static IEnumerable<PointFeature> CreateRandomFeatures(MRect? envelope, int count, Random? random = null)
+    public static IEnumerable<PointFeature> CreateRandomFeatures(MRect? envelope, int count, Random? random = null, int seed = 123)
     {
-        random ??= new Random(123);
+        random ??= new Random(seed);
 
         return CreateFeatures(GenerateRandomPoints(envelope, count, random));
     }

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSymbolScaleStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSymbolScaleStyleSample.cs
@@ -16,7 +16,7 @@ public class DynamicSymbolScaleStyleSample : ISample
     private const double _level3 = 8000.0;
 
     public string Name => "Dynamic Symbol Scale Style";
-    public string Category => "1";
+    public string Category => "Styles";
 
     public Task<Map> CreateMapAsync()
     {

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSymbolScaleStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSymbolScaleStyleSample.cs
@@ -1,0 +1,43 @@
+﻿using Mapsui.Layers;
+using Mapsui.Samples.Common.DataBuilders;
+using Mapsui.Styles;
+using Mapsui.Styles.Thematics;
+using Mapsui.Tiling;
+using System.Threading.Tasks;
+
+namespace Mapsui.Samples.Common.Maps.Demo;
+
+public class DynamicSymbolScaleStyleSample : ISample
+{
+    private const double _resolutionFlippingPoint = 300.0;
+    private const string _imageSource = "embedded://Mapsui.Samples.Common.Images.arrow.svg";
+
+    public string Name => "Dynamic Symbol Scale Style";
+    public string Category => "Styles";
+
+    public Task<Map> CreateMapAsync()
+    {
+        var map = new Map();
+        map.Layers.Add(OpenStreetMap.CreateTileLayer());
+        map.Layers.Add(CreateLayerWithDynamicScaleStyle(map));
+        return Task.FromResult(map);
+    }
+
+    private static MemoryLayer CreateLayerWithDynamicScaleStyle(Map map) => new()
+    {
+        Name = "Dynamic Symbol Scale",
+        Features = RandomPointsBuilder.CreateRandomFeatures(map.Extent, 1000),
+        Style = CreateDynamicSymbolScaleStyle()
+    };
+
+    private static ThemeStyle CreateDynamicSymbolScaleStyle()
+    {
+        return new ThemeStyle((f, v) => CreateImageStyle(v));
+    }
+
+    private static ImageStyle CreateImageStyle(Viewport v) => new()
+    {
+        Image = new Image { Source = _imageSource },
+        SymbolScale = v.Resolution > _resolutionFlippingPoint ? 0.5 : 2.0,
+    };
+}

--- a/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSymbolScaleStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/DynamicSymbolScaleStyleSample.cs
@@ -1,43 +1,88 @@
 ﻿using Mapsui.Layers;
+using Mapsui.Nts.Extensions;
+using Mapsui.Providers;
 using Mapsui.Samples.Common.DataBuilders;
 using Mapsui.Styles;
 using Mapsui.Styles.Thematics;
-using Mapsui.Tiling;
+using NetTopologySuite.Geometries;
 using System.Threading.Tasks;
 
 namespace Mapsui.Samples.Common.Maps.Demo;
 
 public class DynamicSymbolScaleStyleSample : ISample
 {
-    private const double _resolutionFlippingPoint = 300.0;
-    private const string _imageSource = "embedded://Mapsui.Samples.Common.Images.arrow.svg";
+    private const double _level1 = 32000.0;
+    private const double _level2 = 16000.0;
+    private const double _level3 = 8000.0;
 
     public string Name => "Dynamic Symbol Scale Style";
-    public string Category => "Styles";
+    public string Category => "1";
 
     public Task<Map> CreateMapAsync()
     {
         var map = new Map();
-        map.Layers.Add(OpenStreetMap.CreateTileLayer());
+        map.Layers.Add(CreatePolygonLayer());
         map.Layers.Add(CreateLayerWithDynamicScaleStyle(map));
+        map.Navigator.OverrideResolutions = new[] { _level1, _level2, _level3 };
+        map.Navigator.OverrideZoomBounds = new MMinMax(_level1, _level3);
+        map.Navigator.ZoomToLevel(0);
         return Task.FromResult(map);
     }
 
     private static MemoryLayer CreateLayerWithDynamicScaleStyle(Map map) => new()
     {
         Name = "Dynamic Symbol Scale",
-        Features = RandomPointsBuilder.CreateRandomFeatures(map.Extent, 1000),
+        Features = RandomPointsBuilder.CreateRandomFeatures(map.Extent!.Grow(-map.Extent.Width * 0.94), 50, seed: 245),
         Style = CreateDynamicSymbolScaleStyle()
     };
 
     private static ThemeStyle CreateDynamicSymbolScaleStyle()
     {
-        return new ThemeStyle((f, v) => CreateImageStyle(v));
+        var fill = new Brush(new Color(242, 229, 29, 255));
+        var pen = new Pen(Color.DimGray, 1.6);
+
+        var smallStyle = new SymbolStyle { SymbolScale = 0.75, Fill = fill, Outline = pen };
+        var mediumStyle = new SymbolStyle { SymbolScale = 1, Fill = fill, Outline = pen };
+        var bigStyle = new SymbolStyle { SymbolScale = 1.5, Fill = fill, Outline = pen };
+
+        return new ThemeStyle((f, v) =>
+        {
+            return v.Resolution switch
+            {
+                > _level2 => smallStyle,
+                > _level3 => mediumStyle,
+                _ => bigStyle
+            };
+        });
     }
 
-    private static ImageStyle CreateImageStyle(Viewport v) => new()
+    public static ILayer CreatePolygonLayer()
     {
-        Image = new Image { Source = _imageSource },
-        SymbolScale = v.Resolution > _resolutionFlippingPoint ? 0.5 : 2.0,
-    };
+        return new Layer("Polygons")
+        {
+            DataSource = new MemoryProvider(CreateSquarePolygon(10000000).ToFeature()),
+            Style = new VectorStyle
+            {
+                Fill = new Brush(Color.LightGray),
+                Outline = new Pen
+                {
+                    Color = Color.DimGray,
+                    Width = 3
+                }
+            }
+        };
+    }
+
+    private static Polygon CreateSquarePolygon(int width)
+    {
+        int halfWidth = width / 2;
+        return new Polygon(new LinearRing(new[]
+        {
+            new Coordinate(-halfWidth, -halfWidth),
+            new Coordinate(-halfWidth, halfWidth),
+            new Coordinate(halfWidth, halfWidth),
+            new Coordinate(halfWidth, -halfWidth),
+            new Coordinate(-halfWidth, -halfWidth) // Closing the ring
+        }));
+    }
 }


### PR DESCRIPTION
This PR implements a way to return styles that depend on the viewport when using the ThemeStyle, based on a user request.

![image](https://github.com/user-attachments/assets/27625505-2f4f-450f-b777-d2b8feff66a9)

This the way this could be implemented:
```cs
private static ThemeStyle CreateDynamicSymbolScaleStyle()
{
    var fill = new Brush(new Color(242, 229, 29, 255));
    var pen = new Pen(Color.DimGray, 1.6);

    var smallStyle = new SymbolStyle { SymbolScale = 0.75, Fill = fill, Outline = pen };
    var mediumStyle = new SymbolStyle { SymbolScale = 1, Fill = fill, Outline = pen };
    var bigStyle = new SymbolStyle { SymbolScale = 1.5, Fill = fill, Outline = pen };

    return new ThemeStyle((f, v) =>
    {
        return v.Resolution switch
        {
            > _level2 => smallStyle,
            > _level3 => mediumStyle,
            _ => bigStyle
        };
    });
}
```