### PR TITLE
Add support for CustomLayerRenderer in the RasterizingTileSource

### DIFF
--- a/Mapsui.Tiling/Provider/RasterizingTileSource.cs
+++ b/Mapsui.Tiling/Provider/RasterizingTileSource.cs
@@ -94,6 +94,11 @@ public class RasterizingTileSource : ILocalTileSource, ILayerFeatureInfo
 
         var resolution = tileResolution.UnitsPerPixel;
         var section = new MSection(tileInfo.Extent.ToMRect(), resolution);
+        // Layers with a custom renderer handle their own data access; skip the feature-fetch and
+        // RenderLayer wrapper so the renderer receives the original layer and can cast it directly.
+        if (_layer.CustomLayerRendererName is not null)
+            return (section, _layer);
+
         var featureSearchGrowth = await GetAdditionalSearchSizeAroundAsync(tileInfo, renderer, section, renderService);
         var extent = section.Extent;
         if (featureSearchGrowth > 0)


### PR DESCRIPTION
**Description:**

When using a `RasterizingTileLayer` wrapping a layer that has `CustomLayerRendererName` set, tiles were rendered blank. 

**Root cause:** `RasterizingTileSource.CreateRenderLayerAsync` always called `_layer.GetFeatures()` and wrapped the result in an internal `RenderLayer`. That wrapper does not copy `CustomLayerRendererName`, so the inner `MapRenderer` instance (used to build tile bitmaps) saw no custom renderer and rendered nothing.

**Fix:** In `CreateRenderLayerAsync`, when the source layer has `CustomLayerRendererName` set, we now skip the feature-fetch and `RenderLayer` wrapping entirely and pass the original layer directly to the tile renderer. The `VisibleFeatureIterator` inside the tile renderer then correctly detects `CustomLayerRendererName` and invokes the custom renderer.

**How to test:** Run the *"Rasterizing Tile Layer with Custom Layer Renderer"* sample in the Performance category. One million purple squares should be visible, rendered without any `IFeature` or `IStyle` overhead.