### PR TITLE
Mapsui.UI.Maui: implement workaround for SkiaSharp issue 2550 with MAUI 9 on Android

### DIFF
--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -438,7 +438,9 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
 
         glThreadField = typeof(SkiaSharp.Views.Android.GLTextureView).GetField("glThread", BindingFlags.NonPublic | BindingFlags.Instance);
         var glThread = glThreadField?.GetValue(glTextureView);
+#pragma warning disable IL2075
         glThreadExitedField = glThread?.GetType().GetField("exited", BindingFlags.Instance | BindingFlags.Public);
+#pragma warning restore IL2075
     }
 
     /// <summary>

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -11,11 +11,6 @@ using System.ComponentModel;
 using System.Linq;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
-#if ANDROID
-using System.Reflection;
-using System.Threading.Tasks;
-using SkiaSharp.Views.Maui.Handlers;
-#endif
 
 namespace Mapsui.UI.Maui;
 
@@ -31,8 +26,6 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     private readonly ConcurrentDictionary<long, PointerRecording> _positions = new();
     private static List<WeakReference<MapControl>>? _listeners;
     private readonly ManipulationTracker _manipulationTracker = new();
-    private Page? _page;
-    private Element? _element;
 
     /// <summary>
     /// If finger position is not updated during the IsStaleTimeSpan period, the touch event is considered stale and is removed.
@@ -321,17 +314,9 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
             Map?.Dispose();
         }
 
-        if (_element != null)
-        {
-            _element.ParentChanged -= Element_ParentChanged;
-            _element = null;
-        }
-
-        if (_page != null)
-        {
-            _page.Appearing -= Page_Appearing;
-            _page = null;
-        }
+#if ANDROID
+        DisposeAndroid();
+#endif
 
         SharedDispose(disposing);
     }
@@ -359,130 +344,8 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
 
     private static bool GetShiftPressed() => false; // Work in progress: https://github.com/dotnet/maui/issues/16202
 
-    protected override void OnParentSet()
-    {
-        base.OnParentSet();
-        AttachToOnAppearing();
-    }
-
-    private void Element_ParentChanged(object? sender, EventArgs e)
-    {
-        if (_element != null)
-        {
-            _element.ParentChanged -= Element_ParentChanged;
-            _element = null;
-        }
-
-        AttachToOnAppearing();
-    }
-
     private record struct PointerRecording(ScreenPosition ScreenPosition, long Timestamp)
     {
     }
-
-    // Everything below is a workaround for Android not displaying the map after Maui page navigation (when using GPU)
-    // https://github.com/mono/SkiaSharp/issues/2550
-
-    private void AttachToOnAppearing()
-    {
-#if ANDROID
-        if (UseGPU && Parent != null)
-        {
-            _page = GetPage(Parent);
-            if (_page != null)
-            {
-                _page.Appearing += Page_Appearing;
-            }
-        }
-#endif
-    }
-
-    private void Page_Appearing(object? sender, EventArgs e)
-    {
-#if ANDROID
-        FixInvisible();
-#endif
-    }
-
-#if ANDROID
-    private Page? GetPage(Element? element)
-    {
-        if (element == null)
-        {
-            return null;
-        }
-
-        if (element is Page page)
-        {
-            return page;
-        }
-
-        if (element.Parent == null)
-        {
-            _element = element;
-            _element.ParentChanged += Element_ParentChanged;
-            return null;
-        }
-
-        return GetPage(element.Parent);
-    }
-
-    private static FieldInfo? glThreadField;
-    private static FieldInfo? glThreadExitedField;
-    private Task? sizeNotifyTask;
-
-    private static void LoadReflectionFields(SkiaSharp.Views.Android.GLTextureView glTextureView)
-    {
-        if (glThreadExitedField is not null)
-            return;
-
-        glThreadField = typeof(SkiaSharp.Views.Android.GLTextureView).GetField("glThread", BindingFlags.NonPublic | BindingFlags.Instance);
-        var glThread = glThreadField?.GetValue(glTextureView);
-#pragma warning disable IL2075
-        glThreadExitedField = glThread?.GetType().GetField("exited", BindingFlags.Instance | BindingFlags.Public);
-#pragma warning restore IL2075
-    }
-
-    /// <summary>
-    /// An SKGLView may become invisible when it is reappearing after being off-screen. Calling this hack will trigger the View to render again properly.
-    /// This is because the SkiaSharp.Views.Android.GLTextureView.GLThread is restarted when an SKGLView has reappeared, and it by default assumes that
-    /// the size of the View is (0, 0) until notified otherwise. Instead of resizing this View, we are calling the GLTextureView's
-    /// OnSurfaceTextureSizeChanged function, which in turn will call the GLThread's OnWindowResize(int width, int height)
-    /// with the actual View's size to kick the GLThread back into action.
-    /// </summary>
-    public void FixInvisible()
-    {
-        var handler = _glView?.Handler as SKGLViewHandler;
-        if (handler is not null)
-        {
-            SkiaSharp.Views.Android.GLTextureView glTextureView = handler.PlatformView;
-            LoadReflectionFields(glTextureView);
-
-            // Ensure there's only a single polling Task that will fix the SKGLView's internal render thread
-            if (sizeNotifyTask is not null && !sizeNotifyTask.IsCompleted)
-            {
-                return;
-            }
-
-            sizeNotifyTask = Task.Run(async () =>
-            {
-                while (true)
-                {
-                    var glThread = glThreadField?.GetValue(glTextureView);
-                    bool? exited = (bool?)glThreadExitedField?.GetValue(glThread);
-                    if (exited.HasValue && exited.Value)
-                    {
-                        // The TextureView still has its old glThread. Wait for the new glThread to be created
-                        await Task.Delay(30);
-                        continue;
-                    }
-                    // Now notify the glThread of the actual size of the View
-                    glTextureView.OnSurfaceTextureSizeChanged(null, glTextureView.Width, glTextureView.Height);
-                    return;
-                }
-            });
-        }
-    }
-#endif
 
 }

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -400,15 +400,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
     private void Page_Appearing(object? sender, EventArgs e)
     {
 #if ANDROID
-        if (IsMaui9())
-        {
-            FixInvisible();
-        }
-        else
-        {
-            IsVisible = false;
-            IsVisible = true;
-        }
+        FixInvisible();
 #endif
     }
 

--- a/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
+++ b/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net9.0-android</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <DefineConstants>__MAUI__</DefineConstants>

--- a/Mapsui.UI.Maui/Platforms/Android/MapControl.cs
+++ b/Mapsui.UI.Maui/Platforms/Android/MapControl.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using SkiaSharp.Views.Maui.Handlers;
+
+namespace Mapsui.UI.Maui;
+
+/// <summary>
+/// UI component that displays an interactive map 
+/// </summary>
+public partial class MapControl : ContentView, IMapControl, IDisposable
+{
+    // Everything in this file is a workaround for Android not displaying the map after Maui page navigation (when using GPU)
+    // https://github.com/mono/SkiaSharp/issues/2550
+
+    private Page? _page;
+    private Element? _element;
+
+    private void DisposeAndroid()
+    {
+        if (_element != null)
+        {
+            _element.ParentChanged -= Element_ParentChanged;
+            _element = null;
+        }
+
+        if (_page != null)
+        {
+            _page.Appearing -= Page_Appearing;
+            _page = null;
+        }
+    }
+
+    protected override void OnParentSet()
+    {
+        base.OnParentSet();
+        AttachToOnAppearing();
+    }
+
+    private void Element_ParentChanged(object? sender, EventArgs e)
+    {
+        if (_element != null)
+        {
+            _element.ParentChanged -= Element_ParentChanged;
+            _element = null;
+        }
+
+        AttachToOnAppearing();
+    }
+
+    private void AttachToOnAppearing()
+    {
+        if (UseGPU && Parent != null)
+        {
+            _page = GetPage(Parent);
+            if (_page != null)
+            {
+                _page.Appearing += Page_Appearing;
+            }
+        }
+    }
+
+    private void Page_Appearing(object? sender, EventArgs e)
+    {
+        FixInvisible();
+    }
+
+    private Page? GetPage(Element? element)
+    {
+        if (element == null)
+        {
+            return null;
+        }
+
+        if (element is Page page)
+        {
+            return page;
+        }
+
+        if (element.Parent == null)
+        {
+            _element = element;
+            _element.ParentChanged += Element_ParentChanged;
+            return null;
+        }
+
+        return GetPage(element.Parent);
+    }
+
+    private static FieldInfo? glThreadField;
+    private static FieldInfo? glThreadExitedField;
+    private Task? sizeNotifyTask;
+
+    private static void LoadReflectionFields(SkiaSharp.Views.Android.GLTextureView glTextureView)
+    {
+        if (glThreadExitedField is not null)
+            return;
+
+        glThreadField = typeof(SkiaSharp.Views.Android.GLTextureView).GetField("glThread", BindingFlags.NonPublic | BindingFlags.Instance);
+        var glThread = glThreadField?.GetValue(glTextureView);
+#pragma warning disable IL2075
+        glThreadExitedField = glThread?.GetType().GetField("exited", BindingFlags.Instance | BindingFlags.Public);
+#pragma warning restore IL2075
+    }
+
+    /// <summary>
+    /// An SKGLView may become invisible when it is reappearing after being off-screen. Calling this hack will trigger the View to render again properly.
+    /// This is because the SkiaSharp.Views.Android.GLTextureView.GLThread is restarted when an SKGLView has reappeared, and it by default assumes that
+    /// the size of the View is (0, 0) until notified otherwise. Instead of resizing this View, we are calling the GLTextureView's
+    /// OnSurfaceTextureSizeChanged function, which in turn will call the GLThread's OnWindowResize(int width, int height)
+    /// with the actual View's size to kick the GLThread back into action.
+    /// </summary>
+    public void FixInvisible()
+    {
+        var handler = _glView?.Handler as SKGLViewHandler;
+        if (handler is not null)
+        {
+            SkiaSharp.Views.Android.GLTextureView glTextureView = handler.PlatformView;
+            LoadReflectionFields(glTextureView);
+
+            // Ensure there's only a single polling Task that will fix the SKGLView's internal render thread
+            if (sizeNotifyTask is not null && !sizeNotifyTask.IsCompleted)
+            {
+                return;
+            }
+
+            sizeNotifyTask = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    var glThread = glThreadField?.GetValue(glTextureView);
+                    bool? exited = (bool?)glThreadExitedField?.GetValue(glThread);
+                    if (exited.HasValue && exited.Value)
+                    {
+                        // The TextureView still has its old glThread. Wait for the new glThread to be created
+                        await Task.Delay(30);
+                        continue;
+                    }
+                    // Now notify the glThread of the actual size of the View
+                    glTextureView.OnSurfaceTextureSizeChanged(null, glTextureView.Width, glTextureView.Height);
+                    return;
+                }
+            });
+        }
+    }
+}

--- a/Mapsui.UI.Maui8/Mapsui.UI.Maui8.csproj
+++ b/Mapsui.UI.Maui8/Mapsui.UI.Maui8.csproj
@@ -38,6 +38,11 @@
     <Compile Include="..\Mapsui.UI.Maui\MapControl.cs" Link="MapControl.cs" />
     <Compile Include="..\Mapsui.UI.Maui\Utils\KnownColor.cs" Link="Utils\KnownColor.cs" />
   </ItemGroup>
+
+  <!-- Android -->
+  <ItemGroup Condition="$(TargetFramework.Contains('-android'))">
+    <Compile Include="..\Mapsui.UI.Maui\Platforms\Android\MapControl.cs" Link="Platforms\Android\MapControl.cs" />
+  </ItemGroup>
  
   <ItemGroup>
     <PackageReference Include="SkiaSharp" />

--- a/Mapsui.UI.Maui8/Mapsui.UI.Maui8.csproj
+++ b/Mapsui.UI.Maui8/Mapsui.UI.Maui8.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <DefineConstants>__MAUI__</DefineConstants>


### PR DESCRIPTION
This PR implements a workaround for mono/SkiaSharp#2550 in the context of MAUI 9.

The SkiaSharp bug did already occur with MAUI 8, and was a bit easier to work around there (see #2820 by @inforithmics). It transformed a bit with MAUI 9 (see https://github.com/mono/SkiaSharp/issues/2550#issuecomment-3094137132), and the old workaround stopped working.

Gladly, an effective workaround for MAUI 9 was found by @SimonvBez, and I adapted and applied it to Mapsui.UI.Maui.MapControl (extending the previous MAUI 8 workaround).

Note: In order to include Android-specific code properly (via conditional compilation, `#if ANDROID ... #endif`), it was necessary to add a net9.0-android TFM to Mapsui.UI.Maui.

A reproducer (based on Mapsui.Samples.Maui) can be found here:
* https://github.com/janusw/Mapsui/tree/SkiaSharp_issue2550_repro/Samples/Mapsui.Samples.Maui
* https://github.com/janusw/Mapsui/commit/f149bb322396c5fa20c8dfc40e71cff84433a6a5

I verified that it is fixed with this PR (on a Pixel 9 with Android 16).

@SimonvBez If you have any comments on this, please let us know.