### PR TITLE
Fix change of the hash in url if there was already a hash in the initial url

### DIFF
--- a/Samples/Mapsui.Samples.Blazor/Pages/Index.razor.cs
+++ b/Samples/Mapsui.Samples.Blazor/Pages/Index.razor.cs
@@ -74,7 +74,6 @@ public sealed partial class Index : IDisposable
         LoggingWidget.ShowLoggingInMap = ActiveMode.Yes; // To show logging in release mode
         Performance.DefaultIsActive = ActiveMode.Yes; // To show performance in release mode
         FillComboBoxWithCategories();
-        SampleCategory = SampleCategories[0];
         // Subscribe to URL changes (hash changes will trigger LocationChanged)
         Nav.LocationChanged += OnLocationChanged;
         // Initialize from the current hash, or set the default


### PR DESCRIPTION
There was just one glitch left. If there was an initial hash in the url it was replaced with the default url, while the default url should only be set if 