### PR TITLE
Fix mbtiles on blazor sample app

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,9 @@
     <PackageVersion Include="SkiaSharp.Views.WinUI" Version="3.119.1" />
     <PackageVersion Include="SkiaSharp.Views.WPF" Version="3.119.1" />
     <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="3.119.1" />
-    <PackageVersion Include="SourceGear.sqlite3" Version="3.50.4.2" />
+    <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
+	<PackageVersion Include="SourceGear.sqlite3" Version="3.50.4.2" />
     <PackageVersion Include="sqlite-net-base" Version="1.10.196-beta" />
     <PackageVersion Include="SQLitePCLRaw.config.e_sqlite3" Version="3.0.2" />
     <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.2" />

--- a/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
+++ b/Samples/Mapsui.Samples.Blazor/Mapsui.Samples.Blazor.csproj
@@ -13,8 +13,8 @@
 
   <!-- Release -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-		<WasmNativeStrip>false</WasmNativeStrip>
-		<EmccCompileOptimizationFlag>-O1</EmccCompileOptimizationFlag>
+    <WasmNativeStrip>false</WasmNativeStrip>
+    <EmccCompileOptimizationFlag>-O1</EmccCompileOptimizationFlag>
     <!--<RunAOTCompilation>true</RunAOTCompilation>
     <WasmStripILAfterAOT>true</WasmStripILAfterAOT>-->
   </PropertyGroup>
@@ -25,16 +25,19 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" VersionOverride="9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" VersionOverride="9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" VersionOverride="9.0" PrivateAssets="all" />
-    
+ 
     <!--still needed for direct project reference the nuget package of blazor doesn't need this anymore-->
     <NativeFileReference Include="libHarfBuzzSharp.a" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
+
+    <PackageReference Include="sqlite-net-pcl" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Mapsui.UI.Blazor\Mapsui.UI.Blazor.csproj" />
-    <ProjectReference Include="..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
+     <ProjectReference Include="..\Mapsui.Samples.Common\Mapsui.Samples.Common.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This bug was introduced with the fix for Android 16 KB problem. https://github.com/Mapsui/Mapsui/pull/3128/files

I could fix it by adding the references explicitly to the Blazor project. To me it is quite obscure how this works. Adding references to Blazor should not break Android, that seems clear. So, I guess this is alright.