### PR TITLE
MapView: prevent PinClicked event from being triggered multiple times

### DIFF
--- a/Mapsui.UI.MapView/MapView.cs
+++ b/Mapsui.UI.MapView/MapView.cs
@@ -56,7 +56,6 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
         // Add some events to _mapControl
         Map.Navigator.ViewportChanged += HandlerViewportChanged;
-        Info += (s, e) => HandlerInfo(e);
         SizeChanged += HandlerSizeChanged;
 
         // Add MapView layers to Map
@@ -430,7 +429,6 @@ public class MapView : MapControl, INotifyPropertyChanged, IEnumerable<Pin>
 
                 // Add event handlers
                 Map.Navigator.ViewportChanged += HandlerViewportChanged;
-                Info += (s, e) => HandlerInfo(e);
             }
         }
     }

--- a/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MainPageLarge.xaml.cs
@@ -3,7 +3,6 @@ using Mapsui.Extensions;
 using System.Diagnostics.CodeAnalysis;
 using Mapsui.Logging;
 using Mapsui.Samples.Common.Extensions;
-using Mapsui.Styles;
 using Mapsui.UI.Maui;
 using Mapsui.Manipulations;
 
@@ -70,15 +69,6 @@ public sealed partial class MainPageLarge : ContentPage, IDisposable
         if (mapInfo.Feature != null)
         {
             featureInfo.Text = $"Click Info:{Environment.NewLine}{mapInfo.Feature.ToDisplayText()}";
-
-            foreach (var style in mapInfo.Feature.Styles)
-            {
-                if (style is CalloutStyle)
-                {
-                    style.Enabled = !style.Enabled;
-                    e.Handled = true;
-                }
-            }
 
             mapView.RefreshGraphics();
         }

--- a/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
+++ b/Samples/Mapsui.Samples.Maui.MapView/MapPage.xaml.cs
@@ -3,7 +3,6 @@ using Mapsui.Extensions;
 using Mapsui.Logging;
 using Mapsui.Samples.Common;
 using Mapsui.Samples.Common.Extensions;
-using Mapsui.Styles;
 using Mapsui.UI.Maui;
 using Compass = Microsoft.Maui.Devices.Sensors.Compass;
 using Mapsui.Manipulations;
@@ -40,8 +39,6 @@ public sealed partial class MapPage : ContentPage, IDisposable
 
         mapView.MyLocationLayer.UpdateMyLocation(new Position());
 
-        mapView.Info += MapView_Info;
-
         Catch.TaskRun(StartGPS);
 
         try
@@ -66,28 +63,6 @@ public sealed partial class MapPage : ContentPage, IDisposable
     {
         mapView.IsVisible = true;
         mapView.Refresh();
-    }
-
-    private void MapView_Info(object? sender, MapInfoEventArgs? e)
-    {
-        if (e is null)
-            return;
-
-        var mapInfo = e.GetMapInfo(mapView.MapInfoLayers);
-
-        if (mapInfo.Feature != null)
-        {
-            foreach (var style in mapInfo.Feature.Styles)
-            {
-                if (style is CalloutStyle)
-                {
-                    style.Enabled = !style.Enabled;
-                    e.Handled = true;
-                }
-            }
-
-            mapView.RefreshGraphics();
-        }
     }
 
     private void OnMapClicked(object? sender, MapClickedEventArgs e)


### PR DESCRIPTION
This is supposed to fix #3091 (by removing the use of the `MapControl.Info` event, which is apparently "deprecated", from the `MapView` class).

In addition it fixes a minor problem with the PinSample (in the `Mapsui.Samples.Maui.MapView` app), which has been noticed by @pauldendulk:

> BTW, I notices something odd. If I remove a callout by clicking on the callout I can not enable the callout by clicking on the pin. If I remove the callout by clicking on the pin I can toggle it back on. Perhaps this is just an unrelated problem.

This is not a general `MapView` issue, but only occurs in the sample app. It is fixed by the second commit.