### PR TITLE
Fix invalid extent returned by empty geometry to avoid "minX can not be greater than maxX" error

### DIFF
--- a/Mapsui.Nts/Extensions/EnvelopeExtensions.cs
+++ b/Mapsui.Nts/Extensions/EnvelopeExtensions.cs
@@ -4,8 +4,10 @@ namespace Mapsui.Nts.Extensions;
 
 public static class EnvelopeExtensions
 {
-    public static MRect ToMRect(this Envelope envelope)
+    public static MRect? ToMRect(this Envelope envelope)
     {
+        if (envelope.IsNull)
+            return null;
         return new MRect(envelope.MinX, envelope.MinY, envelope.MaxX, envelope.MaxY);
     }
 }


### PR DESCRIPTION
### The problem

The NTS Geometry.Envelope is not nullable but if the Geometry is empty no extent can be determined. In that case it returns an invalid extent (0, 0, -1, -1) where minX/Y is bigger than maxX/Y. From this extent an MRect was created and in v5 we now throw if that happens (instead of the automatic repair in v4). So thanks to being more strict we have found a bug that was already in v4.

### The Solution

Return null if the Geometry is empty. We return null for an extent if a provider is empty, so this is similar.

### The problem in v4

In v4 it did not throw but would cause incorrect values. Suppose you are working with a set of geometries in the North Sea and one of those is empty (perhaps because users edit the geometries) then if you calculate the extent for all of them it will cover the area in the North Sea up to the -1, -1 point near Africa.