### PR TITLE
Update Mapsui.UI.Uno.WinUI to Uno 6.2 and adjust RenderControl to be condition compilation-free

### DIFF
--- a/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
+++ b/Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop;net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-android;net9.0-browserwasm;net9.0-windows10.0.19041;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-android;net8.0-windows10.0.19041;net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-android;net9.0-windows10.0.19041</TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
@@ -19,14 +19,9 @@
       https://aka.platform.uno/singleproject-features
     -->
     <UnoFeatures>
-      SkiaRenderer;
+      Skia;
     </UnoFeatures>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">$(DefineConstants);__UNO_WINDOWS__</DefineConstants>
-    <DefineConstants Condition="
-                     $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != '' and
-                     $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows' and
-                     ($([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'desktop' or $(UnoFeatures.Contains('SkiaRenderer')))">$(DefineConstants);__UNO_SKIA__</DefineConstants>
 	</PropertyGroup>
 
 

--- a/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
+++ b/Samples/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI/Mapsui.Samples.Uno.WinUI.csproj
@@ -67,10 +67,35 @@
     </ItemGroup>
   </Target>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Mapsui.UI.Uno.WinUI\Mapsui.UI.Uno.WinUI.csproj" />
-    <ProjectReference Include="..\..\..\Tests\Mapsui.Tests.Common\Mapsui.Tests.Common.csproj" />
-    <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="!$(TargetFramework.Contains('windows')) and $(UnoFeatures.Contains('SkiaRenderer'))">
+      <ItemGroup>
+        <!-- The UndefineProperties and SetTargetFramework properties below are necessary to force
+           this TFM of the projects below to be net9.0 even when the TFM of this project is net9.0-<platform>.
+           This is only necessary when SkiaRenderer is set and only for this sample app that uses ProjectReferences.
+           For user apps that use the Mapsui.UI.Uno.WinUI package (with PackageReferences), the logic below is unnecessary
+           and selecting the correct TFM is handled by Uno.Sdk  -->
+        <ProjectReference Include="..\..\..\Mapsui.UI.Uno.WinUI\Mapsui.UI.Uno.WinUI.csproj">
+          <UndefineProperties>RuntimeIdentifier</UndefineProperties>
+          <SetTargetFramework>TargetFramework=net9.0</SetTargetFramework>
+        </ProjectReference>
+        <ProjectReference Include="..\..\..\Tests\Mapsui.Tests.Common\Mapsui.Tests.Common.csproj">
+          <UndefineProperties>RuntimeIdentifier</UndefineProperties>
+          <SetTargetFramework>TargetFramework=net9.0</SetTargetFramework>
+        </ProjectReference>
+        <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj">
+          <UndefineProperties>RuntimeIdentifier</UndefineProperties>
+          <SetTargetFramework>TargetFramework=net9.0</SetTargetFramework>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <ProjectReference Include="..\..\..\Mapsui.UI.Uno.WinUI\Mapsui.UI.Uno.WinUI.csproj" />
+        <ProjectReference Include="..\..\..\Tests\Mapsui.Tests.Common\Mapsui.Tests.Common.csproj" />
+        <ProjectReference Include="..\..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "rollForward": "disable"
   },
   "msbuild-sdks": {
-    "Uno.Sdk": "6.0.130"
+    "Uno.Sdk": "6.2.29"
   }
 }


### PR DESCRIPTION
This is related to https://github.com/Mapsui/Mapsui/issues/3030 and follows up https://github.com/Mapsui/Mapsui/pull/3054. It moves to the just-released Uno 6.2 which includes adjustments to the SKCanvasElement API to make it available at compile time on all targets (but will crash at runtime if unsupported on the current target). This removes all the conditional compilation logic that was added in the previous PR.

More importantly, the Mapsui.UI.Uno.WinUI no longer declares `SkiaRenderer`. This allows it to support both native rendering and skia rendering depending on the end application declaration of `SkiaRenderer` instead of the current situation where only skia rendering is supported. How this works is through the Uno.Sdk.
* If the user app referencing Mapsui.UI.Uno.WinUI doesn't declare `SkiaRenderer`, the used TFM of Mapsui.UI.Uno.WinUI will match that of the app. Meaning that on Android, net9.0-android will be used, in which case SKSwapChainPanel will be used.
* If the user app referecing Mapsui.UI.Uno.WinUI declares `SkiaRenderer`, Uno.Sdk will force Mapsui.UI.Uno.WinUI to switch to the net9.0 TFM (even though by default MSBuild would grab the net9.0-<platform> TFM assemblies) which will use SKCanvasElement.