### PR TITLE
Add Create Release Tag workflow and releasing docs

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,59 @@
+name: Create Release Tag
+
+# Creates a git tag on the selected branch. Use the "Use workflow from" branch
+# selector to choose which branch to tag (main for regular releases, a patch
+# branch for patch releases). After this succeeds, trigger "Release Nugets" and
+# then publish the GitHub Release manually.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to create (e.g. 6.2.0). Check https://github.com/Mapsui/Mapsui/releases for the latest tag.'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - name: Show latest existing tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          LATEST=$(git describe --tags --abbrev=0 2>/dev/null || echo "(no tags yet)")
+          echo "Latest existing tag : $LATEST"
+          echo "New tag to create   : $VERSION"
+          echo "Branch              : ${{ github.ref_name }}"
+
+      - name: Validate tag does not already exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git tag -l "$VERSION" | grep -q .; then
+            echo "Error: tag $VERSION already exists."
+            exit 1
+          fi
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Summary
+        env:
+          VERSION: ${{ inputs.version }}
+        run: echo "Tag $VERSION created on ${{ github.ref_name }}. Now trigger 'Release Nugets'."

--- a/docs/general/markdown/releasing.md
+++ b/docs/general/markdown/releasing.md
@@ -1,0 +1,58 @@
+# Releasing
+
+This page describes the release procedure for Mapsui maintainers.
+
+## Overview
+
+A release consists of three steps:
+
+1. **Create the version tag** — triggers the build and NuGet publish
+2. **Verify** — confirm the NuGet packages are live
+3. **Publish the GitHub Release** — notifies users and documents the changes
+
+Separating steps 1–2 from step 3 means users are only notified after NuGets are confirmed live. If the build fails, fix it and re-run before anyone is notified.
+
+---
+
+## Step 1 — Create the version tag
+
+Go to [Actions → Create Release Tag](https://github.com/Mapsui/Mapsui/actions/workflows/create-release-tag.yml).
+
+- Click **Run workflow**
+- Select the branch to release from (`main` for a regular release, a patch branch for a patch release)
+- Enter the version, e.g. `6.2.0`
+- Click **Run workflow**
+
+The workflow will validate that the tag does not already exist, then create and push it. The log prints the previous latest tag so you can sanity-check the version bump.
+
+---
+
+## Step 2 — Release NuGets
+
+Go to [Actions → Release Nugets](https://github.com/Mapsui/Mapsui/actions/workflows/dotnet-release-nugets.yml).
+
+- Click **Run workflow**
+- Select the **same branch** you used in step 1 (important for patch releases — if you select `main` it will pick up the wrong tag)
+- Check the **release to nuget.org** checkbox
+- Click **Run workflow**
+
+The workflow derives the version from the tag created in step 1. Wait for it to go green, then confirm the packages appear on [nuget.org](https://www.nuget.org/packages?q=Mapsui).
+
+---
+
+## Step 3 — Publish the GitHub Release
+
+Go to [Releases → Draft a new release](https://github.com/Mapsui/Mapsui/releases/new).
+
+- In **Choose a tag**, select the tag you created in step 1 (it already exists — do not create a new one)
+- Click **Generate release notes** to auto-generate notes from PR titles
+- Review and adjust the notes
+- Click **Publish release**
+
+Users watching the repository receive notifications at this point.
+
+---
+
+## Patch releases
+
+For a patch release, create a branch off the tag you want to patch (e.g. `release/6.1`), cherry-pick or backport the fix, then follow the same three steps selecting the patch branch in step 1.

--- a/docs/general/mkdocs.yml
+++ b/docs/general/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - 'rendering-tests.md'
     - 'documentation.md'
     - 'touch-and-mouse-handling.md'
+    - 'releasing.md'
 
 repo_url: https://github.com/Mapsui/Mapsui/
 edit_uri: blob/master/docs/general/markdown


### PR DESCRIPTION
## What

Adds a new `Create Release Tag` GitHub Actions workflow and a `releasing.md` documentation page.

## Why

The previous release process required a local machine to create and push a git tag before the NuGet publish workflow could run. This change makes it possible to do a full release from the browser (or a phone).

## New release flow

1. **Actions → Create Release Tag** — enter the version, select the branch, run. The workflow validates the tag doesn't already exist, then creates and pushes it.
2. **Actions → Release Nugets** — select the same branch, check "release to nuget.org", run. Wait for green.
3. **Releases → Draft a new release** — select the existing tag, generate release notes, publish. Users are notified only after NuGets are confirmed live.

## Changes

- `.github/workflows/create-release-tag.yml` — new workflow with `contents: write` permission; user input routed through env variables to prevent shell injection
- `docs/general/markdown/releasing.md` — new maintainer-facing doc describing the three-step process
- `docs/general/mkdocs.yml` — registers `releasing.md` under "Contributing to Mapsui"