### PR TITLE
Fix feature copy constructor by copying Data and Id fields

### DIFF
--- a/Mapsui/Features/BaseFeature.cs
+++ b/Mapsui/Features/BaseFeature.cs
@@ -8,8 +8,8 @@ namespace Mapsui.Layers;
 
 public abstract class BaseFeature : IFeature
 {
-    // last used feature id
-    private static long _currentFeatureId;
+    private static long _currentFeatureId; // last used feature id
+    private readonly Dictionary<string, object?> _dictionary = [];
 
     protected BaseFeature(long id)
     {
@@ -45,8 +45,6 @@ public abstract class BaseFeature : IFeature
         foreach (var field in baseFeature.Fields)
             this[field] = baseFeature[field];
     }
-
-    private readonly Dictionary<string, object?> _dictionary = [];
 
     /// <inheritdoc />
     public ICollection<IStyle> Styles { get; set; } = [];

--- a/Mapsui/Features/BaseFeature.cs
+++ b/Mapsui/Features/BaseFeature.cs
@@ -21,14 +21,6 @@ public abstract class BaseFeature : IFeature
         Id = NextId();
     }
 
-    private static long NextId()
-    {
-        return Interlocked.Increment(ref _currentFeatureId);
-    }
-
-    /// <inheritdoc />
-    public long Id { get; private set; }
-
     protected BaseFeature(BaseFeature baseFeature) : this()
     {
         Copy(baseFeature);
@@ -39,12 +31,8 @@ public abstract class BaseFeature : IFeature
         Copy(baseFeature);
     }
 
-    private void Copy(BaseFeature baseFeature)
-    {
-        Styles = baseFeature.Styles.ToList(); // Styles is an ICollection, we need ToList instead of ToArray to prevent a NotSupportedException on Styles.Clear();
-        foreach (var field in baseFeature.Fields)
-            this[field] = baseFeature[field];
-    }
+    /// <inheritdoc />
+    public long Id { get; private set; }
 
     /// <inheritdoc />
     public ICollection<IStyle> Styles { get; set; } = [];
@@ -65,6 +53,20 @@ public abstract class BaseFeature : IFeature
         set => _dictionary[key] = value;
     }
 
+    private static long NextId()
+    {
+        return Interlocked.Increment(ref _currentFeatureId);
+    }
+
+    private void Copy(BaseFeature baseFeature)
+    {
+        Id = baseFeature.Id; // Copy the Id to maintain the same identity. If one of the copies is updated Modified() needs to be called.
+        Styles = baseFeature.Styles.ToList(); // Styles is an ICollection, we need ToList instead of ToArray to prevent a NotSupportedException on Styles.Clear();
+        foreach (var field in baseFeature.Fields)
+            this[field] = baseFeature[field];
+        Data = baseFeature.Data;
+    }
+
     /// <inheritdoc />
     virtual public void Modified()
     {
@@ -77,5 +79,4 @@ public abstract class BaseFeature : IFeature
 
     /// <inheritdoc />
     public abstract object Clone();
-
 }

--- a/Tests/Mapsui.Tests/Features/PointFeatureTests.cs
+++ b/Tests/Mapsui.Tests/Features/PointFeatureTests.cs
@@ -1,0 +1,31 @@
+﻿using Mapsui.Layers;
+using NUnit.Framework;
+
+namespace Mapsui.Tests.Features;
+
+[TestFixture]
+public class PointFeatureTests
+{
+    [Test]
+    public void Clone_ShouldCopyIdAndData_AndExtent()
+    {
+        // Arrange
+        var x = 5.0;
+        var y = 6.0;
+        var original = new PointFeature(x, y);
+        var data = "SomeData";
+        original.Data = data;
+
+        // Act
+        var clone = (PointFeature)original.Clone();
+
+        // Assert
+        Assert.That(clone.Id, Is.EqualTo(original.Id), "Clone should copy the Id field.");
+        Assert.That(clone.Data, Is.EqualTo(data), "Clone should copy the Data field.");
+        Assert.That(clone.Extent, Is.Not.Null, "Extent should not be null.");
+        Assert.That(clone.Extent.MinX, Is.EqualTo(x), "Extent.MinX should match the point's X.");
+        Assert.That(clone.Extent.MaxX, Is.EqualTo(x), "Extent.MaxX should match the point's X.");
+        Assert.That(clone.Extent.MinY, Is.EqualTo(y), "Extent.MinY should match the point's Y.");
+        Assert.That(clone.Extent.MaxY, Is.EqualTo(y), "Extent.MaxY should match the point's Y.");
+    }
+}


### PR DESCRIPTION
The projection logic copies the feature. The Data field gets lost this way. 

I decided to also copy the Id field. This way the Id could be used for the cache. The fact the that feature is mutable is a problem because different features could have the same Id. The solution is that the user has to call Modified after a mutation. This was already necessary to avoid using an outdated cache entry.