### PR TITLE
Fallback to higher level tiles if tiles are missing in the source data while avoiding re-fetches

### DIFF
--- a/Mapsui.Tiling/Fetcher/TileFetchStatusFeature.cs
+++ b/Mapsui.Tiling/Fetcher/TileFetchStatusFeature.cs
@@ -1,0 +1,33 @@
+// Copyright (c) The Mapsui authors.
+// The Mapsui authors licensed this file under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Mapsui.Layers;
+
+namespace Mapsui.Tiling.Fetcher;
+
+public enum TileFetchStatus
+{
+    /// <summary>The tile source confirmed this tile does not exist (e.g. absent in a sparse MBTiles file).</summary>
+    PermanentlyUnavailable,
+    /// <summary>Fetching failed too many times; no further attempts will be made.</summary>
+    GaveUp,
+}
+
+/// <summary>
+/// A non-renderable sentinel stored in the tile cache to record the definitive status of a tile
+/// that cannot be displayed. Prevents the fetcher from retrying, and signals render strategies
+/// to fall back to a lower-resolution tile instead of rendering a blank.
+/// 
+/// We use an IFeature as the sentinel to avoid a breaking change to the cache type parameter
+/// (ITileCache&lt;IFeature?&gt;). A cleaner design would be a typed wrapper around the cache entry
+/// that carries a status field directly, decoupling tile status from the feature model.
+/// </summary>
+internal sealed class TileFetchStatusFeature(TileFetchStatus status) : BaseFeature, IFeature
+{
+    public TileFetchStatus Status { get; } = status;
+    public override MRect? Extent => null;
+    public override void CoordinateVisitor(Action<double, double, CoordinateSetter> visit) { }
+    public override object Clone() => new TileFetchStatusFeature(Status);
+}

--- a/Mapsui.Tiling/Layers/TileLayer.cs
+++ b/Mapsui.Tiling/Layers/TileLayer.cs
@@ -154,13 +154,17 @@ public class TileLayer : BaseLayer, IFetchableSource, IDisposable
         {
             var tileData = await httpTileSource.GetTileAsync(GetHttpClient(), tileInfo).ConfigureAwait(false);
             var mRaster = ToRaster(tileInfo, tileData);
-            return new RasterFeature(mRaster);
+            return mRaster == null
+                ? new TileFetchStatusFeature(TileFetchStatus.PermanentlyUnavailable)
+                : new RasterFeature(mRaster);
         }
         else if (_tileSource is ILocalTileSource localTileSource)
         {
             var tileData = await localTileSource.GetTileAsync(tileInfo).ConfigureAwait(false);
             var mRaster = ToRaster(tileInfo, tileData);
-            return new RasterFeature(mRaster);
+            return mRaster == null
+                ? new TileFetchStatusFeature(TileFetchStatus.PermanentlyUnavailable)
+                : new RasterFeature(mRaster);
         }
         else
         {
@@ -174,9 +178,9 @@ public class TileLayer : BaseLayer, IFetchableSource, IDisposable
         // for MbTilesTileSource. It is to indicate that the tile is not present in the source,
         // although it should be given the tile schema. It does not mean the tile could not
         // be accessed because of some temporary reason. In that case it will throw an exception.
-        // For Mapsui this is important because it will not try again and again to fetch it. 
-        // Here we return the geometry as null so that it will be added to the tile cache. 
-        // TileLayer.GetFeatureInView will have to return only the non null geometries.
+        // Returning null here causes the caller to store a TileFetchStatusFeature sentinel in the
+        // tile cache. The sentinel prevents the fetcher from retrying and signals render strategies
+        // to fall back to a lower-resolution tile instead of rendering a blank.
 
         if (tileData == null) return null;
         return new MRaster(tileData, tileInfo.Extent.ToMRect());

--- a/Mapsui.Tiling/Rendering/MinimalRenderFetchStrategy.cs
+++ b/Mapsui.Tiling/Rendering/MinimalRenderFetchStrategy.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using BruTile;
 using BruTile.Cache;
 using Mapsui.Tiling.Extensions;
+using Mapsui.Tiling.Fetcher;
 
 namespace Mapsui.Tiling.Rendering;
 
@@ -18,7 +19,7 @@ public class MinimalRenderFetchStrategy : IRenderFetchStrategy
         {
             var feature = memoryCache.Find(tileInfo.Index);
 
-            if (feature != null)
+            if (feature != null && feature is not TileFetchStatusFeature)
                 result.Add(feature);
         }
         return result;

--- a/Mapsui.Tiling/Rendering/RenderFetchStrategy.cs
+++ b/Mapsui.Tiling/Rendering/RenderFetchStrategy.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BruTile;
 using BruTile.Cache;
 using Mapsui.Tiling.Extensions;
+using Mapsui.Tiling.Fetcher;
 
 namespace Mapsui.Tiling.Rendering;
 
@@ -79,10 +80,10 @@ public class RenderFetchStrategy : IRenderFetchStrategy
         {
             var feature = cache.Find(tileInfo.Index);
 
-            // Geometry can be null for some tile sources to indicate the tile is not present.
-            // It is stored in the tile cache to prevent retries. It should not be returned to the 
-            // renderer.
-            if (feature == null)
+            // A null feature means the tile has not been fetched yet.
+            // A TileFetchStatusFeature means the tile source confirmed the tile is unavailable.
+            // In both cases fall back to a lower-resolution tile rather than rendering a blank.
+            if (feature == null || feature is TileFetchStatusFeature)
             {
                 // only continue the recursive search if this tile is within the extent and we haven't exceeded the max levels up
                 if (tileInfo.Extent.Intersects(extent) && currentLevelsUp < maxLevelsUp)


### PR DESCRIPTION
When a tile source (e.g. a sparse MBTiles file) confirms a tile does not exist, `ToFeatureAsync` previously stored either a `RasterFeature(null)` (old code, caused blank tiles) or `null` (PR #3313's fix, caused unnecessary re-fetching on every viewport change).

This change introduces `TileFetchStatusFeature`, a lightweight non-renderable `IFeature` sentinel that is stored in the tile cache to represent a tile with a definitive status (currently `PermanentlyUnavailable`).

- **`TileLayer`**: returns a `TileFetchStatusFeature` instead of `null` when the tile source returns no data.
- **`RenderFetchStrategy`**: treats a `TileFetchStatusFeature` the same as an absent tile — recurses up to find a lower-resolution fallback tile.
- **`MinimalRenderFetchStrategy`**: excludes sentinels from the render result.
- **`FetchTracker`**: no change needed — a non-null sentinel already prevents re-queuing, which is the correct behaviour.

The result: sparse tiles correctly display their nearest available lower-resolution ancestor, with no unnecessary re-fetch attempts.
