### PR TITLE
☢️ Add screen-space coordinate support to partial refresh

### DIFF
--- a/Mapsui.Experimental.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/MapRenderer.cs
@@ -74,25 +74,39 @@ public sealed class MapRenderer : IMapRenderer
     }
 
     /// <inheritdoc />
+    // Resolves the dirty rect to a screen-space SKRect once here and passes it
+    // through to the internal helpers, so screen-space requests never need world conversion.
     public void Render(object target, Viewport viewport, IEnumerable<ILayer> layers,
-        IEnumerable<IWidget> widgets, RenderService renderService, Color? background = null, MRect? dirtyRegion = null)
+        IEnumerable<IWidget> widgets, RenderService renderService, Color? background = null, MRect? dirtyRegion = null, CoordinateSpace coordinateSpace = CoordinateSpace.World)
     {
         var attributions = layers.Where(l => l.Enabled).Select(l => l.Attribution).Where(w => w != null).ToList();
         var allWidgets = widgets.Concat(attributions);
         var targetCanvas = (SKCanvas)target;
 
-        // Full update (or nearly full): render directly to the platform canvas — no intermediate
-        // surface, no Snapshot(), no DrawImage(). The persistent surface becomes stale because it
-        // no longer reflects the current frame.
-        if (dirtyRegion == null || IsNearlyFullScreen(dirtyRegion, viewport))
+        // Resolve the dirty rect to a screen-space SKRect and, for world-space requests only,
+        // a world-coord MRect for feature-query filtering.
+        SKRect? dirtyScreenRect = null;
+        MRect? worldDirtyRegion = null;
+        if (dirtyRegion is not null)
+        {
+            if (coordinateSpace == CoordinateSpace.Screen)
+                dirtyScreenRect = dirtyRegion.ToSkia();
+            else
+            {
+                worldDirtyRegion = dirtyRegion;
+                dirtyScreenRect = viewport.WorldToScreen(worldDirtyRegion).ToSkia();
+            }
+        }
+
+        // Full update (or nearly full): render directly to the platform canvas.
+        if (dirtyScreenRect == null || IsNearlyFullScreen(dirtyScreenRect.Value, viewport))
         {
             _persistentSurfaceIsStale = true;
             RenderTypeSave(targetCanvas, viewport, layers, allWidgets, renderService, background, null);
             return;
         }
 
-        // Partial update: use the persistent surface as the backing "previous full frame" so we
-        // only redraw the dirty region while the rest of the image stays intact.
+        // Partial update: use the persistent surface as the backing "previous full frame".
 #pragma warning disable IDISP005 // EnsurePersistentSurface returns a surface whose ownership transfers to RenderService
         var grContext = renderService.GpuContext as GRContext;
         var surface = (PersistentSurface)renderService.GetPersistentRenderSurface(current => EnsurePersistentSurface(current, viewport, grContext));
@@ -100,15 +114,12 @@ public sealed class MapRenderer : IMapRenderer
 
         if (_persistentSurfaceIsStale)
         {
-            // The persistent surface is out of date (e.g. after panning). Do a one-time catch-up
-            // full render so it contains the correct base frame before applying the small delta.
             _persistentSurfaceIsStale = false;
             RenderTypeSave(surface.SKSurface.Canvas, viewport, layers, allWidgets, renderService, background, null);
         }
 
-        RenderTypeSave(surface.SKSurface.Canvas, viewport, layers, allWidgets, renderService, background, dirtyRegion);
+        RenderTypeSave(surface.SKSurface.Canvas, viewport, layers, allWidgets, renderService, background, dirtyScreenRect, worldDirtyRegion);
 
-        // Blit the persistent surface (full frame + delta) to the platform-provided canvas.
         surface.SKSurface.Canvas.Flush();
         using var snapshot = surface.SKSurface.Snapshot();
         targetCanvas.DrawImage(snapshot, 0, 0);
@@ -118,11 +129,9 @@ public sealed class MapRenderer : IMapRenderer
     // of reading back the persistent surface for a region that covers nearly everything anyway.
     private const double NearlyFullScreenThreshold = 0.8;
 
-    private static bool IsNearlyFullScreen(MRect dirtyRegion, Viewport viewport)
+    private static bool IsNearlyFullScreen(SKRect dirtyScreenRect, Viewport viewport)
     {
-        // Convert the dirty world rect to screen pixels and compare against the viewport area.
-        var screenRect = viewport.WorldToScreen(dirtyRegion);
-        var dirtyArea = screenRect.Width * screenRect.Height;
+        var dirtyArea = dirtyScreenRect.Width * dirtyScreenRect.Height;
         var totalArea = viewport.Width * viewport.Height;
         return totalArea <= 0 || dirtyArea / totalArea >= NearlyFullScreenThreshold;
     }
@@ -146,21 +155,21 @@ public sealed class MapRenderer : IMapRenderer
     }
 
     private void RenderTypeSave(SKCanvas canvas, Viewport viewport, IEnumerable<ILayer> layers,
-        IEnumerable<IWidget> widgets, RenderService renderService, Color? background = null, MRect? dirtyRegion = null)
+        IEnumerable<IWidget> widgets, RenderService renderService, Color? background = null,
+        SKRect? dirtyScreenRect = null, MRect? worldDirtyRegion = null)
     {
         if (!viewport.HasSize()) return;
 
-        if (dirtyRegion is not null)
+        if (dirtyScreenRect is not null)
         {
             // Clip the entire render (layers + widgets) to the dirty screen region.
             // Widgets outside the dirty rect produce no pixel changes — their pixels
             // are already correct in the persistent surface and remain untouched.
-            var screenRect = viewport.WorldToScreen(dirtyRegion).ToSkia();
             var saveCount = canvas.Save();
-            canvas.ClipRect(screenRect);
+            canvas.ClipRect(dirtyScreenRect.Value);
             if (background is not null) canvas.DrawColor(background.ToSkia());
-            Render(canvas, viewport, layers, renderService, dirtyRegion);
-            Render(canvas, viewport, widgets, renderService, 1, screenRect);
+            Render(canvas, viewport, layers, renderService, worldDirtyRegion);
+            Render(canvas, viewport, widgets, renderService, 1, dirtyScreenRect);
             canvas.RestoreToCount(saveCount);
         }
         else

--- a/Mapsui.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia/MapRenderer.cs
@@ -61,7 +61,7 @@ public sealed class MapRenderer : IMapRenderer
     }
 
     public void Render(object target, Viewport viewport, IEnumerable<ILayer> layers,
-        IEnumerable<IWidget> widgets, RenderService renderService, Color? background = null, MRect? dirtyRegion = null)
+        IEnumerable<IWidget> widgets, RenderService renderService, Color? background = null, MRect? dirtyRegion = null, CoordinateSpace coordinateSpace = CoordinateSpace.World)
     {
         var attributions = layers.Where(l => l.Enabled).Select(l => l.Attribution).Where(w => w != null).ToList();
 

--- a/Mapsui.UI.Shared/MapControl.cs
+++ b/Mapsui.UI.Shared/MapControl.cs
@@ -175,7 +175,7 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
     private void Map_RefreshGraphicsRequest(object? sender, EventArgs e)
     {
         var request = (e as RefreshGraphicsEventArgs)?.Request;
-        _renderController?.RefreshGraphics(request?.DirtyRect);
+        _renderController?.RefreshGraphics(request);
     }
 
     /// <summary>
@@ -534,7 +534,12 @@ public partial class MapControl : INotifyPropertyChanged, IDisposable
             handled = true;
         if (UseFling)
             _flingTracker.FlingIfNeeded((vX, vY) => Map.Navigator.Fling(vX, vY, 1000));
-        Refresh();
+        // Only refresh when nothing claimed the event. A handler that sets e.Handled = true
+        // takes ownership of the event and is responsible for calling map.RefreshGraphics()
+        // itself — either directly or via a side effect such as a viewport change. Calling
+        // Refresh() unconditionally would upgrade any targeted partial refresh to a full one.
+        if (!handled)
+            Refresh();
         return handled;
     }
 

--- a/Mapsui.UI.Shared/RenderController.cs
+++ b/Mapsui.UI.Shared/RenderController.cs
@@ -83,14 +83,14 @@ public sealed class RenderController : IDisposable
     }
 
     /// <summary>
-    /// Signals that only the given world-coordinate rectangle needs to be redrawn.
-    /// Multiple calls before the next render are unioned into one accumulated dirty rect.
-    /// If a full refresh is already pending, the dirty rect is ignored.
+    /// Signals that only the given region needs to be redrawn.
+    /// Multiple calls before the next render are accumulated.
+    /// If a full refresh is already pending, the incoming request is ignored.
     /// </summary>
-    /// <param name="dirtyRect">The world-coordinate region that changed, or <see langword="null"/> to force a full refresh.</param>
-    public void RefreshGraphics(MRect? dirtyRect)
+    /// <param name="request">The refresh request, or <see langword="null"/> to force a full refresh.</param>
+    public void RefreshGraphics(RefreshRequest? request)
     {
-        var incoming = dirtyRect == null ? RefreshRequest.Full : new RefreshRequest(dirtyRect);
+        var incoming = request ?? RefreshRequest.Full;
         lock (_refreshLock)
             _pendingRefresh = _pendingRefresh == null ? incoming : _pendingRefresh.Accumulate(incoming);
         _needsRefresh.Set();
@@ -177,7 +177,8 @@ public sealed class RenderController : IDisposable
         _stopwatch.Restart();
         _timestampStartDraw = GetTimestampInMilliseconds();
 
-        _mapRenderer.Render(canvas, map.Navigator.Viewport, map.Layers, map.Widgets, map.RenderService, map.BackColor, TakePendingRefresh()?.DirtyRect);
+        var pending = TakePendingRefresh();
+        _mapRenderer.Render(canvas, map.Navigator.Viewport, map.Layers, map.Widgets, map.RenderService, map.BackColor, pending?.DirtyRect, pending?.CoordinateSpace ?? CoordinateSpace.World);
 
         _isDrawingDone.Set();
         _stopwatch.Stop();

--- a/Mapsui/CoordinateSpace.cs
+++ b/Mapsui/CoordinateSpace.cs
@@ -1,0 +1,21 @@
+namespace Mapsui;
+
+/// <summary>
+/// Specifies the coordinate space of an <see cref="MRect"/> passed to
+/// <see cref="Map.RefreshGraphics(MRect, CoordinateSpace)"/>.
+/// </summary>
+public enum CoordinateSpace
+{
+    /// <summary>
+    /// World/map coordinates (e.g. EPSG:3857 metres).
+    /// Use for data-driven updates such as moving a GPS marker.
+    /// </summary>
+    World,
+
+    /// <summary>
+    /// Screen coordinates in device-independent pixels.
+    /// Use for widget-area updates that are fixed to the screen, such as
+    /// refreshing the area occupied by a custom widget.
+    /// </summary>
+    Screen,
+}

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -274,7 +274,7 @@ public class Map : INotifyPropertyChanged, IDisposable
 
     /// <summary>
     /// Signals that the entire map needs to be redrawn on the next render cycle.
-    /// Use <see cref="RefreshGraphics(MRect)"/> instead when only a small area has changed.
+    /// Use <see cref="RefreshGraphics(MRect, CoordinateSpace)"/> instead when only a small area has changed.
     /// </summary>
     public void RefreshGraphics()
     {
@@ -282,14 +282,16 @@ public class Map : INotifyPropertyChanged, IDisposable
     }
 
     /// <summary>
-    /// Signals that only the given world-coordinate rectangle needs to be redrawn.
-    /// Use this instead of <see cref="RefreshGraphics()"/> when a data change affects only a
-    /// small region, so the render controller can limit work to that area.
+    /// Signals that only the given rectangle needs to be redrawn.
+    /// Use <paramref name="coordinateSpace"/> to specify whether <paramref name="dirtyRect"/>
+    /// is in world coordinates (e.g. for a moving GPS marker) or in screen coordinates
+    /// (e.g. for a widget area fixed to the screen).
     /// </summary>
-    /// <param name="dirtyRect">The world-coordinate region that changed.</param>
-    public void RefreshGraphics(MRect dirtyRect)
+    /// <param name="dirtyRect">The region that changed.</param>
+    /// <param name="coordinateSpace">The coordinate space of <paramref name="dirtyRect"/>. Defaults to <see cref="CoordinateSpace.World"/>.</param>
+    public void RefreshGraphics(MRect dirtyRect, CoordinateSpace coordinateSpace = CoordinateSpace.World)
     {
-        RefreshGraphicsRequest?.Invoke(this, new RefreshGraphicsEventArgs(new RefreshRequest(dirtyRect)));
+        RefreshGraphicsRequest?.Invoke(this, new RefreshGraphicsEventArgs(new RefreshRequest(dirtyRect, coordinateSpace)));
     }
 
     public void OnViewportSizeInitialized()

--- a/Mapsui/RefreshRequest.cs
+++ b/Mapsui/RefreshRequest.cs
@@ -2,8 +2,8 @@ namespace Mapsui;
 
 /// <summary>
 /// Describes what needs to be redrawn on the next render cycle.
-/// Either the full viewport (<see cref="Full"/>) or a specific world-coordinate dirty rectangle.
-/// Accumulate consecutive requests with <see cref="Accumulate"/>.
+/// Either the full viewport (<see cref="Full"/>) or a partial dirty rectangle in a specific
+/// <see cref="CoordinateSpace"/>. Accumulate consecutive requests with <see cref="Accumulate"/>.
 /// </summary>
 public sealed record RefreshRequest
 {
@@ -11,9 +11,16 @@ public sealed record RefreshRequest
     public static readonly RefreshRequest Full = new();
 
     /// <summary>
-    /// The world-coordinate region to redraw, or <see langword="null"/> when this is a full refresh.
+    /// The dirty region to redraw, or <see langword="null"/> when this is a full refresh.
+    /// Its coordinate space is given by <see cref="CoordinateSpace"/>.
     /// </summary>
     public MRect? DirtyRect { get; }
+
+    /// <summary>
+    /// Whether <see cref="DirtyRect"/> is in world or screen coordinates.
+    /// Irrelevant when <see cref="IsFullRefresh"/> is <see langword="true"/>.
+    /// </summary>
+    public CoordinateSpace CoordinateSpace { get; }
 
     /// <summary>Returns <see langword="true"/> when the entire viewport must be redrawn.</summary>
     public bool IsFullRefresh => DirtyRect == null;
@@ -22,16 +29,26 @@ public sealed record RefreshRequest
     private RefreshRequest() { }
 
     /// <summary>Creates a partial refresh request for the given world-coordinate rectangle.</summary>
-    public RefreshRequest(MRect dirtyRect) => DirtyRect = dirtyRect;
+    public RefreshRequest(MRect dirtyRect) : this(dirtyRect, CoordinateSpace.World) { }
+
+    /// <summary>Creates a partial refresh request for the given rectangle in the specified coordinate space.</summary>
+    public RefreshRequest(MRect dirtyRect, CoordinateSpace coordinateSpace)
+    {
+        DirtyRect = dirtyRect;
+        CoordinateSpace = coordinateSpace;
+    }
 
     /// <summary>
     /// Returns a <see cref="RefreshRequest"/> that covers the union of this request and
-    /// <paramref name="other"/>. If either is a full refresh the result is always
-    /// <see cref="Full"/>; otherwise the dirty rectangles are joined.
+    /// <paramref name="other"/>. If either is a full refresh, or the two requests use different
+    /// coordinate spaces, the result is always <see cref="Full"/>; otherwise the dirty rectangles
+    /// are joined within the shared coordinate space.
     /// </summary>
     public RefreshRequest Accumulate(RefreshRequest other)
     {
         if (IsFullRefresh || other.IsFullRefresh) return Full;
-        return new RefreshRequest(DirtyRect!.Join(other.DirtyRect!));
+        // Rects from different coordinate spaces can't be unioned without a viewport.
+        if (CoordinateSpace != other.CoordinateSpace) return Full;
+        return new RefreshRequest(DirtyRect!.Join(other.DirtyRect!), CoordinateSpace);
     }
 }

--- a/Mapsui/Rendering/IMapRenderer.cs
+++ b/Mapsui/Rendering/IMapRenderer.cs
@@ -41,10 +41,11 @@ public interface IMapRenderer
     /// <param name="widgets">The widgets to draw on top of the map.</param>
     /// <param name="renderService">The render service, which holds shared caches and resources.</param>
     /// <param name="background">Optional background color to fill before drawing layers. Pass <see langword="null"/> to skip.</param>
-    /// <param name="dirtyRegion">World-coordinate rectangle of the area that needs to be redrawn.
+    /// <param name="dirtyRegion">Rectangle of the area that needs to be redrawn, interpreted in <paramref name="coordinateSpace"/>.
     /// Pass <see langword="null"/> to redraw the full viewport.
     /// When provided, only this region is repainted (canvas is clipped and feature queries are limited to this area).</param>
-    void Render(object target, Viewport viewport, IEnumerable<ILayer> layers, IEnumerable<IWidget> widgets, RenderService renderService, Color? background = null, MRect? dirtyRegion = null);
+    /// <param name="coordinateSpace">The coordinate space of <paramref name="dirtyRegion"/>. Ignored when <paramref name="dirtyRegion"/> is <see langword="null"/>.</param>
+    void Render(object target, Viewport viewport, IEnumerable<ILayer> layers, IEnumerable<IWidget> widgets, RenderService renderService, Color? background = null, MRect? dirtyRegion = null, CoordinateSpace coordinateSpace = CoordinateSpace.World);
 
     /// <summary>
     /// Renders the map to a PNG (or other format) bitmap and returns it as a stream.

--- a/Samples/Mapsui.Samples.Common/Maps/Special/PartialRefreshWidgetSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/PartialRefreshWidgetSample.cs
@@ -1,0 +1,152 @@
+using Mapsui.Experimental.Rendering.Skia;
+using Mapsui.Extensions;
+using Mapsui.Rendering;
+using Mapsui.Styles;
+using Mapsui.Tiling;
+using Mapsui.Widgets;
+using Mapsui.Widgets.BoxWidgets;
+using Mapsui.Widgets.ButtonWidgets;
+using SkiaSharp;
+using System;
+using System.Threading.Tasks;
+
+namespace Mapsui.Samples.Common.Maps.Special;
+
+// This sample demonstrates partial viewport refresh: instead of redrawing the entire map,
+// only a specified rectangle is redrawn. The random-colour full-screen overlay makes it easy
+// to see exactly which area was repainted on each button tap.
+//
+// Two coordinate spaces are shown:
+//   - World (EPSG:3857 metres): the dirty rect is expressed in geographic coordinates.
+//     Use this when refreshing spatial features whose position changes in the real world,
+//     such as a moving GPS marker or a live vehicle track. Panning the map away from the
+//     feature's location means the refresh has no visible effect — which is correct.
+//   - Screen (device-independent pixels): the dirty rect is expressed relative to the
+//     top-left corner of the rendered surface. Use this for fixed-position UI elements
+//     such as widgets, overlays, or attribution labels that always occupy the same spot
+//     regardless of where the map is panned or zoomed.
+public sealed class PartialRefreshWidgetSample : ISample
+{
+    public string Name => "PartialRefreshWidget";
+    public string Category => "Special";
+
+    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+
+    public static Map CreateMap()
+    {
+        Mapsui.Rendering.Skia.MapRenderer.RegisterWidgetRenderer(typeof(FullScreenColorWidget), new FullScreenColorWidgetRenderer());
+        MapRenderer.RegisterWidgetRenderer(typeof(FullScreenColorWidget), new FullScreenColorWidgetExperimentalRenderer());
+
+        var map = new Map { CRS = "EPSG:3857" };
+        map.Layers.Add(OpenStreetMap.CreateTileLayer());
+        map.Widgets.Add(new FullScreenColorWidget());
+        map.Widgets.Add(CreateInstructionTextBox());
+        map.Widgets.Add(CreateWorldSpaceRefreshButton());
+        map.Widgets.Add(CreateScreenSpaceRefreshButton());
+        return map;
+    }
+
+    // World-space refresh: the dirty rect is a fixed geographic extent in EPSG:3857 metres.
+    // Only tiles and features that intersect this rectangle are redrawn. If you pan the
+    // viewport outside this area the button has no visible effect, illustrating that the
+    // refresh is tied to geography, not to the screen. This is the right choice for
+    // features that move through the world, e.g. a live GPS position update.
+    private static ButtonWidget CreateWorldSpaceRefreshButton() => new()
+    {
+        Text = "Refresh World Area (World coords)",
+        VerticalAlignment = VerticalAlignment.Bottom,
+        HorizontalAlignment = HorizontalAlignment.Left,
+        CornerRadius = 3,
+        BackColor = new Color(0, 123, 255),
+        TextColor = Color.White,
+        Margin = new MRect(10, 50, 10, 50),
+        Padding = new MRect(8),
+        TextSize = 16,
+        WithTappedEvent = (s, e) =>
+        {
+            // Fixed world-space extent — pan away from this area and the button has no effect.
+            var dirtyRect = new MRect(-1_000_000, -1_000_000, 1_000_000, 1_000_000);
+            e.Map.RefreshGraphics(dirtyRect); // CoordinateSpace.World is the default
+            e.Handled = true;
+        }
+    };
+
+    // Screen-space refresh: the dirty rect is expressed in device-independent pixels
+    // relative to the top-left of the rendered surface. The refreshed region stays at
+    // exactly the same spot on screen regardless of how the map is panned or zoomed.
+    // This is the right choice for widgets and overlays — e.g. a GPS accuracy badge or
+    // an attribution label — whose screen position never changes.
+    private static ButtonWidget CreateScreenSpaceRefreshButton() => new()
+    {
+        Text = "Refresh Bottom-Center (Screen)",
+        VerticalAlignment = VerticalAlignment.Bottom,
+        HorizontalAlignment = HorizontalAlignment.Left,
+        CornerRadius = 3,
+        BackColor = new Color(40, 167, 69),
+        TextColor = Color.White,
+        Margin = new MRect(10),
+        Padding = new MRect(8),
+        TextSize = 16,
+        WithTappedEvent = (s, e) =>
+        {
+            // A fixed pixel rectangle covering the bottom-centre of the screen — exactly
+            // where a typical overlay widget (e.g. an attribution bar) would live.
+            var w = e.Map.Navigator.Viewport.Width;
+            var h = e.Map.Navigator.Viewport.Height;
+            var dirtyRect = new MRect(w / 2 - 100, h - 60, w / 2 + 100, h);
+            e.Map.RefreshGraphics(dirtyRect, CoordinateSpace.Screen);
+            e.Handled = true;
+        }
+    };
+
+    private static TextBoxWidget CreateInstructionTextBox() => new()
+    {
+        Text = "Partial viewport refresh in world and screen coordinate space using a random color overlay.",
+        TextSize = 16,
+        VerticalAlignment = VerticalAlignment.Top,
+        HorizontalAlignment = HorizontalAlignment.Center,
+        Margin = new MRect(10),
+        Padding = new MRect(8),
+        CornerRadius = 3,
+        BackColor = new Color(108, 117, 125, 128),
+        TextColor = Color.White,
+    };
+
+
+}
+
+internal sealed class FullScreenColorWidget : BaseWidget { }
+
+internal sealed class FullScreenColorWidgetRenderer : Mapsui.Rendering.Skia.SkiaWidgets.ISkiaWidgetRenderer
+{
+    private static readonly Random _random = new();
+
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity)
+    {
+        widget.Envelope = new MRect(0, 0, viewport.Width, viewport.Height);
+        // A new random colour on every draw call — this is intentional: it makes each
+        // render cycle visually distinct, which clearly demonstrates when a partial vs
+        // full repaint occurs.
+        var alpha = (byte)Math.Clamp((int)Math.Round(80 * layerOpacity), 0, 255);
+        var color = new SKColor((byte)_random.Next(256), (byte)_random.Next(256), (byte)_random.Next(256), alpha);
+        using var paint = new SKPaint { Color = color };
+        canvas.DrawRect(new SKRect(0, 0, (float)viewport.Width, (float)viewport.Height), paint);
+    }
+}
+
+internal sealed class FullScreenColorWidgetExperimentalRenderer : Mapsui.Experimental.Rendering.Skia.SkiaWidgets.ISkiaWidgetRenderer
+{
+    private static readonly Random _random = new();
+
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity, SKRect? dirtyScreenRect)
+    {
+        widget.Envelope = new MRect(0, 0, viewport.Width, viewport.Height);
+        // A new random colour on every draw call — this is intentional: it makes each
+        // render cycle visually distinct, which clearly demonstrates when a partial vs
+        // full repaint occurs.
+        var alpha = (byte)Math.Clamp((int)Math.Round(80 * layerOpacity), 0, 255);
+        var color = new SKColor((byte)_random.Next(256), (byte)_random.Next(256), (byte)_random.Next(256), alpha);
+        using var paint = new SKPaint { Color = color };
+        canvas.DrawRect(new SKRect(0, 0, (float)viewport.Width, (float)viewport.Height), paint);
+    }
+}


### PR DESCRIPTION
## Summary

The partial refresh API previously only accepted world-coordinate (EPSG:3857) dirty rects. This adds a `CoordinateSpace` enum so callers can express whether a dirty rect is in **world** or **screen** coordinates, enabling correct partial redraws for fixed-screen-position elements such as widgets and overlays.

## Changes

### Core (`Mapsui`)
- New `CoordinateSpace` enum (`World` | `Screen`)
- `RefreshRequest` now carries a `CoordinateSpace` and preserves it through accumulation; requests from different coordinate spaces fall back to a full refresh (they can't be unioned without a viewport)
- `Map.RefreshGraphics(MRect, CoordinateSpace)` exposes the new overload to callers (defaults to `World` for backward compatibility)

### Experimental renderer (`Mapsui.Experimental.Rendering.Skia`)
- `MapRenderer.Render` resolves the dirty rect to a screen-space `SKRect` once at the entry point, avoiding repeated world→screen conversions downstream and correctly handling screen-space requests without any viewport transform
- `IsNearlyFullScreen` now operates directly on the already-resolved `SKRect`

### Non-experimental renderer (`Mapsui.Rendering.Skia`)
- `IMapRenderer.Render` signature extended with `coordinateSpace` parameter; non-experimental renderer accepts but ignores it (no partial-refresh support there)

### UI (`Mapsui.UI.Shared`)
- `RenderController.RefreshGraphics` now accepts a full `RefreshRequest?` instead of just an `MRect?`, passing the coordinate space through to the renderer
- `MapControl.OnPointerReleased` no longer calls `Refresh()` unconditionally — only when no handler claimed the event, so partial refreshes issued by widget tap handlers aren't silently upgraded to full redraws

### Sample
- `PartialRefreshWidgetSample` demonstrates both coordinate spaces with a random-colour overlay; two buttons show world-space vs screen-space partial refresh in action

## Backward compatibility

`Map.RefreshGraphics(MRect)` and `RefreshRequest(MRect)` still work unchanged (both default to `CoordinateSpace.World`).