### PR TITLE
Remove Microsoft.Maui.Controls.Compatibility 

### DIFF
--- a/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
+++ b/Mapsui.UI.Maui/Mapsui.UI.Maui.csproj
@@ -36,8 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="$(MauiVersion)" />    
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This Removes dependency from Microsoft.Maui.Controls.Compatibility nuget. It isn't used and is deprecated.
