### PR TITLE
Fix map now showing at startup on WinUI and possibly other platforms

### DIFF
--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -27,15 +27,15 @@ public partial class MapControl : ViewGroup, IMapControl
     public MapControl(Context context, IAttributeSet attrs) :
         base(context, attrs)
     {
-        SharedConstructor();
         LocalConstructor();
+        SharedConstructor();
     }
 
     public MapControl(Context context, IAttributeSet attrs, int defStyle) :
         base(context, attrs, defStyle)
     {
-        SharedConstructor();
         LocalConstructor();
+        SharedConstructor();
     }
 
 

--- a/Mapsui.UI.Avalonia/MapControl.cs
+++ b/Mapsui.UI.Avalonia/MapControl.cs
@@ -28,8 +28,6 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
 
     public MapControl()
     {
-        SharedConstructor();
-
         Initialized += MapControlInitialized;
 
         // Pointer events
@@ -45,6 +43,8 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
         KeyUp += (s, e) => _shiftPressed = GetShiftPressed(e.KeyModifiers);
 
         ClipToBounds = true;
+
+        SharedConstructor();
     }
 
     public void InvalidateCanvas()

--- a/Mapsui.UI.Eto/MapControl.cs
+++ b/Mapsui.UI.Eto/MapControl.cs
@@ -16,8 +16,8 @@ public partial class MapControl : SkiaDrawable, IMapControl
 
     public MapControl()
     {
-        SharedConstructor();
         SizeChanged += MapControl_SizeChanged; ;
+        SharedConstructor();
     }
 
     public void InvalidateCanvas()

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -41,8 +41,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
 
     public MapControl()
     {
-        SharedConstructor();
-
         View view;
 
         BackgroundColor = KnownColor.White;
@@ -75,6 +73,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
         }
         view.SizeChanged += View_SizeChanged;
         Content = view;
+        SharedConstructor();
     }
 
     public void InvalidateCanvas()

--- a/Mapsui.UI.WindowsForms/MapControl.cs
+++ b/Mapsui.UI.WindowsForms/MapControl.cs
@@ -21,8 +21,6 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
 #endif
     public MapControl()
     {
-        SharedConstructor();
-
         Control view;
 
         Dock = DockStyle.Fill;
@@ -56,6 +54,8 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
         view.Dock = DockStyle.Fill;
 
         Controls.Add(view);
+
+        SharedConstructor();
     }
 
     public void InvalidateCanvas()

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -21,8 +21,6 @@ public partial class MapControl : Grid, IMapControl, IDisposable
 
     public MapControl()
     {
-        SharedConstructor();
-
         Children.Add(SkiaCanvas);
 
         SkiaCanvas.PaintSurface += SKElementOnPaintSurface;
@@ -46,6 +44,9 @@ public partial class MapControl : Grid, IMapControl, IDisposable
         IsManipulationEnabled = true;
 
         SkiaCanvas.Visibility = Visibility.Visible;
+
+        SharedConstructor();
+
         RefreshGraphics();
     }
 

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -18,15 +18,15 @@ public partial class MapControl : UIView, IMapControl
     public MapControl(CGRect frame)
         : base(frame)
     {
-        SharedConstructor();
         LocalConstructor();
+        SharedConstructor();
     }
 
     [Preserve]
     public MapControl(IntPtr handle) : base(handle) // Used when initialized from storyboard
     {
-        SharedConstructor();
         LocalConstructor();
+        SharedConstructor();
     }
 
     public void InvalidateCanvas()


### PR DESCRIPTION
This fix a possible bug where a refresh was called before the invalidate method was assigned. The shared constructor was moved to the end of regular constructor to postpone map refresh.