### PR TITLE
Update VexTile to 2.0.0-beta.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -85,6 +85,6 @@
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="Topten.RichTextKit" Version="0.4.167" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
-    <PackageVersion Include="VexTile.TileSource.Mvt" Version="1.0.2" />
+    <PackageVersion Include="VexTile.TileSource.Mvt" Version="2.0.0-beta.1" />
   </ItemGroup>
 </Project>

--- a/Mapsui.Experimental.VectorTiles/Mapsui.Experimental.VectorTiles.csproj
+++ b/Mapsui.Experimental.VectorTiles/Mapsui.Experimental.VectorTiles.csproj
@@ -6,7 +6,6 @@
     <PackageTags>$(PackageTags) vector tiles vextile tiling mbtiles mvt</PackageTags>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
-    <Version>5.0.0-beta.23</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/Mapsui.Experimental.VectorTiles/RasterizedVectorTileSource.cs
+++ b/Mapsui.Experimental.VectorTiles/RasterizedVectorTileSource.cs
@@ -25,7 +25,7 @@ public sealed class RasterizedVectorTileSource : ILocalTileSource
     public string Name => "VexTile";
     public Attribution Attribution => new("Attributions");
 
-    public Task<byte[]?> GetTileAsync(BruTile.TileInfo tileInfo)
+    public async Task<byte[]?> GetTileAsync(BruTile.TileInfo tileInfo)
     {
         var canvas = new SkiaCanvas();
         var col = tileInfo.Index.Col;
@@ -38,7 +38,8 @@ public sealed class RasterizedVectorTileSource : ILocalTileSource
 
         var tileWidth = _schema.GetTileWidth(tileInfo.Index.Level);
         var tileHeight = _schema.GetTileHeight(tileInfo.Index.Level);
-        return TileRendererFactory.RenderAsync(_style, canvas, col, row, tileInfo.Index.Level,
+        await TileRendererFactory.RenderAsync(_style, canvas, col, row, tileInfo.Index.Level,
             tileWidth, tileHeight);
+        return canvas.ToPngByteArray();
     }
 }


### PR DESCRIPTION
This solves an cross thread exception and this might make this useable in this form.  The current implementation rasterizes early, but for background maps this is not a big problem (it is ugly for labels and symbols). Performance can be improved, and it will, over time.