### PR TITLE
Add wrapper fields to editing widget

### DIFF
--- a/Mapsui.Nts/Widgets/EditingWidget.cs
+++ b/Mapsui.Nts/Widgets/EditingWidget.cs
@@ -1,5 +1,6 @@
 ﻿using Mapsui.Nts.Editing;
 using Mapsui.Widgets;
+using Mapsui.Layers;
 
 namespace Mapsui.Nts.Widgets;
 
@@ -11,6 +12,24 @@ public class EditingWidget : InputOnlyWidget // Derived from InputOnlyWidget bec
     {
         _editManager = editManager;
         InputAreaType = InputAreaType.Map;
+    }
+
+    public EditMode EditMode
+    {
+        get => _editManager.EditMode;
+        set => _editManager.EditMode = value;
+    }
+
+    public bool SelectMode
+    {
+        get => _editManager.SelectMode;
+        set => _editManager.SelectMode = value;
+    }
+
+    public WritableLayer? Layer
+    {
+        get => _editManager.Layer;
+        set => _editManager.Layer = value;
     }
 
     public override void OnPointerPressed(WidgetEventArgs e) =>

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/CustomStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/CustomStyleSample.cs
@@ -25,7 +25,7 @@ public class CustomStyleSample : ISample
 
     public static Map CreateMap()
     {
-        // This the crucial part where we tell the renderer that a CustomStyle should be
+        // This is the crucial part where we tell the renderer that a CustomStyle should be
         // rendered with the SkiaCustomStyleRenderer
         MapRenderer.RegisterStyleRenderer(typeof(CustomStyle), new SkiaCustomStyleRenderer());
 


### PR DESCRIPTION
This adds some fields to wrap the EditingManager. This way the samples can work with the EditingWidget instead of the EditingManager which I think makes more sense.