### PR TITLE
Remove lock in RotateTo

### DIFF
--- a/Mapsui/Navigator.cs
+++ b/Mapsui/Navigator.cs
@@ -455,9 +455,6 @@ public class Navigator
             return;
         }
 
-        if (RotationLock)
-            return;
-
         var newViewport = Viewport with { Rotation = rotation };
         SetViewport(newViewport, duration, easing);
     }


### PR DESCRIPTION
A fix of this issue:
https://github.com/Mapsui/Mapsui/issues/3156

On the Navigator we distinguish between end-user-methods that respect the lock and developer-method that ignore the lock.

End-user-methods are:
- Fling (fairly obvious user input)
- Manipulation (this is touch, also fairly obvious).
- MouseWheelZoom (also)
- MouseWheelZoomContinuous (also)
- ZoomIn(long duration = -1, Easing? easing = default) (but not the other ZoomIn overload!)
- ZoomOut(long duration = -1, Easing? easing = default) (but not the other ZoomOut overload!)

This distinction should be made cleaner in a next version. There should probably be a separate class for the end-user-methods.