### PR TITLE
Revert more stripping in Blazor

### DIFF
--- a/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
+++ b/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
@@ -13,8 +13,8 @@
 
   <!-- Release -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <WasmNativeStrip>true</WasmNativeStrip>
-    <EmccCompileOptimizationFlag>-O3</EmccCompileOptimizationFlag>
+		<WasmNativeStrip>false</WasmNativeStrip>
+		<EmccCompileOptimizationFlag>-O1</EmccCompileOptimizationFlag>
     <!--<RunAOTCompilation>true</RunAOTCompilation>
     <WasmStripILAfterAOT>true</WasmStripILAfterAOT>-->
   </PropertyGroup>


### PR DESCRIPTION
Revert some stripping option in release because mbtiles and shapefiles don't work in Blazor.