### PR TITLE
Enable GPU by default on MAUI 9 again

### DIFF
--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -19,7 +19,7 @@ namespace Mapsui.UI.Maui;
 /// </summary>
 public partial class MapControl : ContentView, IMapControl, IDisposable
 {
-    public static bool UseGPU = !IsMaui9();
+    public static bool UseGPU { get; set; } = true;
 
     private readonly SKGLView? _glView;
     private readonly SKCanvasView? _canvasView;

--- a/Mapsui.UI.WindowsForms/MapControl.cs
+++ b/Mapsui.UI.WindowsForms/MapControl.cs
@@ -9,7 +9,7 @@ namespace Mapsui.UI.WindowsForms;
 
 public partial class MapControl : UserControl, IMapControl, IDisposable
 {
-    public static bool UseGPU = false;
+    public static bool UseGPU { get; set; } = false;
 
     private readonly SKGLControl? _glView;
     private readonly SKControl? _canvasView;


### PR DESCRIPTION
This was disabled because of a bug in SkiaSharp that has been fixed with in SkiaSharp 3.119.1. The way to test this is be doing the getting started with a nuget package. I did not test it.
