### PR TITLE
Dependencies: Update NTS to Version 2.6.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,7 +58,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="[2.6.2,3.0.0)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.2" />
-    <PackageVersion Include="NetTopologySuite" Version="[2.5.0,3.0.0)" />
+    <PackageVersion Include="NetTopologySuite" Version="2.6.0" />
     <PackageVersion Include="NetTopologySuite.IO.GeoJSON4STJ" Version="[4.0.0,5.0.0)" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />


### PR DESCRIPTION
Update NTS NetTopologySuite to 2.6.0

Main changes is the removal of the System.Memory Dependency for .NET Core which often caused dependency Problems.
(.Net Standard 2.1 Target).