### PR TITLE
Improve documentation based on questions in the issues

### DIFF
--- a/docs/general/markdown/faq.md
+++ b/docs/general/markdown/faq.md
@@ -10,6 +10,22 @@ The most common reason is that the default user-agent used by the osm layer is b
 MapControl.Map.Layers.Add(OpenStreetMap.CreateTileLayer("your-user-agent"));
 ```
 
+### How do I set User-Agent or Referer headers on a tiled map source?
+Use the `configureHttpRequestMessage` parameter of `HttpTileSource` to add any HTTP headers, including `Referer`:
+
+```csharp
+var tileSource = new HttpTileSource(new GlobalSphericalMercator(),
+    "https://example.com/tiles/{z}/{x}/{y}.png",
+    configureHttpRequestMessage: (r) =>
+    {
+        r.Headers.TryAddWithoutValidation("User-Agent", "your-app-name");
+        r.Headers.TryAddWithoutValidation("Referer", "https://yoursite.com");
+    });
+MapControl.Map.Layers.Add(new TileLayer(tileSource));
+```
+
+This is also how `OpenStreetMap.CreateTileLayer` sets its user-agent internally.
+
 ### Why is all my data in a small area near the west coast of Africa?
 This is because the background data is in SphericalMercator (it is in the SphericalMercator 
 coordinate system) and the foreground data is in WGS84 (latlon). Use 
@@ -21,3 +37,4 @@ This is because the coordinates you pass to NavigateTo are in WGS84 whereas the
 background data is in SphericalMercator. Use SphericalMercator.FromLonLat to transform 
 the NavigateTo arguments to SphericalMercator.
 Note: There can be many other forms of mixing up coordinate systems, but this is the most common.
+

--- a/docs/general/markdown/vector-style.md
+++ b/docs/general/markdown/vector-style.md
@@ -1,0 +1,111 @@
+# VectorStyle
+
+`VectorStyle` is the standard style for rendering vector geometries. It has three properties — `Fill`, `Line`, and `Outline` — but which ones are relevant depends on the geometry type being drawn. `Point`, `LineString`, and `Polygon` are NetTopologySuite (NTS) types from the `Mapsui.Nts` package. Mapsui's own `MPoint` renders identically to the NTS `Point`.
+
+### Point and MPoint
+
+Points are rendered as a circle. Use `Fill` to set the interior colour and `Outline` for the circle border.
+
+```csharp
+var style = new VectorStyle
+{
+    Fill = new Brush(Color.CornflowerBlue),
+    Outline = new Pen(Color.DarkBlue, width: 2)
+};
+```
+
+### LineString
+
+Lines use `Line` as the main stroke. `Outline` is drawn wider behind the line, which creates a border or halo effect. `Fill` has no effect.
+
+```csharp
+var style = new VectorStyle
+{
+    Line = new Pen(Color.Violet, width: 3),
+    Outline = new Pen(Color.Black, width: 5) // drawn behind Line, creates a border
+};
+```
+
+### Polygon
+
+Polygons use `Fill` for the interior and `Outline` for the border stroke. `Line` has no effect.
+
+```csharp
+var style = new VectorStyle
+{
+    Fill = new Brush(Color.CornflowerBlue),
+    Outline = new Pen(Color.DarkBlue, width: 2)
+};
+```
+
+## FillStyle patterns
+
+`Brush.FillStyle` controls how the fill area is rendered. The available values are:
+
+| Value | Description |
+|---|---|
+| `Solid` | Filled with a single colour (default) |
+| `Hollow` | No fill — transparent interior |
+| `Dotted` | Dot pattern |
+| `Cross` | Horizontal and vertical lines crossing |
+| `DiagonalCross` | Diagonal lines crossing |
+| `BackwardDiagonal` | Lines from upper-right to lower-left |
+| `ForwardDiagonal` | Lines from upper-left to lower-right |
+| `Horizontal` | Horizontal lines |
+| `Vertical` | Vertical lines |
+| `Bitmap` | Tiled bitmap image |
+| `BitmapRotated` | Tiled bitmap image, rotated |
+| `Svg` | Tiled SVG image |
+
+```csharp
+var style = new VectorStyle
+{
+    Fill = new Brush { Color = Color.Red, FillStyle = FillStyle.Cross }
+};
+```
+
+## Combining a pattern fill with a background colour
+
+`VectorStyle.Fill` holds a single `Brush`, so a pattern and a solid background cannot both be expressed in one style. The solution is to stack two styles — a solid background rendered first, and the pattern rendered on top.
+
+### Same background for all features
+
+Set a solid `VectorStyle` on the layer, and add the patterned style to individual features:
+
+```csharp
+var layer = new MemoryLayer
+{
+    Style = new VectorStyle { Fill = new Brush(Color.CornflowerBlue) } // background for all features
+};
+
+var feature = new GeometryFeature { Geometry = myPolygon };
+feature.Styles.Add(new VectorStyle
+{
+    Fill = new Brush { Color = Color.Red, FillStyle = FillStyle.Cross }
+});
+```
+
+### Different background per feature
+
+Add a `StyleCollection` to the feature with the solid style first, then the patterned style:
+
+```csharp
+feature.Styles.Add(new StyleCollection
+{
+    Styles =
+    [
+        new VectorStyle { Fill = new Brush(Color.CornflowerBlue) },
+        new VectorStyle { Fill = new Brush { Color = Color.Red, FillStyle = FillStyle.Cross } }
+    ]
+});
+```
+
+## Hit detection on patterned and hollow fills
+
+Mapsui determines a hit by checking for a non-transparent pixel at the tapped location. A patterned or `FillStyle.Hollow` fill is transparent between the strokes, so tapping between the pattern lines registers as a miss.
+
+To make the whole polygon area hittable, add a nearly-transparent solid background using one of the layering approaches above. An alpha value of 1 is enough:
+
+```csharp
+new VectorStyle { Fill = new Brush(new Color(0, 0, 0, 1)) } // invisible but hittable
+```

--- a/docs/general/markdown/wms.md
+++ b/docs/general/markdown/wms.md
@@ -1,0 +1,28 @@
+# WMS
+
+WMS (Web Map Service) is an OGC standard for serving geo-referenced map images over HTTP. Mapsui supports WMS through the `WmsProvider` class in the `Mapsui.Extensions` package.
+
+## Creating a WMS layer
+
+`WmsProvider.CreateAsync` fetches the service's `GetCapabilities` response to discover available layers and coordinate systems.
+
+```csharp
+var provider = await WmsProvider.CreateAsync("https://example.com/wms");
+var layer = new ImageLayer("WMS") { DataSource = provider };
+map.Layers.Add(layer);
+```
+
+## Setting User-Agent and custom HTTP headers
+
+Some WMS servers require a specific `User-Agent` or `Referer` header. `WmsProvider.CreateAsync` accepts both a `userAgent` parameter and an `httpHeaders` dictionary for any additional headers:
+
+```csharp
+var provider = await WmsProvider.CreateAsync(url,
+    userAgent: "your-app-name",
+    httpHeaders: new Dictionary<string, string>
+    {
+        ["Referer"] = "https://yoursite.com"
+    });
+var layer = new ImageLayer("WMS") { DataSource = provider };
+map.Layers.Add(layer);
+```

--- a/docs/general/mkdocs.yml
+++ b/docs/general/mkdocs.yml
@@ -26,6 +26,8 @@ nav:
   - 'static-image-generation.md'
   - 'resolution.md'
   - 'projections.md'
+  - 'wms.md'
+  - 'vector-style.md'
   - 'custom-style-renders.md'
   - 'custom-point-style-renderer.md'
   - 'custom-layer-renderer.md'


### PR DESCRIPTION
Adds documentation for topics that were coming up repeatedly as questions in issues.

**Changes:**
- **`faq.md`** — added a new FAQ entry explaining how to set `User-Agent` and `Referer` headers on an `HttpTileSource` via `configureHttpRequestMessage`.
- **wms.md** (new) — dedicated WMS page covering how to create a WMS layer and how to set `User-Agent` and custom HTTP headers on `WmsProvider`. Addresses #3257.
- **vector-style.md** (new) — dedicated `VectorStyle` page covering which properties (`Fill`, `Line`, `Outline`) apply to each geometry type (Point/MPoint, LineString, Polygon), the full `FillStyle` pattern table, how to combine a pattern fill with a solid background colour by stacking styles, and hit detection behaviour on patterned/hollow fills. Addresses #2502.
- **mkdocs.yml** — registered the two new pages in the navigation.