### PR TITLE
Add properties for passing additional HTTP headers to requests.

### DIFF
--- a/Mapsui.Nts/Providers/Wfs/WFSProvider.cs
+++ b/Mapsui.Nts/Providers/Wfs/WFSProvider.cs
@@ -81,6 +81,7 @@ public class WFSProvider : IProvider, IDisposable
     private string? _sridOverride;
     private string? _proxyUrl;
     private ICredentials? _credentials;
+    private Dictionary<string, string>? _httpHeaders;
     private readonly CrsAxisOrderRegistry _crsAxisOrderRegistry = new();
     private readonly SemaphoreSlim _init = new(1, 1);
     private bool _initialized;
@@ -223,6 +224,19 @@ public class WFSProvider : IProvider, IDisposable
         set
         {
             _credentials = value;
+            _initialized = false;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the additional HTTP headers for the requests.
+    /// </summary>
+    public Dictionary<string, string>? HttpHeaders
+    {
+        get => _httpHeaders;
+        set
+        {
+            _httpHeaders = value;
             _initialized = false;
         }
     }
@@ -665,6 +679,14 @@ public class WFSProvider : IProvider, IDisposable
         if (_credentials != null)
         {
             httpClientUtil.Credentials = _credentials;
+        }
+
+        if (_httpHeaders != null)
+        {
+            foreach (var httpHeader in _httpHeaders)
+            {
+                httpClientUtil.AddHeader(httpHeader.Key, httpHeader.Value, true);
+            }
         }
 
         if (_proxyUrl != null)

--- a/Mapsui/Providers/Wms/GetFeatureInfo.cs
+++ b/Mapsui/Providers/Wms/GetFeatureInfo.cs
@@ -40,6 +40,11 @@ public class GetFeatureInfo
     public ICredentials? Credentials { get; set; }
 
     /// <summary>
+    /// Gets or sets additional HTTP headers to be sent with each request.
+    /// </summary>
+    public Dictionary<string, string>? HttpHeaders { get; set; }
+
+    /// <summary>
     /// Request FeatureInfo for a WMS Server
     /// </summary>
     /// <param name="baseUrl">Base URL of the WMS server</param>
@@ -88,6 +93,15 @@ public class GetFeatureInfo
 
         using var client = new HttpClient(handler) { Timeout = TimeSpan.FromMilliseconds(TimeOut) };
         client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent ?? "If you use Mapsui please specify a user-agent specific to your app");
+
+        if (HttpHeaders != null)
+        {
+            foreach (var httpHeader in HttpHeaders)
+            {
+                client.DefaultRequestHeaders.Add(httpHeader.Key, httpHeader.Value);
+            }
+        }
+
         using var req = new HttpRequestMessage(HttpMethod.Get, url);
         using var response = await client.SendAsync(req).ConfigureAwait(false);
 


### PR DESCRIPTION
This commit adds the ability to add custom HTTP Headers to WFS and WMS web requests (e.g. for authorization).

I tested this implementation via Mapsui WPF.

This PR is related to this Feature Request: https://github.com/Mapsui/Mapsui/issues/3281
