### PR TITLE
Uno 6.0.130

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="DotSpatial.Projections" Version="[4.0.656,5.0.0)" />
     <PackageVersion Include="CommunityToolkit.Maui.Markup" Version="[1.0.0,2.0.0)" />
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="DotNext.Threading" Version="5.15.0" />
     <PackageVersion Include="Eto.Forms" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.Platform.Wpf" Version="[2.8.0,3.0.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,7 +78,7 @@
     <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="3.119.0" />
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
-    <PackageVersion Include="Svg.Skia" Version="3.0.3" />
+    <PackageVersion Include="Svg.Skia" Version="3.0.0" />
     <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="Topten.RichTextKit" Version="0.4.167" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,8 +32,8 @@
     <PackageVersion Include="Eto.Platform.XamMac2" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.Platform.Gtk" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.SkiaDraw" Version="[0.2.0,0.3.0)" />
-    <PackageVersion Include="HarfBuzzSharp" Version="8.3.0.1" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.0.1" />
+    <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.1" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.1" />
     <PackageVersion Include="IDisposableAnalyzers" Version="[4.0.8,5.0.0)" />
     <PackageVersion Include="Mapsui.Android" Version="5.0.0-beta.8" />
     <PackageVersion Include="Mapsui.ArcGIS" Version="5.0.0-beta.8" />
@@ -62,20 +62,20 @@
     <PackageVersion Include="NetTopologySuite.IO.GeoJSON4STJ" Version="[4.0.0,5.0.0)" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageVersion Include="SkiaSharp" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.Skottie" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.Views" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.Views.Uno" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.Views.WinUI" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.Views.WPF" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="3.116.1" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.Skottie" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.Views" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.Views.Uno" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.Views.WinUI" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.Views.WPF" Version="3.119.0" />
+    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="3.119.0" />
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
     <PackageVersion Include="Svg.Skia" Version="2.0.0.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,7 +78,7 @@
     <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="3.119.0" />
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
-    <PackageVersion Include="Svg.Skia" Version="2.0.0.4" />
+    <PackageVersion Include="Svg.Skia" Version="3.0.3" />
     <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="Topten.RichTextKit" Version="0.4.167" />

--- a/Mapsui.Rendering.Skia/SkiaStyles/SvgColorModifier.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/SvgColorModifier.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using Svg;
-using Svg.Model;
 
 namespace Mapsui.Styles;
 
@@ -14,7 +13,7 @@ public static class SvgColorModifier
         var svgStrokeColor = (System.Drawing.Color?)strokeColor;
 
         using var memoryStream = new MemoryStream(bytes);
-        var svgDocument = SvgExtensions.Open(memoryStream) ?? throw new Exception("Could not open stream as svg");
+        var svgDocument = SvgDocument.Open<SvgDocument>(memoryStream) ?? throw new Exception("Could not open stream as svg");
 
         var elements = GetAllElements(svgDocument.Children);
         foreach (var element in elements)

--- a/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
+++ b/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
@@ -19,7 +19,8 @@
       https://aka.platform.uno/singleproject-features
     -->
     <UnoFeatures>
-    </UnoFeatures>
+			SkiaRenderer;
+		</UnoFeatures>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 

--- a/Mapsui.UI.WinUI/MapControl.cs
+++ b/Mapsui.UI.WinUI/MapControl.cs
@@ -41,8 +41,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
     public MapControl()
     {
-        SharedConstructor();
-
         // The commented out code crashes the app when MouseWheelAnimation.Duration > 0. Could be a bug in SKXamlCanvas
         //if (Dispatcher.HasThreadAccess) _canvas?.Invalidate();
         //else RunOnUIThread(() => _canvas?.Invalidate());
@@ -61,6 +59,9 @@ public partial class MapControl : Grid, IMapControl, IDisposable
             Children.Add(_canvas);
             _canvas.PaintSurface += Canvas_PaintSurface;
         }
+
+        // The Canvas needs to be first set before calling the Shared Constructor or else it crashes in the InvalidateCanvas
+        SharedConstructor();
 
         Children.Add(_selectRectangle);
 
@@ -320,6 +321,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         SharedDispose(disposing);
         base.Dispose();
     }
+
     public new void Dispose()
     {
         Dispose(true);

--- a/Mapsui.UI.WinUI/MapControl.cs
+++ b/Mapsui.UI.WinUI/MapControl.cs
@@ -314,21 +314,12 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         GC.SuppressFinalize(this);
     }
 #else
-#if __ANDROID__
-    protected new virtual void Dispose(bool disposing)
-    {
-        CommonUnoDispose(disposing);
-        SharedDispose(disposing);
-        base.Dispose(disposing);
-    }
-#else
     protected virtual void Dispose(bool disposing)
     {
         CommonUnoDispose(disposing);
         SharedDispose(disposing);
         base.Dispose();
     }
-#endif
     public new void Dispose()
     {
         Dispose(true);

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -41,6 +41,14 @@
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI"/>
   </ItemGroup>
 
+  <!--workaround for Uno.Resizetizer uses a newer skiasharp version then maui resizetizer -->
+  <ItemGroup>
+    <PackageReference Include="Uno.Resizetizer" VersionOverride="1.8.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <!--https://github.com/dotnet/runtime/issues/109289#issuecomment-2448960065-->
   <Target Name="Issue109289_Workaround" AfterTargets="_BrowserWasmWriteRspForLinking" Condition="'$(TargetFramework)' == 'net9.0-browserwasm'">
     <ItemGroup>

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -32,6 +32,14 @@
       SkiaRenderer;
 		</UnoFeatures>
   </PropertyGroup>
+	
+	<!--workaround for Uno.Resizetizer uses a newer skiasharp version then maui resizetizer -->
+	<ItemGroup>
+		<PackageReference Include="Uno.Resizetizer" VersionOverride="1.8.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('windows'))">
     <PackageReference Include="SkiaSharp.Views.WinUI"/>
@@ -39,14 +47,6 @@
 
   <ItemGroup Condition="!$(TargetFramework.Contains('windows'))">
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI"/>
-  </ItemGroup>
-
-  <!--workaround for Uno.Resizetizer uses a newer skiasharp version then maui resizetizer -->
-  <ItemGroup>
-    <PackageReference Include="Uno.Resizetizer" VersionOverride="1.8.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <!--https://github.com/dotnet/runtime/issues/109289#issuecomment-2448960065-->

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -33,14 +33,6 @@
 		</UnoFeatures>
   </PropertyGroup>
 
-  <!--workaround for Uno.Resizetizer uses a newer skiasharp version then maui resizetizer -->
-	<!--<ItemGroup>
-    <PackageReference Include="Uno.Resizetizer" VersionOverride="1.5.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>-->
-
   <ItemGroup Condition="$(TargetFramework.Contains('windows'))">
     <PackageReference Include="SkiaSharp.Views.WinUI"/>
   </ItemGroup>

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -33,12 +33,12 @@
   </PropertyGroup>
 
   <!--workaround for Uno.Resizetizer uses a newer skiasharp version then maui resizetizer -->
-  <ItemGroup>
+	<!--<ItemGroup>
     <PackageReference Include="Uno.Resizetizer" VersionOverride="1.5.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
+  </ItemGroup>-->
 
   <ItemGroup Condition="$(TargetFramework.Contains('windows'))">
     <PackageReference Include="SkiaSharp.Views.WinUI"/>

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -29,7 +29,8 @@
       https://aka.platform.uno/singleproject-features
     -->
     <UnoFeatures>
-    </UnoFeatures>
+      SkiaRenderer;
+		</UnoFeatures>
   </PropertyGroup>
 
   <!--workaround for Uno.Resizetizer uses a newer skiasharp version then maui resizetizer -->

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Android/Main.Android.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Android/Main.Android.cs
@@ -1,5 +1,4 @@
 using Android.Runtime;
-using Com.Nostra13.Universalimageloader.Core;
 
 namespace Mapsui.Samples.Uno.WinUI.Droid;
 

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Android/Main.Android.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Android/Main.Android.cs
@@ -15,19 +15,6 @@ public class Application : Microsoft.UI.Xaml.NativeApplication
     public Application(IntPtr javaReference, JniHandleOwnership transfer)
         : base(() => new App(), javaReference, transfer)
     {
-        ConfigureUniversalImageLoader();
-    }
-
-    private static void ConfigureUniversalImageLoader()
-    {
-        // Create global configuration and initialize ImageLoader with this config
-        ImageLoaderConfiguration config = new ImageLoaderConfiguration
-            .Builder(Context)
-            .Build();
-
-        ImageLoader.Instance.Init(config);
-
-        ImageSource.DefaultImageLoader = ImageLoader.Instance.LoadImageAsync;
     }
 }
 

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Desktop/Program.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Desktop/Program.cs
@@ -1,5 +1,4 @@
 using Uno.UI.Hosting;
-using Uno.UI.Runtime.Skia;
 
 namespace Mapsui.Samples.Uno.WinUI;
 

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Desktop/Program.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/Desktop/Program.cs
@@ -1,3 +1,4 @@
+using Uno.UI.Hosting;
 using Uno.UI.Runtime.Skia;
 
 namespace Mapsui.Samples.Uno.WinUI;
@@ -9,7 +10,7 @@ public class Program
     {
         App.InitializeLogging();
 
-        var host = SkiaHostBuilder.Create()
+        var host = UnoPlatformHostBuilder.Create()
             .App(() => new App())
             .UseX11()
             .UseLinuxFrameBuffer()

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/WebAssembly/Program.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/WebAssembly/Program.cs
@@ -6,8 +6,11 @@ public class Program
 
     public static int Main(string[] args)
     {
-        Microsoft.UI.Xaml.Application.Start(_ => _app = new App());
+        var host = UnoPlatformHostBuilder.Create()
+        .App(() => new App())
+        .UseWebAssembly()
+        .Build();
 
-        return 0;
+        await host.RunAsync();
     }
 }

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/iOS/Main.iOS.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/iOS/Main.iOS.cs
@@ -1,4 +1,5 @@
 using UIKit;
+using Uno.UI.Hosting;
 
 namespace Mapsui.Samples.Uno.WinUI.iOS;
 
@@ -7,8 +8,13 @@ public class EntryPoint
     // This is the main entry point of the application.
     public static void Main(string[] args)
     {
-        // if you want to use a different Application Delegate class from "AppDelegate"
-        // you can specify it here.
-        UIApplication.Main(args, null, typeof(App));
+        App.InitializeLogging();
+
+        var host = UnoPlatformHostBuilder.Create()
+            .App(() => new App())
+            .UseAppleUIKit()
+            .Build();
+
+        host.Run();
     }
 }

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/iOS/Main.iOS.cs
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Platforms/iOS/Main.iOS.cs
@@ -1,4 +1,3 @@
-using UIKit;
 using Uno.UI.Hosting;
 
 namespace Mapsui.Samples.Uno.WinUI.iOS;

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "rollForward": "disable"
   },
   "msbuild-sdks": {
-    "Uno.Sdk": "5.5.56"
+    "Uno.Sdk": "6.0.130"
   }
 }


### PR DESCRIPTION
Please summarize your PR and explain which problem it solves.

- Updates Uno to Version 6.0.130
- Updates SkiaSharp to 3.119 (Needed by Uno 6.0.130)
- Updated to Svg.Skia 3.0.0 (based on SkiaSharp 3.x)
- Fixed Bug in MapControl WinUI: 
SharedConstructor should only be called  after Canvas Initialization. Because else the First InvalidateCanvas crashes because the _canvas is not set yet.
