### PR TITLE
Pass the IFeature along in the experimental CustomPointStyleRenderer

### DIFF
--- a/Mapsui.Experimental.Rendering.Skia/SkiaStyles/CustomPointStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/SkiaStyles/CustomPointStyleRenderer.cs
@@ -16,7 +16,7 @@ public class CustomPointStyleRenderer : ISkiaStyleRenderer
             {
                 var opacity = (float)(layer.Opacity * customPointStyle.Opacity);
                 if (MapRenderer.TryGetPointStyleRenderer(customPointStyle.RendererName, out var pointStyleRenderer))
-                    PointStyleRenderer.DrawPointStyle(canvas, viewport, x, y, customPointStyle, renderService, opacity, pointStyleRenderer);
+                    PointStyleRenderer.DrawPointStyle(canvas, viewport, x, y, customPointStyle, feature, renderService, opacity, pointStyleRenderer);
                 else
                     Logger.Log(LogLevel.Error, $"Could not find the point style renderer with name {customPointStyle.RendererName}");
             });

--- a/Mapsui.Experimental.Rendering.Skia/SkiaStyles/ImageStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/SkiaStyles/ImageStyleRenderer.cs
@@ -20,12 +20,12 @@ public class ImageStyleRenderer : ISkiaStyleRenderer, IFeatureSize
         feature.CoordinateVisitor((x, y, setter) =>
         {
             var opacity = (float)(layer.Opacity * symbolStyle.Opacity);
-            PointStyleRenderer.DrawPointStyle(canvas, viewport, x, y, symbolStyle, renderService, opacity, DrawImageStyle);
+            PointStyleRenderer.DrawPointStyle(canvas, viewport, x, y, symbolStyle, feature, renderService, opacity, DrawImageStyle);
         });
         return true;
     }
 
-    private static void DrawImageStyle(SKCanvas canvas, IPointStyle pointStyle, Mapsui.Rendering.RenderService renderService, float opacity)
+    private static void DrawImageStyle(SKCanvas canvas, IPointStyle pointStyle, IFeature feature, Mapsui.Rendering.RenderService renderService, float opacity)
     {
         if (pointStyle is ImageStyle imageStyle)
         {

--- a/Mapsui.Experimental.Rendering.Skia/SkiaStyles/PointStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/SkiaStyles/PointStyleRenderer.cs
@@ -6,9 +6,9 @@ namespace Mapsui.Experimental.Rendering.Skia.SkiaStyles;
 
 public abstract class PointStyleRenderer
 {
-    public delegate void RenderHandler(SKCanvas canvas, IPointStyle style, Mapsui.Rendering.RenderService renderService, float opacity);
+    public delegate void RenderHandler(SKCanvas canvas, IPointStyle style, IFeature feature, Mapsui.Rendering.RenderService renderService, float opacity);
 
-    public static void DrawPointStyle(SKCanvas canvas, Viewport viewport, double x, double y, IPointStyle imageStyle,
+    public static void DrawPointStyle(SKCanvas canvas, Viewport viewport, double x, double y, IPointStyle imageStyle, IFeature feature,
         Mapsui.Rendering.RenderService renderService, float opacity, RenderHandler renderHandler)
     {
         try
@@ -32,7 +32,7 @@ public abstract class PointStyleRenderer
             // Translate to offset
             canvas.Translate((float)imageStyle.Offset.X, (float)-imageStyle.Offset.Y);
 
-            renderHandler(canvas, imageStyle, renderService, opacity);
+            renderHandler(canvas, imageStyle, feature, renderService, opacity);
         }
         finally
         {

--- a/Mapsui.Experimental.Rendering.Skia/SkiaStyles/SymbolStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/SkiaStyles/SymbolStyleRenderer.cs
@@ -9,10 +9,10 @@ namespace Mapsui.Experimental.Rendering.Skia.SkiaStyles;
 
 public class SymbolStyleRenderer : ISkiaStyleRenderer, IFeatureSize
 {
-    public static void DrawStatic(SKCanvas canvas, Viewport viewport, ILayer layer, double x, double y, IPointStyle pointStyle, Mapsui.Rendering.RenderService renderService)
+    public static void DrawStatic(SKCanvas canvas, Viewport viewport, ILayer layer, double x, double y, IPointStyle pointStyle, IFeature feature, Mapsui.Rendering.RenderService renderService)
     {
         var opacity = (float)(layer.Opacity * pointStyle.Opacity);
-        PointStyleRenderer.DrawPointStyle(canvas, viewport, x, y, pointStyle, renderService, opacity, DrawSymbolStyle);
+        PointStyleRenderer.DrawPointStyle(canvas, viewport, x, y, pointStyle, feature, renderService, opacity, DrawSymbolStyle);
     }
 
     public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, IStyle style, Mapsui.Rendering.RenderService renderService, long iteration)
@@ -21,12 +21,12 @@ public class SymbolStyleRenderer : ISkiaStyleRenderer, IFeatureSize
         feature.CoordinateVisitor((x, y, setter) =>
         {
             var opacity = (float)(layer.Opacity * symbolStyle.Opacity);
-            PointStyleRenderer.DrawPointStyle(canvas, viewport, x, y, symbolStyle, renderService, opacity, DrawSymbolStyle);
+            PointStyleRenderer.DrawPointStyle(canvas, viewport, x, y, symbolStyle, feature, renderService, opacity, DrawSymbolStyle);
         });
         return true;
     }
 
-    private static void DrawSymbolStyle(SKCanvas canvas, IPointStyle pointStyle, Mapsui.Rendering.RenderService renderService, float opacity)
+    private static void DrawSymbolStyle(SKCanvas canvas, IPointStyle pointStyle, IFeature feature, Mapsui.Rendering.RenderService renderService, float opacity)
     {
         if (pointStyle is SymbolStyle symbolStyle)
         {

--- a/Mapsui.Experimental.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/SkiaStyles/VectorStyleRenderer.cs
@@ -30,7 +30,7 @@ public class VectorStyleRenderer : ISkiaStyleRenderer, IFeatureSize
                     }
                     break;
                 case Point point:
-                    SymbolStyleRenderer.DrawStatic(canvas, viewport, layer, point.X, point.Y, CreateSymbolStyle(vectorStyle), renderService);
+                    SymbolStyleRenderer.DrawStatic(canvas, viewport, layer, point.X, point.Y, CreateSymbolStyle(vectorStyle), feature, renderService);
                     break;
                 case Polygon polygon:
                     PolygonRenderer.Draw(canvas, viewport, vectorStyle, feature, polygon, opacity, renderService.VectorCache, position);
@@ -50,7 +50,7 @@ public class VectorStyleRenderer : ISkiaStyleRenderer, IFeatureSize
             switch (feature)
             {
                 case PointFeature pointFeature:
-                    SymbolStyleRenderer.DrawStatic(canvas, viewport, layer, pointFeature.Point.X, pointFeature.Point.Y, CreateSymbolStyle(vectorStyle), renderService);
+                    SymbolStyleRenderer.DrawStatic(canvas, viewport, layer, pointFeature.Point.X, pointFeature.Point.Y, CreateSymbolStyle(vectorStyle), feature, renderService);
                     break;
                 case GeometryFeature geometryFeature:
                     DrawGeometry(geometryFeature?.Geometry);


### PR DESCRIPTION
This was a mistake in the design of the CustomPointStyleRenderer. The feature information is typical input to the custom style. This is now fixed in the experimental copy of the CustomPointStyleRenderer. 

Here is one of our samples adapted to use the experimental CustomPointStyleRenderer.
```cs
using BruTile.Predefined;
using Mapsui.Extensions;
using Mapsui.Layers;
using Mapsui.Rendering;
using Mapsui.Samples.Common.DataBuilders;
using Mapsui.Styles;
using Mapsui.Tiling.Fetcher;
using Mapsui.Tiling.Layers;
using Mapsui.Widgets.InfoWidgets;
using SkiaSharp;
using System;
using System.Collections.Generic;
using System.Linq;
using System.Threading.Tasks;

namespace Mapsui.Samples.Common.Maps.Styles;

public class CustomPointStyleShaderSample : ISample
{
    public string Name => $"Shader";
    public string Category => $"{nameof(CustomPointStyle)}";

    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());

    public static Map CreateMap()
    {
        var map = new Map();
        map.Layers.Add(CreateLayer());
        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
        {
            Features = CreateFeatures(map.Extent!, 32).ToList(),
            Style = new CustomPointStyle() { RendererName = "custom-style-shader" },
        });
        map.Widgets.Add(new MapInfoWidget(map, [map.Layers.Last()]));

        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-shader", MyBasicCustomStyleRenderer);
        return map;
    }

    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
        .Select(p => new PointFeature(p))
        .ToList();

    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, IFeature feature, RenderService renderService, float opacity)
    {
        // Now use the feature attributes in how you create the style. 
        using var paint = new SKPaint { Color = SKColors.OliveDrab, IsAntialias = true };
        canvas.DrawCircle(0f, 0f, 10f, paint);
        DrawEllipseWithGradient(canvas, CreatePath());
    }

    private static SKRect CreatePath()
    {
        var halfWidth = 20;
        var halfHeight = 20f;
        return new SKRect(-halfWidth, -halfHeight, halfWidth, halfHeight);
    }

    private static TileLayer CreateLayer()
    {
        var tileSource = KnownTileSources.Create(KnownTileSource.BKGTopPlusGrey);
        return new TileLayer(tileSource, dataFetchStrategy: new DataFetchStrategy()) // DataFetchStrategy prefetches tiles from higher levels
        {
            Name = "BKG Top Plus Grey",
        };
    }

    private static void DrawEllipseWithGradient(SKCanvas canvas, SKRect rect)
    {
        // create the shader
        var colors = new SKColor[] {
            new(0, 255, 255),
            new(255, 0, 255),
            new(255, 255, 0),
            new(0, 255, 255)
        };
        var shader = SKShader.CreateSweepGradient(new SKPoint(0, 0), colors, null);

        using var paint = new SKPaint { Shader = shader, IsAntialias = true };
        canvas.DrawOval(rect, paint);
    }
}
```