### PR TITLE
Sparse mbtile fix

### DIFF
--- a/Mapsui.Tiling/Layers/TileLayer.cs
+++ b/Mapsui.Tiling/Layers/TileLayer.cs
@@ -154,13 +154,13 @@ public class TileLayer : BaseLayer, IFetchableSource, IDisposable
         {
             var tileData = await httpTileSource.GetTileAsync(GetHttpClient(), tileInfo).ConfigureAwait(false);
             var mRaster = ToRaster(tileInfo, tileData);
-            return new RasterFeature(mRaster);
+            return mRaster == null ? null : new RasterFeature(mRaster);
         }
         else if (_tileSource is ILocalTileSource localTileSource)
         {
             var tileData = await localTileSource.GetTileAsync(tileInfo).ConfigureAwait(false);
             var mRaster = ToRaster(tileInfo, tileData);
-            return new RasterFeature(mRaster);
+            return mRaster == null ? null : new RasterFeature(mRaster);
         }
         else
         {

--- a/Mapsui.Wpf.slnf
+++ b/Mapsui.Wpf.slnf
@@ -4,6 +4,7 @@
     "projects": [
       "Benchmarks\\Mapsui.Rendering.Benchmarks\\Mapsui.Rendering.Benchmarks.csproj",
       "Mapsui.ArcGIS\\Mapsui.ArcGIS.csproj",
+      "Mapsui.Experimental.Rendering.Skia\\Mapsui.Experimental.Rendering.Skia.csproj",
       "Mapsui.Extensions\\Mapsui.Extensions.csproj",
       "Mapsui.Nts\\Mapsui.Nts.csproj",
       "Mapsui.Rendering.Skia\\Mapsui.Rendering.Skia.csproj",


### PR DESCRIPTION
I use mbtiles that are sparse meaning for certain areas only higher level resolutions are provided.

Without this fix the tile Layer returns a feature on lower resolution without images causing to render an empty tile. 
With this fix the high resolution tile is displayed.

An alternative implementation would be to ignore Raster images with empty Image Data, and not to render tehme.