### PR TITLE
Fix custom svg color sample

### DIFF
--- a/Samples/Mapsui.Samples.Common/Maps/Demo/CustomSvgColorSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Demo/CustomSvgColorSample.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 namespace Mapsui.Samples.Common.Maps.Demo;
 
 [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP001:Dispose created")]
-public class CustomSvgStyleSample : ISample
+public class CustomSvgColorSample : ISample
 {
     private const double _circumferenceOfTheEarth = 40075017;
 


### PR DESCRIPTION
Fix file-name/class-name mismatch. This breaks the way we link the html code sample to the site.
