### PR TITLE
[4.1] Mapsui.UI.Maui: allow usage with .NET MAUI 9

### DIFF
--- a/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
+++ b/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
@@ -48,8 +48,8 @@
 	</ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
-    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="[$(MauiVersion),9.0.0)" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="[$(MauiVersion),9.0.0)" />
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="[$(MauiVersion),10.0.0)" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="[$(MauiVersion),10.0.0)" />
   </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This PR is motivated by the discussion at https://github.com/Mapsui/Mapsui/discussions/3063 (which for now is largely a monologue 😆): Although MAUI 9 is potentially a breaking change wrt MAUI 8, it seems that Mapsui4 works well with .NET MAUI 9 in common scenarios (although only targeting .NET 8).

Consequently, the PR loosens the package-version restrictions of Mapsui.UI.Maui to allow Maui 9.x, fixing warnings like this:

```
warning NU1608: Detected package version outside of dependency constraint:
Mapsui.Maui 4.1.9 requires Microsoft.Maui.Controls (>= 8.0.100 && < 9.0.0) but version Microsoft.Maui.Controls 9.0.51 was resolved.
warning NU1608: Detected package version outside of dependency constraint:
Mapsui.Maui 4.1.9 requires Microsoft.Maui.Controls.Compatibility (>= 8.0.100 && < 9.0.0) but version Microsoft.Maui.Controls.Compatibility 9.0.51 was resolved.
```