### PR TITLE
Add Copilot skills for regression tests and RichTextKit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,49 +90,19 @@ Then revert any files that were not actually affected by your change (avoid unne
 Samples **do not need to be manually registered**. The `Mapsui.Sample.SourceGenerator` (in `SourceGenerators/`) scans all classes that implement `ISample`, `ISampleBase`, `ISampleTest`, or `IMapViewSample` at build time and generates a `Samples.Register()` method in the assembly. Adding a new sample class that implements one of these interfaces is sufficient — no call to `AllSamples.Register()` is needed. The regression tests in `Mapsui.Rendering.Skia.Tests` pick up samples through the same mechanism.
 
 ### Experimental renderer and text layout
-The experimental renderer (`Mapsui.Experimental.Rendering.Skia`) wraps RichTextKit (RTK) inside `SkiaTextLayoutHelper`. RTK remains a required dependency — it provides UAX#14 line breaking, BiDi, and font fallback. When measuring line height, always use `font.Spacing` (ascent + descent + leading) rather than tight glyph bounds. See `.github/instructions/richtextkit.instructions.md` for full RTK guidance.
+The experimental renderer (`Mapsui.Experimental.Rendering.Skia`) wraps RichTextKit (RTK) inside `SkiaTextLayoutHelper`. RTK remains a required dependency — it provides UAX#14 line breaking, BiDi, and font fallback. When measuring line height, always use `font.Spacing` (ascent + descent + leading) rather than tight glyph bounds. See `.github/instructions/richtextkit.instructions.md` for full RTK guidance, or load the `.github/skills/richtextkit/SKILL.md` skill for on-demand reference.
 
 ## After making changes — checklist
 
-After completing any non-trivial change, work through this checklist in order:
+Before opening a pull request, load the done-checklist skill (`.github/skills/done-checklist/SKILL.md`) and work through every task. The skill tracks state in a per-branch JSON file so nothing is skipped across sessions.
 
-### 1. Build — no errors allowed
-```ps
-dotnet build
-```
-Fix all build errors before proceeding.
+## Available skills
 
-### 2. Unit tests — run first (fast)
-```ps
-dotnet test --filter "Category!=Regression"
-```
-Or target the affected project directly. These are fast and catch most logic errors.
-
-### 3. Rendering regression tests — run after unit tests (slower)
-Required for any change that touches rendering (styles, renderers, callouts, widgets, etc.):
-```ps
-dotnet test Tests/Mapsui.Rendering.Skia.Tests --filter "TestSampleAsync"
-```
-See the **Rendering regression tests** section in Testing guidance for how to interpret results and update reference images.
-
-### 4. Code style and guidelines check
-- Does the code follow the compact Mapsui style (see **Code style** section)?
-- Are comments explaining *why*, not *what*?
-- Are new public APIs documented with XML doc comments?
-- Are there any guideline violations (disposability, rendering in draw loop, lon/lat order, extension methods)?
-
-### 5. Documentation — does anything need updating?
-- **Upgrade guide** (see below): are there breaking changes?
-- **README or user-facing docs** (`docs/general/markdown/`): does behavior change in a way users need to know?
-- **mkdocs nav** (`docs/general/mkdocs.yml`): if a new doc page was added, register it in the nav.
-
-### 6. Breaking changes → update the upgrade guide
-If the change removes, renames, or alters the behavior of any public API, **update the upgrade guide** for the current major version:
-- Location: `docs/general/markdown/v6.0-upgrade-guide.md`
-- Describe what changed, why, and how users should migrate.
-- Keep entries concise: old API → new API, with a one-sentence rationale.
-
-There are no E2E tests in this repository, so step 3 (regression tests) is the closest equivalent.
+| Skill | When to load |
+|---|---|
+| `.github/skills/done-checklist/SKILL.md` | Before opening any PR — runs the full pre-PR checklist |
+| `.github/skills/regression-tests/SKILL.md` | When working with rendering regression tests: running, updating references, diagnosing failures, or adding experimental-renderer samples |
+| `.github/skills/richtextkit/SKILL.md` | When implementing text rendering features involving word wrap, BiDi/RTL, emoji, font fallback, or multi-style text blocks |
 
 ## Documentation
 - Update README or docs when behavior changes or new features are added.

--- a/.github/skills/done-checklist/SKILL.md
+++ b/.github/skills/done-checklist/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: done-checklist
+description: Run the pre-PR completion checklist — build, unit tests, rendering regression tests, style, docs, architecture review, instructions improvement, and code review — tracked as a JSON file so nothing is skipped. Load this skill when you finish implementing any feature, bug fix, or refactoring before opening a pull request.
+---
+
+# Done Checklist
+
+Use this skill every time you finish implementing a feature or resolving an issue, before opening a pull request. State is stored in `.github/skills/done-checklist/state/<branch>.json` (gitignored). All chat sessions on the same branch share one file — one branch = one checklist.
+
+> **RULE: Never declare a feature done or open a PR until every task in the state file shows `"status": "completed"`.**
+
+---
+
+## Step 1 — Decide which tasks to include
+
+| Task | Include when |
+|---|---|
+| `build` | Always |
+| `unit-tests` | Always |
+| `regression-tests` | Any change that touches rendering: styles, renderers, callouts, widgets, GridLayer, or anything in `Mapsui.Rendering.Skia` / `Mapsui.Experimental.Rendering.Skia`. When in doubt, include it. |
+| `update-regression-images` | Include together with `regression-tests` **only** when rendering was intentionally changed (e.g. a new visual feature, not a bug fix). |
+| `no-todos-left` | Always |
+| `code-style` | Always |
+| `copilot-guidelines` | Always |
+| `upgrade-guide` | Always |
+| `documentation` | Always |
+| `architecture` | Always |
+| `improve-instructions` | Always |
+| `code-review`, `code-review-fixes-1`, `code-review-2`, `code-review-fixes-2`, `code-review-3`, `code-review-fixes-3` | Always (always last) |
+
+---
+
+## Step 2 — Initialize or resume the state file
+
+Two files are involved, with clearly separate responsibilities:
+
+- **`tasks.json`** — task definitions (id, label, instructions, commands). This is the user-maintained source of truth for *what* the checklist does. The agent never modifies it.
+- **`state/<branch>.json`** — progress tracking. This is agent-maintained and gitignored. It contains only the task IDs and their completion status. The user never touches it.
+
+The state file lives at `.github/skills/done-checklist/state/<branch>.json` where `<branch>` has `/` and `\` replaced with `_`.
+
+**At the start of every new chat session involving this skill, always read the state file first.**
+
+- **File does not exist**: create it at `state/<branch>.json` using `create_file`. Read `tasks.json` to get the task list, omit tasks where `"optional": true` that don't apply (see Step 1). The state file contains only ids and status — not the full task definitions:
+  ```json
+  {
+    "branch": "<branch>",
+    "createdAt": "<timestamp>",
+    "tasks": [
+      { "id": "build",       "status": "pending", "completedAt": null },
+      { "id": "unit-tests",  "status": "pending", "completedAt": null }
+    ]
+  }
+  ```
+- **File exists and this is a continuation** of interrupted work: read it and continue from the first `"pending"` task.
+- **File exists but this is a fresh piece of work** on this branch: delete the old content and recreate as above.
+
+---
+
+## Step 3 — Work through tasks in order
+
+Read the state file. Find the first task with `"status": "pending"`. Execute it. Mark it complete. Repeat until all tasks are `"status": "completed"`.
+
+### Command tasks (`"type": "command"`)
+
+1. Run the `command` in a terminal from the workspace root (`c:\code\github\Mapsui`).
+2. Read `instruction` — it defines exactly what success means.
+3. If it fails: **fix the problem, re-run, confirm it passes**, then mark complete.
+4. Never mark a failing command complete.
+
+### Agent tasks (`"type": "agent"`)
+
+Perform the task yourself according to `instruction`:
+
+- **`regression-tests`** — Run the rendering regression tests. Results mean: `Passed` = matches reference; `Inconclusive` = no reference image yet, one was generated (review the generated image visually before marking complete); `Failed` = pixel difference exceeded threshold — compare the Generated vs Original images, fix the rendering cause, re-run until all results are Passed or Inconclusive. Never mark complete with any `Failed` results.
+- **`update-regression-images`** — Only run this task after `regression-tests` passes/is-inconclusive and the rendering change was intentional. Run `.\Scripts\CopyGeneratedImagesOverOriginalImages.ps1`. Then use `git diff --name-only` and revert any image files that were NOT affected by your change (avoid binary noise in the git history). Report which images were updated before marking complete.
+- **`no-todos-left`** — Search all changed files for `TODO`, `FIXME`, and `HACK` comments. Each one must be resolved now or tracked as a GitHub issue. Report any found before marking complete.
+- **`code-style`** — Run `dotnet format Mapsui.slnx --verify-no-changes`. If violations are found, run `dotnet format Mapsui.slnx` to fix them, then re-run `dotnet build` to confirm nothing broke. Note: exit code 1 with only "Warnings were encountered while loading the workspace" in the output is a pre-existing issue (VexTile.Perf missing a SQLite dep) — not a style failure. Check the output for actual formatting changes made by running `git diff --name-only HEAD` after applying format. Report what was changed before marking complete.
+- **`copilot-guidelines`** — Review all changed code against the guidelines in `.github/copilot-instructions.md`. Check specifically: compact style (var, expression-bodied, no unnecessary braces), comments explain *why* not *what*, no rendering in the draw/paint loop, lon/lat ordering (`SphericalMercator.FromLonLat(lon, lat)`), extension methods in correct `Extensions/` folder with correct class name (`{TypeItExtends}Extensions`), no new `IDisposable` on renderers for Skia resources (use `RenderService` instead), public API has XML doc comments. Fix any violation before marking complete.
+- **`upgrade-guide`** — Check whether any public API was removed, renamed, or had its behavior changed. If yes, add an entry to `docs/general/markdown/v6.0-upgrade-guide.md` describing old API → new API with a one-sentence rationale. If no breaking changes, mark complete immediately.
+- **`documentation`** — Review all changes and update any affected user-facing docs in `docs/general/markdown/`. Consider whether new documentation is needed (new concepts, new sample, behavior changes, new public API). If a new doc page was added, register it in `docs/general/mkdocs.yml`. Report what was done before marking complete.
+- **`architecture`** — Review changes for architecture implications against the Mapsui hierarchy (`DataSource → Fetcher → Layer → Map → MapControl`). Check: does anything push `IDisposable`, `async/await`, or exception-throwing code deeper into core than it should be? Does anything render inside a draw loop? Is anything coupled that should be independent? If NO refactoring needed: mark complete immediately. If YES: discuss with the user and get explicit agreement before proceeding.
+- **`improve-instructions`** — Reflect on this session: was there anything that took several attempts, required searching in multiple places, or was unexpectedly hard to figure out? If yes, improve the relevant instructions or skill so the next session goes faster. Good candidates: a convention that wasn't documented, a command that wasn't obvious, a pattern that needed several searches to locate, a gotcha in the codebase. Update `.github/copilot-instructions.md` for general conventions, a specific `.github/instructions/*.instructions.md` for subsystem-specific knowledge, or a skill file for workflow steps. Report what you added or changed, or explain why nothing needed updating. Mark complete only after making the improvement (or genuinely concluding nothing was friction).
+- **`code-review`** — Review ALL changes for correctness, edge cases, dead code, security, naming, and conventions. List ALL findings. Do NOT fix yet. If nothing found, mark `code-review-fixes-1`, `code-review-2`, `code-review-fixes-2`, `code-review-3`, and `code-review-fixes-3` all complete immediately.
+- **`code-review-fixes-1`** — Apply every fix from `code-review`. Re-run build and unit tests after. If nothing was found in `code-review`, mark this and all remaining review tasks complete immediately.
+- **`code-review-2`** — Second pass focusing on anything changed in `code-review-fixes-1`. List findings. Do NOT fix yet. If nothing found, mark `code-review-fixes-2`, `code-review-3`, `code-review-fixes-3` complete immediately.
+- **`code-review-fixes-2`** — Apply every fix from `code-review-2`. Re-run build and unit tests. If nothing found, mark the remaining two tasks complete immediately.
+- **`code-review-3`** — Third and final pass focusing on anything changed in `code-review-fixes-2`. List findings. Do NOT fix yet. If nothing found, mark `code-review-fixes-3` complete immediately.
+- **`code-review-fixes-3`** — Apply every fix from `code-review-3`. Re-run build and unit tests. If nothing found, mark complete immediately.
+
+### Marking a task complete
+
+Use `replace_string_in_file` on the state file. The task `"id"` is unique — include it in the match for context. Change `"status": "pending"` to `"status": "completed"` and set `"completedAt"` to the current timestamp. Example:
+
+```json
+      "id": "build",
+      "status": "pending",
+      "completedAt": null
+```
+
+→
+
+```json
+      "id": "build",
+      "status": "completed",
+      "completedAt": "2026-04-25T10:00:00.000Z"
+```
+
+---
+
+## Rules
+
+- **Never mark a failing task complete.** Fix → re-run → pass → complete.
+- **Never skip a task.**
+- **Zero tolerance for red tests.** Every test must be green.
+- **Architecture task:** if refactoring is needed, discuss with the user before proceeding. Never silently mark it complete.
+- **Rendering regression tests:** `Inconclusive` is acceptable (new sample, no reference yet — just review the generated image). `Failed` is never acceptable.

--- a/.github/skills/done-checklist/state/.gitignore
+++ b/.github/skills/done-checklist/state/.gitignore
@@ -1,0 +1,2 @@
+# Ignore all state files — these are local per-developer, per-branch tracking files.
+*.json

--- a/.github/skills/done-checklist/tasks.json
+++ b/.github/skills/done-checklist/tasks.json
@@ -1,0 +1,140 @@
+{
+  "tasks": [
+    {
+      "id": "build",
+      "label-for-human": "Build solution",
+      "type": "command",
+      "command": "dotnet build",
+      "instruction": "Run the full solution build. Read ALL output. Fix every compilation error and warning before marking complete.",
+      "optional": false
+    },
+    {
+      "id": "unit-tests",
+      "label-for-human": "Run unit tests",
+      "type": "command",
+      "command": "dotnet test --filter \"Category!=Regression\"",
+      "instruction": "Run all unit tests (excluding rendering regression tests). Every test must be green — zero failures. Fix any failure before marking complete.",
+      "optional": false
+    },
+    {
+      "id": "regression-tests",
+      "label-for-human": "Run rendering regression tests",
+      "type": "agent",
+      "command": "dotnet test Tests/Mapsui.Rendering.Skia.Tests --filter \"TestSampleAsync\"",
+      "instruction": "Run all rendering regression tests. Results: Passed = matches reference image (good); Inconclusive = no reference yet, one was generated — review the generated image visually before marking complete; Failed = pixel difference exceeded threshold — compare Generated vs Original images (both under Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net9.0/Resources/Images/), fix the rendering cause, re-run until no Failed results remain. Never mark complete with any Failed results.",
+      "optional": true
+    },
+    {
+      "id": "update-regression-images",
+      "label-for-human": "Update regression reference images",
+      "type": "agent",
+      "command": null,
+      "instruction": "Run .\\Scripts\\CopyGeneratedImagesOverOriginalImages.ps1 to promote generated images to reference images. Then run 'git diff --name-only' and revert any image files that were NOT affected by your intentional rendering change — avoid committing unrelated binary diffs. Report which images were updated before marking complete.",
+      "optional": true
+    },
+    {
+      "id": "no-todos-left",
+      "label-for-human": "No untracked TODOs",
+      "type": "agent",
+      "command": null,
+      "instruction": "Search all changed files for TODO, FIXME, and HACK comments introduced by this change. Each one must be resolved now or tracked as a GitHub issue. Do not leave untracked debt in the codebase. Report any found before marking complete.",
+      "optional": false
+    },
+    {
+      "id": "code-style",
+      "label-for-human": "Code style check",
+      "type": "agent",
+      "command": null,
+      "instruction": "Run 'dotnet format --check'. If violations are found, run 'dotnet format' to fix them automatically, then re-run 'dotnet build' to confirm nothing broke. Report what was changed before marking complete. If no violations, mark complete immediately.",
+      "optional": false
+    },
+    {
+      "id": "copilot-guidelines",
+      "label-for-human": "Mapsui guidelines review",
+      "type": "agent",
+      "command": null,
+      "instruction": "Review all changed code against .github/copilot-instructions.md. Check: (1) compact style — var everywhere, expression-bodied members, optional braces for single-statement blocks; (2) comments explain *why* not *what*; (3) no rendering (SKPath creation etc.) inside the draw/paint loop — separate rendering from drawing; (4) lon/lat ordering — always SphericalMercator.FromLonLat(lon, lat); (5) extension methods in Extensions/ folder, class named {TypeItExtends}Extensions; (6) no new IDisposable on renderer classes for Skia resources — store in RenderService instead; (7) new public members have XML doc comments. Fix any violation before marking complete.",
+      "optional": false
+    },
+    {
+      "id": "upgrade-guide",
+      "label-for-human": "Upgrade guide — breaking changes",
+      "type": "agent",
+      "command": null,
+      "instruction": "Check whether any public API was removed, renamed, or had its observable behavior changed. If yes, add an entry to docs/general/markdown/v6.0-upgrade-guide.md: old API → new API with a one-sentence rationale. Keep entries concise. If no breaking changes, mark complete immediately.",
+      "optional": false
+    },
+    {
+      "id": "documentation",
+      "label-for-human": "Update documentation",
+      "type": "agent",
+      "command": null,
+      "instruction": "Review all changes and update any affected user-facing docs in docs/general/markdown/. Consider whether new documentation is needed (new concepts, new public API, behavior changes). If a new doc page was added, register it in docs/general/mkdocs.yml. Report what was done before marking complete.",
+      "optional": false
+    },
+    {
+      "id": "architecture",
+      "label-for-human": "Architecture review",
+      "type": "agent",
+      "command": null,
+      "instruction": "Review changes for architecture implications against the Mapsui hierarchy (DataSource → Fetcher → Layer → Map → MapControl). Check: does anything push IDisposable, async/await, or exception-throwing code deeper into core than it should be? Does anything render inside a draw loop? Is anything coupled that should be independent? If NO refactoring needed: mark complete immediately. If YES: discuss with the user and get explicit agreement before proceeding. Never silently mark complete if refactoring is needed.",
+      "optional": false
+    },
+    {
+      "id": "improve-instructions",
+      "label-for-human": "Improve instructions from friction",
+      "type": "agent",
+      "command": null,
+      "instruction": "Reflect on this session: was there anything that took several attempts, required searching in multiple places, or was unexpectedly hard to figure out? If yes, improve the relevant instructions or skill so the next session goes faster. Good candidates: a convention that wasn't documented, a command that wasn't obvious, a pattern that needed several searches to locate, a gotcha in the codebase. Update .github/copilot-instructions.md for general conventions, a specific .github/instructions/*.instructions.md for subsystem-specific knowledge, or a skill file for workflow steps. Report what you added or changed, or explain why nothing needed updating. Mark complete only after making the improvement (or genuinely concluding nothing was friction).",
+      "optional": false
+    },
+    {
+      "id": "code-review",
+      "label-for-human": "Thorough code review — pass 1",
+      "type": "agent",
+      "command": null,
+      "instruction": "Perform a thorough review of ALL changes made for this feature: correctness, edge cases, dead code, security, naming consistency, adherence to project conventions (copilot-instructions.md). List ALL findings clearly. Do NOT fix anything yet — fixes happen in code-review-fixes-1. If you found nothing at all, mark code-review-fixes-1, code-review-2, code-review-fixes-2, code-review-3, and code-review-fixes-3 as completed immediately.",
+      "optional": false
+    },
+    {
+      "id": "code-review-fixes-1",
+      "label-for-human": "Apply code review fixes — pass 1",
+      "type": "agent",
+      "command": null,
+      "instruction": "Apply every fix identified in code-review. Re-run build and unit tests after applying fixes. If nothing was found in code-review, mark this task and all remaining review tasks (code-review-2, code-review-fixes-2, code-review-3, code-review-fixes-3) complete immediately.",
+      "optional": false
+    },
+    {
+      "id": "code-review-2",
+      "label-for-human": "Thorough code review — pass 2",
+      "type": "agent",
+      "command": null,
+      "instruction": "Second pass review focusing on anything changed in code-review-fixes-1. List ALL findings. Do NOT fix yet. If nothing found, mark code-review-fixes-2, code-review-3, and code-review-fixes-3 complete immediately.",
+      "optional": false
+    },
+    {
+      "id": "code-review-fixes-2",
+      "label-for-human": "Apply code review fixes — pass 2",
+      "type": "agent",
+      "command": null,
+      "instruction": "Apply every fix identified in code-review-2. Re-run build and unit tests after applying fixes. If nothing was found in code-review-2, mark this task and the remaining two (code-review-3, code-review-fixes-3) complete immediately.",
+      "optional": false
+    },
+    {
+      "id": "code-review-3",
+      "label-for-human": "Thorough code review — pass 3",
+      "type": "agent",
+      "command": null,
+      "instruction": "Third and final pass review focusing on anything changed in code-review-fixes-2. List ALL findings. Do NOT fix yet. If nothing found, mark code-review-fixes-3 complete immediately.",
+      "optional": false
+    },
+    {
+      "id": "code-review-fixes-3",
+      "label-for-human": "Apply code review fixes — pass 3",
+      "type": "agent",
+      "command": null,
+      "instruction": "Apply every fix identified in code-review-3. Re-run build and unit tests after applying fixes. If nothing was found in code-review-3, mark complete immediately.",
+      "optional": false
+    }
+  ]
+}

--- a/.github/skills/regression-tests/SKILL.md
+++ b/.github/skills/regression-tests/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: regression-tests
+description: >
+  Authoritative guide for working with Mapsui's rendering regression tests — running, interpreting,
+  updating reference images, diagnosing failures, and adding new samples that require the
+  experimental renderer. Load this skill whenever a task involves regression tests or rendering changes.
+---
+
+# Rendering Regression Tests
+
+Tests live in `Tests/Mapsui.Rendering.Skia.Tests`. They render every sample to a PNG and compare it pixel-by-pixel against a stored reference image.
+
+---
+
+## Running
+
+```powershell
+# All regression tests
+dotnet test Tests/Mapsui.Rendering.Skia.Tests --filter "TestSampleAsync"
+
+# Single sample (fastest for targeted changes)
+dotnet test Tests/Mapsui.Rendering.Skia.Tests --filter "FullyQualifiedName~CalloutSample"
+```
+
+---
+
+## Results
+
+| Result | Meaning |
+|---|---|
+| **Passed** | Generated image matches the reference. |
+| **Inconclusive** | No reference image exists yet — the test generated one. **Visually inspect it** before promoting it to a reference. |
+| **Failed** | Pixel difference exceeded the threshold. Compare generated vs. reference (paths printed in the failure message). |
+
+Image paths:
+- Generated: `Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net9.0/Resources/Images/GeneratedRegression/`
+- Reference:  `Tests/Mapsui.Rendering.Skia.Tests/Resources/Images/OriginalRegression/`
+
+---
+
+## Updating reference images after intentional changes
+
+```powershell
+.\Scripts\CopyGeneratedImagesOverOriginalImages.ps1
+```
+
+Then run `git diff --name-only` and **revert every image that was not affected by your change** — avoid committing unrelated binary diffs.
+
+Alternatively, copy a single image manually:
+```powershell
+Copy-Item "Tests\Mapsui.Rendering.Skia.Tests\bin\Debug\net9.0\Resources\Images\GeneratedRegression\MySample.Regression.png" `
+          "Tests\Mapsui.Rendering.Skia.Tests\Resources\Images\OriginalRegression\MySample.Regression.png" -Force
+```
+
+---
+
+## Standard vs. experimental renderer
+
+The test suite can run with **either** renderer. The active renderer is determined by config files, searched in priority order:
+
+1. `config.local.json` in the test binary output dir (created by copying the project-level file)
+2. `config.json` in the test binary output dir (committed — default `experimentalRenderer: false`)
+3. `config.local.json` at the repository root (git-ignored, per-machine)
+4. `config.json` at the repository root
+
+**CI always runs with the standard renderer** (`experimentalRenderer: false`). Do not assume CI uses the experimental renderer.
+
+To run locally with the experimental renderer, create `Tests/Mapsui.Rendering.Skia.Tests/config.local.json`:
+```json
+{ "experimentalRenderer": true }
+```
+This file is git-ignored and automatically copied to the binary output dir at build time.
+
+---
+
+## Samples that require the experimental renderer
+
+The standard renderer does **not** support `Font.FontSource`, RichTextKit BiDi, or emoji rendering. Samples that require any of these must be added to `ExperimentalOnlySamples` in `MapRegressionTests.cs`:
+
+```csharp
+public static ISampleBase[] ExperimentalOnlySamples =>
+[
+    new CalloutWrapAroundSample(),   // FontSource + Chinese text
+    new CustomFontWidgetSample(),    // FontSource for Arabic and Chinese widgets
+    new RightToLeftSample(),         // FontSource for Arabic
+    new EmojiSample(),               // RTK emoji/font-fallback
+];
+```
+
+When `IsExperimentalRenderer = false` (CI), these samples are excluded from the test run. When `IsExperimentalRenderer = true`, they are included and their reference images must have been generated with the experimental renderer.
+
+**If you add a sample that uses `FontSource`, RTK, or emoji — always add it to `ExperimentalOnlySamples`.**
+
+---
+
+## FontSource — common pitfalls
+
+`FontSource` allows embedding custom fonts. Several things can silently fail:
+
+### TTF vs OTF
+`SKTypeface.FromStream` only works with **TTF** (`0x00 0x01 0x00 0x00` magic bytes). OTF/CFF files (magic `OTTO` = `0x4F 0x54 0x54 0x4F`) return `null` silently. Variable fonts in TTF format work fine.
+
+Always verify font format before embedding:
+```powershell
+$bytes = [System.IO.File]::ReadAllBytes("MyFont.ttf")
+"Magic: 0x{0:X2} 0x{1:X2} 0x{2:X2} 0x{3:X2}" -f $bytes[0], $bytes[1], $bytes[2], $bytes[3]
+# Must be: 0x00 0x01 0x00 0x00 (TTF) or 0x74 0x72 0x75 0x65 (truetype)
+# NOT:     0x4F 0x54 0x54 0x4F (OTF/CFF — won't work with SKTypeface.FromStream)
+```
+
+### FetchAllFontDataAsync in tests
+Regression tests call `await map.RenderService.FontSourceCache.FetchAllFontDataAsync()` **before** rendering (see `MapRegressionTests.cs`). This populates the font cache synchronously. In production the cache is populated by `DataFetcher` on viewport change — there is no need to call it manually outside tests.
+
+### Renderer must support FontSource
+Only `Mapsui.Experimental.Rendering.Skia` honours `Font.FontSource`. The standard renderer (`Mapsui.Rendering.Skia`) ignores it and falls back to `FontFamily` / system font. If glyphs render as boxes with the standard renderer, that is expected — add the sample to `ExperimentalOnlySamples`.
+
+**Why Arabic may appear correct while Chinese shows boxes (standard renderer):** Windows ships with system Arabic fonts (e.g. Segoe UI, Arial Unicode MS) so the standard renderer's `FontFamily` fallback accidentally finds a matching glyph. It does *not* ship with a CJK font by default, so Chinese characters render as boxes. This asymmetry can mask the fact that `FontSource` is being ignored — the Arabic "works" for the wrong reason. If a sample uses `FontSource` for any script, add it to `ExperimentalOnlySamples` regardless of whether individual scripts appear to render correctly on the standard renderer.
+
+### Embedded resource path
+The URI must exactly match the fully-qualified assembly resource name:
+```
+embedded://Mapsui.Samples.Common.Resources.Fonts.NotoSansArabic-Regular.ttf
+```
+The project `.csproj` must have a matching `<EmbeddedResource>` entry. Mismatch produces null bytes with no error.
+
+---
+
+## Diagnosing a broken rendering test
+
+1. **Check which renderer is active**: read `Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net9.0/config.local.json` and `config.json`.
+2. **Visually compare** the generated image against the reference image — the failure message prints both paths.
+3. **Font issues**: if text is boxes, the typeface is null. Check: (a) TTF magic bytes, (b) `FetchAllFontDataAsync` was awaited, (c) `Font.FontSource` URI matches the embedded resource name, (d) renderer is experimental.
+4. **Pre-existing failures**: when running with the experimental renderer, some non-related samples may fail because their reference images were generated with the standard renderer. Only fix failures in samples you changed.
+
+---
+
+## Adding a new sample with a regression test
+
+1. Implement the sample (see copilot-instructions for auto-registration via source generator).
+2. Run `dotnet test Tests/Mapsui.Rendering.Skia.Tests --filter "FullyQualifiedName~MySample"`.
+3. Result should be **Inconclusive** (no reference yet).
+4. **Visually inspect** the generated image in `GeneratedRegression/`.
+5. Copy it to `OriginalRegression/` (manually or via `CopyGeneratedImagesOverOriginalImages.ps1`).
+6. Re-run — should now be **Passed**.
+7. If the sample uses `FontSource` / RTK / emoji, add it to `ExperimentalOnlySamples` in `MapRegressionTests.cs` and generate the reference with the experimental renderer.

--- a/.github/skills/richtextkit/SKILL.md
+++ b/.github/skills/richtextkit/SKILL.md
@@ -1,8 +1,16 @@
 ---
-applyTo: "Mapsui.Rendering.Skia/**,Mapsui.Experimental.Rendering.Skia/**"
+name: richtextkit
+description: >
+  Reference and usage guide for RichTextKit (Topten.RichTextKit) in Mapsui's Skia renderers.
+  Load this skill when implementing or modifying any text rendering feature that involves
+  word wrap, BiDi/RTL text, emoji, font fallback, callouts, or multi-style text blocks.
 ---
 
-When working in this area, load and read `.github/skills/richtextkit/SKILL.md` for the full RichTextKit reference (usage patterns, FontMapper, pitfalls, performance notes).
+# RichTextKit (Topten.RichTextKit) in Mapsui
+
+RichTextKit provides text layout capabilities that SkiaSharp alone doesn't offer: Unicode line-breaking (UAX #14), bidirectional text (UAX #9), and font fallback for emoji and international scripts. Both renderers depend on it — it is not being replaced.
+
+NuGet package: `Topten.RichTextKit`
 
 ---
 
@@ -150,13 +158,13 @@ subtitleBlock.Layout();
 ```csharp
 foreach (var line in block.Lines)
 {
-    int  start    = line.Start;                // code-point index into original string
-    int  length   = line.Length;               // use text.Substring(start, length)
-    float top     = line.YCoord;
-    float baseline= line.YCoord + line.BaseLine;
-    float height  = line.Height;               // ascent + descent + leading
-    float width   = line.Width;                // excludes trailing whitespace
-    var  nextLine = line.NextLine;             // null on last line
+    int   start    = line.Start;                // code-point index into original string
+    int   length   = line.Length;               // use text.Substring(start, length)
+    float top      = line.YCoord;
+    float baseline = line.YCoord + line.BaseLine;
+    float height   = line.Height;               // ascent + descent + leading
+    float width    = line.Width;                // excludes trailing whitespace
+    var   nextLine = line.NextLine;             // null on last line
 }
 ```
 
@@ -214,13 +222,3 @@ Per-thread default: `StyleManager.Default`.
 | Custom font ignored by RTK line breaker | Set `block.FontMapper` before `AddText()` |
 | `Truncated` always false | `MaxHeight` or `MaxLines` must be set |
 | Style changes after adding to block | Styles are read at layout time — mutate before `AddText()`, or use `Style.Seal()` |
-| `CS0104: 'IStyle' is ambiguous` in `SkiaTextLayoutHelper.cs` | `Topten.RichTextKit.IStyle` clashes with `Mapsui.Styles.IStyle`. Never add `using Mapsui.Styles;` to this file. Use fully-qualified names (`Mapsui.Styles.Font`, `Mapsui.Styles.FontSource`) instead. |
-
----
-
-## Key files
-
-- [Mapsui.Experimental.Rendering.Skia/Extensions/SkiaTextLayoutHelper.cs](../../Mapsui.Experimental.Rendering.Skia/Extensions/SkiaTextLayoutHelper.cs) — RTK wrappers: `CreateTextBlock`, `PaintTextBlock`, `SplitByWordUnicode`, `MapsuiFontMapper`
-- [Mapsui.Experimental.Rendering.Skia/SkiaStyles/LabelStyleRenderer.cs](../../Mapsui.Experimental.Rendering.Skia/SkiaStyles/LabelStyleRenderer.cs) — label rendering
-- [Mapsui.Experimental.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs](../../Mapsui.Experimental.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs) — callout rendering (double-layout pattern)
-- [Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs](../../Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs) — standard renderer callout (raw RTK API)


### PR DESCRIPTION
## Summary

Adds three Copilot agent skills and cleans up the related instruction file.

### New skills

- **`.github/skills/done-checklist/SKILL.md`** — pre-PR checklist (build, unit tests, regression tests, style, docs, architecture review). Tracks state in a per-branch JSON file so nothing is skipped across sessions.
- **`.github/skills/regression-tests/SKILL.md`** — authoritative guide for running, interpreting, and updating rendering regression tests. Covers standard vs. experimental renderer, config file resolution order, `ExperimentalOnlySamples`, TTF vs. OTF pitfalls, `FetchAllFontDataAsync`, and the Arabic-passes-Chinese-fails false-signal trap.
- **`.github/skills/richtextkit/SKILL.md`** — full RichTextKit reference: `TextBlock`, `Style`, `FontMapper`, Mapsui usage patterns, performance notes, and common pitfalls.

### Updated

- **`.github/instructions/richtextkit.instructions.md`** — reduced from a 220-line duplicate to a 3-line pointer that preserves the `applyTo` frontmatter (auto-applies to `Mapsui.Rendering.Skia/**` and `Mapsui.Experimental.Rendering.Skia/**`) and directs Copilot to load the skill for the actual content. Single source of truth.
- **`.github/copilot-instructions.md`** — updated skills table and experimental renderer paragraph to reference the new skills.