### PR TITLE
Remove experimental as a release category

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -31,9 +31,6 @@ changelog:
     - title: "📝 Documentation"
       labels:
         - "PR type: 📝 Documentation"
-    - title: "☢️ Experimental"
-      labels:
-        - "PR type: ☢️ Experimental"
     # Optional: catch-all for PRs/issues without recognized type labels
     - title: "💩 Other Changes"
       labels:


### PR DESCRIPTION
The `experimental` label is a different nature than the `PR type` labels — it's a modifier (describing a characteristic of the change) rather than a category (describing what kind of change it is). A PR can be both a Feature *and* experimental at the same time, so it doesn't belong as its own release section.

Going forward, experimental PRs get a ☢️ prefix in the PR title (e.g. `☢️ Add GridLayer`). Since release notes are generated from PR titles, the indicator shows up automatically in the correct category without any manual work at release time.