### PR TITLE
Use SkiaSharp.Skottie Version 3.119.0 in the Uno Sample instead of 3.119.0-preview.1.2

### DIFF
--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -39,6 +39,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
+    <PackageReference Include="SkiaSharp.Skottie" />
 	</ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('windows'))">


### PR DESCRIPTION
Small Uno WinUI Sample change. So that the referenced SkiaSharp.Skottie Version is 3.119.0 instead of 3.119.0-preview.1.2 reducing the used versions