### PR TITLE
Use MinimalRenderFetchStrategy in RasterizingTileLayer

### DIFF
--- a/Mapsui.Tiling/Layers/RasterizingTileLayer.cs
+++ b/Mapsui.Tiling/Layers/RasterizingTileLayer.cs
@@ -48,7 +48,7 @@ public class RasterizingTileLayer : TileLayer, ISourceLayer, IFetchableSource, I
         minTiles,
         maxTiles,
         dataFetchStrategy,
-        renderFetchStrategy ?? new TilingRenderFetchStrategy(null),
+        renderFetchStrategy ?? new TilingRenderFetchStrategy(),
         minExtraTiles,
         maxExtraTiles)
     {

--- a/Mapsui.Tiling/Rendering/TilingRenderFetchStrategy.cs
+++ b/Mapsui.Tiling/Rendering/TilingRenderFetchStrategy.cs
@@ -11,9 +11,9 @@ public class TilingRenderFetchStrategy : IRenderFetchStrategy
     private readonly IRenderFetchStrategy _renderFetchStrategy;
     private IList<IFeature>? _lastFetch;
 
-    public TilingRenderFetchStrategy(IRenderFetchStrategy? renderFetchStrategy)
+    public TilingRenderFetchStrategy(IRenderFetchStrategy? renderFetchStrategy = null)
     {
-        _renderFetchStrategy = renderFetchStrategy ?? new RenderFetchStrategy();
+        _renderFetchStrategy = renderFetchStrategy ?? new MinimalRenderFetchStrategy();
     }
 
     public IList<IFeature> Get(MRect extent, double resolution, ITileSchema schema, ITileCache<IFeature?> memoryCache)


### PR DESCRIPTION
### The Problem 

When a tile is missing we can fetch a higher level tile to fill the area of the missing tile with the lower resolution higher level tile. The class we use for this is the RenderFetchStrategy. This method works well for many background layers, but if the layer contains labels or symbols they will be upscaled, which looks ugly. In most cases where the RasterizingTileLayer is used the data does contain labels or symbols

### The Solution
In the RasterizingTileLayer we now default to the MinimalRenderFetchStrategy. 

### Screenshots

Before:

<img width="785" height="582" alt="image" src="https://github.com/user-attachments/assets/e2d80c7b-7a3c-4b3a-a6c0-147070623a0e" />

After:

<img width="783" height="574" alt="image" src="https://github.com/user-attachments/assets/d6823c65-9234-4553-bc5f-73f045be7f70" />


