### PR TITLE
Fix samples: regenerate code pages and fix GridLayerSample name

### DIFF
--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/BasicMapInfoSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/BasicMapInfoSample.html
@@ -47,7 +47,7 @@ public class BasicMapInfoSample : ISample, ISampleTest
         var map = new Map();
 
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(CreateInfoLayer(map.Extent));
+        map.Layers.Add(CreatePointLayer(map.Extent));
         map.Layers.Add(CreatePolygonLayer());
         map.Layers.Add(CreateLineLayer());
 
@@ -148,9 +148,9 @@ public class BasicMapInfoSample : ISample, ISampleTest
         ]);
     }
 
-    private static Layer CreateInfoLayer(MRect? envelope) => new(_infoLayerName)
+    private static MemoryLayer CreatePointLayer(MRect? envelope) => new(_infoLayerName)
     {
-        DataSource = RandomPointsBuilder.CreateProviderWithRandomPoints(envelope, 25, new Random(7)),
+        Features = RandomPointsBuilder.CreateRandomFeatures(envelope, 25, new Random(7)),
         Style = CreateSymbolStyle(),
     };
 

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/BigShapefilesSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/BigShapefilesSample.html
@@ -18,50 +18,85 @@
 <div class="code-container">
     <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
     <pre><code class="csharp">using Mapsui.Layers;
-using Mapsui.Rendering;
-using Mapsui.Rendering.Skia;
-using Mapsui.Samples.Common.DataBuilders;
+using Mapsui.Samples.Common.Utilities;
 using Mapsui.Styles;
 using Mapsui.Tiling;
-using SkiaSharp;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using Mapsui.Tiling.Layers;
+using System.IO;
 using System.Threading.Tasks;
 
-namespace Mapsui.Samples.Common.Maps.Styles;
+namespace Mapsui.Samples.Common.Maps.Performance;
 
-public class CustomPointStyleBasicSample : ISample
+public class BigShapefilesSample : ISample
 {
-    public string Name => $"Basic";
-    public string Category => $"{nameof(CustomPointStyle)}";
+    static BigShapefilesSample()
+    {
+        ShapeFilesDeployer.CopyEmbeddedResourceToFile("EZG_KB_LM.shp");
+        ShapeFilesDeployer.CopyEmbeddedResourceToFile("modell_ezgs_v02_ohneTalsperren_EPSG3857.shp");
+    }
 
-    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+    public string Name => "BigShapesfiles";
+    public string Category => "Performance";
 
-    public static Map CreateMap()
+    public async Task<Map> CreateMapAsync()
     {
         var map = new Map();
-        map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
-        {
-            Features = CreateFeatures(map.Extent!, 32).ToList(),
-            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
-        });
-        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
-        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
-        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
+
+        var tileLayer = OpenStreetMap.CreateTileLayer();
+        var shapeLayer1 = await CreateShapeLayerAsync("EZG_KB_LM.shp");
+        var shapeLayer2 = await CreateShapeLayerAsync("modell_ezgs_v02_ohneTalsperren_EPSG3857.shp");
+
+        map.Layers.Add(tileLayer);
+        map.Layers.Add(shapeLayer1);
+        map.Layers.Add(shapeLayer2);
+
         return map;
     }
 
-    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
+    private static async Task<ILayer[]> CreateShapeLayerAsync(string shapeName)
     {
-        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
-        canvas.DrawCircle(0f, 0f, 10f, paint);
+        var fileLocation = Path.Combine(ShapeFilesDeployer.ShapeFilesLocation, shapeName);
+        using var shapeFile = new Nts.Providers.Shapefile.ShapeFile(fileLocation, false)
+        {
+            CRS = "EPSG:3857"
+        };
+
+        using var blackLayer = new MemoryLayer
+        {
+            Name = shapeName,
+            Features = await shapeFile.GetFeaturesAsync(new FetchInfo(new MSection(shapeFile.GetExtent()!, 156543), "EPSG:3857", ChangeType.Discrete)),
+            Style = CreateBlackStyle(),
+        };
+
+        using var yellowLayer = new MemoryLayer
+        {
+            Name = shapeName,
+            Features = await shapeFile.GetFeaturesAsync(new FetchInfo(new MSection(shapeFile.GetExtent()!, 156543), "EPSG:3857", ChangeType.Discrete)),
+            Style = CreateYellowStyle(),
+        };
+
+        return [new RasterizingTileLayer(blackLayer), new RasterizingLayer(yellowLayer)];
     }
 
-    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
-        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
-            .Select(p => new PointFeature(p)).ToList();
+    private static VectorStyle CreateBlackStyle() => new()
+    {
+        Fill = null,
+        Outline = new Pen
+        {
+            Color = Color.Black,
+            Width = 3
+        }
+    };
+
+    private static VectorStyle CreateYellowStyle() => new()
+    {
+        Fill = null,
+        Outline = new Pen
+        {
+            Color = Color.DarkOrange,
+            Width = 1
+        }
+    };
 }
 </code></pre>
 </div>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CalloutWrapAroundSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CalloutWrapAroundSample.html
@@ -17,51 +17,95 @@
 <body>
 <div class="code-container">
     <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
-    <pre><code class="csharp">using Mapsui.Layers;
-using Mapsui.Rendering;
-using Mapsui.Rendering.Skia;
-using Mapsui.Samples.Common.DataBuilders;
-using Mapsui.Styles;
-using Mapsui.Tiling;
-using SkiaSharp;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+    <pre><code class="csharp">using System.Collections.Generic;
 using System.Threading.Tasks;
+using Mapsui.Layers;
+using Mapsui.Styles;
 
-namespace Mapsui.Samples.Common.Maps.Styles;
+namespace Mapsui.Samples.Common.Maps.Tests;
 
-public class CustomPointStyleBasicSample : ISample
+public class CalloutWrapAroundSample : ISample
 {
-    public string Name => $"Basic";
-    public string Category => $"{nameof(CustomPointStyle)}";
+    public string Name => "Callout with wrap around";
+    public string Category => "Tests";
 
     public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
 
     public static Map CreateMap()
     {
-        var map = new Map();
-        map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
+        var layer = CreateLayer();
+
+        var map = new Map
         {
-            Features = CreateFeatures(map.Extent!, 32).ToList(),
-            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
-        });
-        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
-        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
-        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
+            BackColor = Color.WhiteSmoke,
+        };
+
+        map.Navigator.ZoomToBox(layer.Extent!.Grow(layer.Extent.Width * 2));
+
+        map.Layers.Add(layer);
+
         return map;
     }
 
-    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
-    {
-        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
-        canvas.DrawCircle(0f, 0f, 10f, paint);
-    }
+    private static MemoryLayer CreateLayer() =>
+        new()
+        {
+            Features = CreateFeatures(),
+            Name = "Callouts",
+            Style = null
+        };
 
-    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
-        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
-            .Select(p => new PointFeature(p)).ToList();
+    private static IEnumerable<IFeature> CreateFeatures() =>
+        new List<IFeature>()
+        {
+            new PointFeature(new MPoint(-50, 50)) {
+                Styles = new List<IStyle>
+                {
+                    CreatePointStyle(),
+                    CreateCalloutStyle(
+                        "Word Wrap Demo",
+                        "This is a longer subtitle that should wrap around to multiple lines within the callout balloon")
+                }
+            },
+            new PointFeature(new MPoint(50, -50)) {
+                Styles = new List<IStyle>
+                {
+                    CreatePointStyle(),
+                    CreateCalloutStyle(
+                        "CJK and mixed text",
+                        "Hello ä½ å¥½ä¸–ç•Œ this mixes Latin and CJK characters for line breaking")
+                }
+            },
+        };
+
+    private static SymbolStyle CreatePointStyle() =>
+        new()
+        {
+            Fill = new Brush { Color = Color.Gray },
+            Outline = new Pen(Color.Black),
+        };
+
+    private static CalloutStyle CreateCalloutStyle(string title, string subtitle) =>
+        new()
+        {
+            Title = title,
+            TitleFont = { FontFamily = null, Size = 15, Italic = false, Bold = true },
+            TitleFontColor = Color.Black,
+
+            Subtitle = subtitle,
+            SubtitleFont = { FontFamily = null, Size = 12, Italic = false, Bold = true },
+            SubtitleFontColor = Color.Gray,
+
+            Type = CalloutType.Detail,
+            MaxWidth = 120,
+            Enabled = true,
+            Offset = new Offset(0, SymbolStyle.DefaultHeight * 1f),
+            BalloonDefinition = new CalloutBalloonDefinition
+            {
+                RectRadius = 10,
+                ShadowWidth = 4,
+            },
+        };
 }
 </code></pre>
 </div>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomCalloutStyleSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomCalloutStyleSample.html
@@ -32,7 +32,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using RTK = Topten.RichTextKit;
 
 namespace Mapsui.Samples.Common.Maps.MapInfo;
 
@@ -159,51 +158,40 @@ public class CustomCalloutStyleRenderer : ISkiaStyleRenderer
         // up to you when working with a custom callout style.
 
         var title = "title";
-        var titleFont = new Font { FontFamily = null, Size = 15, Italic = false, Bold = true };
-        var TitleFontColor = Color.Black;
+        var titleFontColor = Color.Black;
         var subtitle = "subtitle";
-        var subtitleFont = new Font { FontFamily = null, Size = 12, Italic = false, Bold = true };
         var subtitleFontColor = Color.Gray;
-        var maxWidth = 120;
 
-        var styleSubtitle = new RTK.Style();
-        var styleTitle = new RTK.Style();
-        var textBlockTitle = new RTK.TextBlock();
-        var textBlockSubtitle = new RTK.TextBlock();
+        using var titleTypeface = SKTypeface.FromFamilyName(null, SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
+        using var subtitleTypeface = SKTypeface.FromFamilyName(null, SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
 
-        styleSubtitle.FontFamily = subtitleFont.FontFamily;
-        styleSubtitle.FontSize = (float)subtitleFont.Size;
-        styleSubtitle.FontItalic = subtitleFont.Italic;
-        styleSubtitle.FontWeight = subtitleFont.Bold ? 700 : 400;
-        styleSubtitle.TextColor = subtitleFontColor.ToSkia();
+        using var titleSkFont = new SKFont { Typeface = titleTypeface, Size = 15 };
+        using var subtitleSkFont = new SKFont { Typeface = subtitleTypeface, Size = 12 };
 
-        textBlockSubtitle.AddText(subtitle, styleSubtitle);
+        using var titlePaint = new SKPaint { Color = titleFontColor.ToSkia(), IsAntialias = true };
+        using var subtitlePaint = new SKPaint { Color = subtitleFontColor.ToSkia(), IsAntialias = true };
 
-        styleTitle.FontFamily = titleFont.FontFamily;
-        styleTitle.FontSize = (float)titleFont.Size;
-        styleTitle.FontItalic = titleFont.Italic;
-        styleTitle.FontWeight = titleFont.Bold ? 700 : 400;
-        styleTitle.TextColor = TitleFontColor.ToSkia();
+        // Measure text
+        titleSkFont.MeasureText(title, out var titleBounds, titlePaint);
+        subtitleSkFont.MeasureText(subtitle, out var subtitleBounds, subtitlePaint);
 
-        textBlockTitle.AddText(title, styleTitle);
+        var titleWidth = titleBounds.Right - titleBounds.Left;
+        var subtitleWidth = subtitleBounds.Right - subtitleBounds.Left;
+        var subtitleHeight = subtitleBounds.Bottom - subtitleBounds.Top;
 
-        textBlockTitle.MaxWidth = textBlockSubtitle.MaxWidth = maxWidth;
-        // Layout TextBlocks
-        textBlockTitle.Layout();
-        textBlockSubtitle.Layout();
-        // Get sizes
-        var width = Math.Max(textBlockTitle.MeasuredWidth, textBlockSubtitle.MeasuredWidth);
-        var height = textBlockTitle.MeasuredHeight + textBlockSubtitle.MeasuredHeight;
-        // Now we have the correct width, so make a new layout cycle for text alignment
-        textBlockTitle.MaxWidth = textBlockSubtitle.MaxWidth = width;
-        textBlockTitle.Layout();
-        textBlockSubtitle.Layout();
-        // Create bitmap from TextBlock
+        // Use tight glyph height plus a small explicit gap for a compact but readable separation.
+        var titleLineHeight = (titleBounds.Bottom - titleBounds.Top) + titleSkFont.Size * 0.25f;
+
+        var width = Math.Max(titleWidth, subtitleWidth);
+        var height = titleLineHeight + subtitleHeight;
+
+        // Draw text to canvas
         using var recorder = new SKPictureRecorder();
         using var canvas = recorder.BeginRecording(new SKRect(0, 0, width, height));
-        // Draw text to canvas
-        textBlockTitle.Paint(canvas, new RTK.TextPaintOptions() { Edging = SKFontEdging.Antialias });
-        textBlockSubtitle.Paint(canvas, new SKPoint(0, textBlockTitle.MeasuredHeight), new RTK.TextPaintOptions() { Edging = SKFontEdging.Antialias });
+
+        canvas.DrawText(title, -titleBounds.Left, -titleBounds.Top, SKTextAlign.Left, titleSkFont, titlePaint);
+        canvas.DrawText(subtitle, -subtitleBounds.Left, titleLineHeight - subtitleBounds.Top, SKTextAlign.Left, subtitleSkFont, subtitlePaint);
+
         return recorder.EndRecording();
     }
 }

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomFontSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomFontSample.html
@@ -17,51 +17,96 @@
 <body>
 <div class="code-container">
     <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
-    <pre><code class="csharp">using Mapsui.Layers;
-using Mapsui.Rendering;
-using Mapsui.Rendering.Skia;
-using Mapsui.Samples.Common.DataBuilders;
-using Mapsui.Styles;
-using Mapsui.Tiling;
-using SkiaSharp;
-using System;
-using System.Collections.Generic;
+    <pre><code class="csharp">using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Mapsui.Layers;
+using Mapsui.Styles;
 
 namespace Mapsui.Samples.Common.Maps.Styles;
 
-public class CustomPointStyleBasicSample : ISample
+public class CustomFontSample : ISample
 {
-    public string Name => $"Basic";
-    public string Category => $"{nameof(CustomPointStyle)}";
+    public string Name => "Custom Font";
+    public string Category => "Styles";
+
+    // FontSource URI for the OpenSans-Regular font embedded in Mapsui.Samples.Common
+    public const string OpenSansSource = "embedded://Mapsui.Samples.Common.Resources.Fonts.OpenSans-Regular.ttf";
 
     public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
 
     public static Map CreateMap()
     {
-        var map = new Map();
-        map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
-        {
-            Features = CreateFeatures(map.Extent!, 32).ToList(),
-            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
-        });
-        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
-        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
-        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
+        var map = new Map { BackColor = Color.WhiteSmoke };
+        map.Layers.Add(CreateLayer());
+        map.Navigator.ZoomToBox(map.Layers.First().Extent!.Grow(map.Layers.First().Extent!.Width));
         return map;
     }
 
-    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
+    private static MemoryLayer CreateLayer() => new()
     {
-        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
-        canvas.DrawCircle(0f, 0f, 10f, paint);
-    }
+        Name = "Custom Font Labels",
+        Features = CreateFeatures(),
+        Style = null,
+    };
 
-    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
-        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
-            .Select(p => new PointFeature(p)).ToList();
+    private static IEnumerable<IFeature> CreateFeatures() =>
+    [
+        new PointFeature(new MPoint(-100, 50)) {
+            Styles =
+            [
+                new LabelStyle
+                {
+                    Text = "System font",
+                    Font = { Size = 18 },
+                    BackColor = new Brush(Color.White),
+                    ForeColor = Color.Black,
+                    HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+                }
+            ]
+        },
+        new PointFeature(new MPoint(100, 50)) {
+            Styles =
+            [
+                new LabelStyle
+                {
+                    Text = "Custom font",
+                    Font = { Size = 18, FontSource = OpenSansSource },
+                    BackColor = new Brush(Color.LightBlue),
+                    ForeColor = Color.Black,
+                    HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+                }
+            ]
+        },
+        new PointFeature(new MPoint(-100, -50)) {
+            Styles =
+            [
+                new LabelStyle
+                {
+                    Text = "Bold system font",
+                    Font = { Size = 18, Bold = true },
+                    BackColor = new Brush(Color.White),
+                    ForeColor = Color.Black,
+                    HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+                }
+            ]
+        },
+        new PointFeature(new MPoint(100, -50)) {
+            Styles =
+            [
+                new LabelStyle
+                {
+                    Text = "Custom font wrap around to show multiple long words",
+                    Font = { Size = 14, FontSource = OpenSansSource },
+                    BackColor = new Brush(Color.LightBlue),
+                    ForeColor = Color.Black,
+                    MaxWidth = 10,
+                    WordWrap = LabelStyle.LineBreakMode.WordWrap,
+                    HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+                }
+            ]
+        },
+    ];
 }
 </code></pre>
 </div>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomFontWidgetSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomFontWidgetSample.html
@@ -1,0 +1,191 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+        pre { margin: 0; }
+        .code-container { position: relative; }
+        .copy-button { position: absolute; top: 12px; right: 12px; background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 4px; padding: 6px 10px; font-size: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; cursor: pointer; color: #495057; transition: all 0.2s ease; z-index: 10; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .copy-button:hover { background: #e9ecef; border-color: #adb5bd; color: #212529; }
+        .copy-button.copied { background: #d4edda; border-color: #c3e6cb; color: #155724; }
+        .copy-button:active { transform: translateY(1px); }
+    </style>
+</head>
+<body>
+<div class="code-container">
+    <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
+    <pre><code class="csharp">using Mapsui.Extensions;
+using Mapsui.Layers;
+using Mapsui.Logging;
+using Mapsui.Styles;
+using Mapsui.Widgets;
+using Mapsui.Widgets.BoxWidgets;
+using Mapsui.Widgets.InfoWidgets;
+using Mapsui.Widgets.ScaleBar;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Mapsui.Samples.Common.Maps.Widgets;
+
+/// <summary>
+/// Demonstrates custom font loading via <see cref="Font.FontSource"/> on every widget renderer
+/// that was updated to support it: TextBoxWidget, LoggingWidget, PerformanceWidget,
+/// GridLayer coordinate labels, and ScaleBarWidget.
+/// </summary>
+public class CustomFontWidgetSample : ISample
+{
+    public string Name => "Custom Font Widgets";
+    public string Category => "Widgets";
+
+    // Noto Sans Arabic covers Arabic script and is licensed under OFL.
+    private const string NotoSansArabicSource = "embedded://Mapsui.Samples.Common.Resources.Fonts.NotoSansArabic-Regular.ttf";
+    // Noto Sans SC covers Simplified Chinese and is licensed under OFL.
+    private const string NotoSansSCSource = "embedded://Mapsui.Samples.Common.Resources.Fonts.NotoSansSC-Regular.ttf";
+
+    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+
+    public static Map CreateMap()
+    {
+        var map = new Map();
+
+        // GridLayer â€” coordinate labels rendered with custom font.
+        map.Layers.Add(new GridLayer
+        {
+            LabelFont = new Font { Size = 12, FontSource = NotoSansArabicSource },
+        });
+
+        map.Navigator.CenterOnAndZoomTo(new MPoint(0, 0), 2500);
+
+        // Arabic TextBoxWidget â€” demonstrates a custom font (NotoSansArabic) via FontSource.
+        map.Widgets.Add(new TextBoxWidget
+        {
+            Text = "Ù…Ø±Ø­Ø¨Ø§ Ø¨Ø§Ù„Ø¹Ø§Ù„Ù…",
+            Font = new Font { Size = 13, FontSource = NotoSansArabicSource },
+            VerticalAlignment = VerticalAlignment.Top,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Margin = new MRect(10),
+            Padding = new MRect(6),
+            CornerRadius = 4,
+            BackColor = new Color(60, 80, 120),
+            TextColor = Color.White,
+        });
+
+        // LoggingWidget â€” log output rendered with custom font.
+        var loggingWidget = new LoggingWidget(map.RefreshGraphics)
+        {
+            Font = new Font { Size = 11, FontSource = NotoSansArabicSource },
+            BackColor = Color.White,
+            Opacity = 0.9f,
+            VerticalAlignment = VerticalAlignment.Top,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Margin = new MRect(10),
+            Padding = new MRect(4),
+            Width = 320,
+            Height = 90,
+        };
+        map.Widgets.Add(loggingWidget);
+
+        // PerformanceWidget â€” fps readout rendered with custom font.
+        var performanceWidget = map.Widgets.OfType<PerformanceWidget>().First();
+        performanceWidget.Font = new Font { Size = 11, FontSource = NotoSansArabicSource };
+        performanceWidget.Performance.IsActive = ActiveMode.Yes;
+        performanceWidget.BackColor = new Color(40, 40, 40);
+        performanceWidget.TextColor = Color.White;
+        performanceWidget.Opacity = 1;
+
+        // Chinese TextBoxWidget â€” bottom-left; uses embedded NotoSansSC for CJK.
+        map.Widgets.Add(new TextBoxWidget
+        {
+            Text = "æ¬¢è¿Žä½¿ç”¨ Mapsui",
+            Font = new Font { Size = 13, FontSource = NotoSansSCSource },
+            VerticalAlignment = VerticalAlignment.Bottom,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Margin = new MRect(10),
+            Padding = new MRect(6),
+            CornerRadius = 4,
+            BackColor = new Color(80, 60, 120),
+            TextColor = Color.White,
+        });
+
+        // ScaleBarWidget â€” tick labels rendered with custom font, centered at the bottom.
+        map.Widgets.Add(new ScaleBarWidget(map)
+        {
+            Font = new Font { Size = 11, FontSource = NotoSansArabicSource },
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Bottom,
+            Margin = new MRect(10),
+        });
+
+        Logger.Log(LogLevel.Information, "CustomFontWidgetSample loaded â€“ all widgets use NotoSansArabic via FontSource", null);
+
+        return map;
+    }
+}
+
+</code></pre>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/csharp.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        hljs.highlightAll();
+        if (window.parent && window.parent !== window) {
+            window.parent.postMessage('highlightjs-highlight', '*');
+        }
+    });
+    function copyCode(button) {
+        try {
+            const codeElement = button.parentElement.querySelector('code');
+            const codeText = codeElement.textContent || codeElement.innerText;
+            if (navigator.clipboard && window.isSecureContext) {
+                navigator.clipboard.writeText(codeText).then(() => {
+                    showCopySuccess(button);
+                }).catch(() => {
+                    fallbackCopy(codeText, button);
+                });
+            } else {
+                fallbackCopy(codeText, button);
+            }
+        } catch (error) {
+            console.error('Copy failed:', error);
+            showCopyError(button);
+        }
+    }
+    function fallbackCopy(text, button) {
+        try {
+            const textArea = document.createElement('textarea');
+            textArea.value = text;
+            textArea.style.position = 'fixed';
+            textArea.style.opacity = '0';
+            document.body.appendChild(textArea);
+            textArea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textArea);
+            showCopySuccess(button);
+        } catch (error) {
+            showCopyError(button);
+        }
+    }
+    function showCopySuccess(button) {
+        const originalText = button.textContent;
+        button.textContent = 'Copied!';
+        button.classList.add('copied');
+        setTimeout(() => {
+            button.textContent = originalText;
+            button.classList.remove('copied');
+        }, 2000);
+    }
+    function showCopyError(button) {
+        const originalText = button.textContent;
+        button.textContent = 'Failed';
+        setTimeout(() => {
+            button.textContent = originalText;
+        }, 2000);
+    }
+</script>
+</body>
+</html>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomLayerRendererSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomLayerRendererSample.html
@@ -46,6 +46,8 @@ public class CustomLayerRendererSample : ISample
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
         map.Layers.Add(CreatePointLayer(map));
         MapRenderer.RegisterLayerRenderer("custom-layer-renderer", CustomLayerRenderer);
+        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
+        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterLayerRenderer("custom-layer-renderer", CustomLayerRenderer);
         map.Widgets.Add(new MapInfoWidget(map, map.Layers.OfType<MemoryLayer>));
         return map;
     }

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomPointStyleAdvancedSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomPointStyleAdvancedSample.html
@@ -64,6 +64,8 @@ public class CustomPointStyleAdvancedSample : ISample
         map.Widgets.Add(new MapInfoWidget(map, [map.Layers.Last()]));
 
         MapRenderer.RegisterPointStyleRenderer("custom-style-advanced", MyCustomStyleRenderer);
+        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
+        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-advanced", MyCustomStyleRenderer);
 
         return map;
     }

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomStyleSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/CustomStyleSample.html
@@ -47,6 +47,8 @@ public class CustomStyleSample : ISample
         // This is the crucial part where we tell the renderer that a CustomStyle should be
         // rendered with the SkiaCustomStyleRenderer
         MapRenderer.RegisterStyleRenderer(typeof(CustomStyle), new SkiaCustomStyleRenderer());
+        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
+        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterStyleRenderer(typeof(CustomStyle), new SkiaCustomStyleRenderer());
 
         var map = new Map();
 

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/EmojiSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/EmojiSample.html
@@ -17,51 +17,98 @@
 <body>
 <div class="code-container">
     <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
-    <pre><code class="csharp">using Mapsui.Layers;
-using Mapsui.Rendering;
-using Mapsui.Rendering.Skia;
-using Mapsui.Samples.Common.DataBuilders;
-using Mapsui.Styles;
-using Mapsui.Tiling;
-using SkiaSharp;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+    <pre><code class="csharp">using System.Collections.Generic;
 using System.Threading.Tasks;
+using Mapsui.Layers;
+using Mapsui.Styles;
 
-namespace Mapsui.Samples.Common.Maps.Styles;
+namespace Mapsui.Samples.Common.Maps.Tests;
 
-public class CustomPointStyleBasicSample : ISample
+public class EmojiSample : ISample
 {
-    public string Name => $"Basic";
-    public string Category => $"{nameof(CustomPointStyle)}";
+    public string Name => "Emoji";
+
+    public string Category => "Tests";
 
     public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
 
     public static Map CreateMap()
     {
-        var map = new Map();
-        map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
+        var layer = CreateLayer();
+
+        var map = new Map
         {
-            Features = CreateFeatures(map.Extent!, 32).ToList(),
-            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
-        });
-        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
-        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
-        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
+            BackColor = Color.WhiteSmoke,
+        };
+
+        map.Navigator.ZoomToBox(layer.Extent!.Grow(layer.Extent.Width * 2));
+        map.Layers.Add(layer);
+
         return map;
     }
 
-    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
-    {
-        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
-        canvas.DrawCircle(0f, 0f, 10f, paint);
-    }
+    private static MemoryLayer CreateLayer() =>
+        new()
+        {
+            Features = CreateFeatures(),
+            Name = "Emoji Text",
+            Style = null
+        };
 
-    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
-        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
-            .Select(p => new PointFeature(p)).ToList();
+    private static IEnumerable<IFeature> CreateFeatures() =>
+        new List<IFeature>
+        {
+            // Label with emoji using the system (default) font â€” no FontSource.
+            // This tests whether the renderer falls back to the emoji font for
+            // glyphs not found in the primary typeface.
+            new PointFeature(new MPoint(-50, 50))
+            {
+                Styles = new List<IStyle>
+                {
+                    new LabelStyle
+                    {
+                        Text = "Hello ðŸŒ World ðŸŽ‰",
+                        Font = { Size = 18 },
+                        BackColor = new Brush(Color.White),
+                        ForeColor = Color.Black,
+                        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+                    }
+                }
+            },
+            // Callout with emoji in title and subtitle, also using the system font.
+            new PointFeature(new MPoint(50, -50))
+            {
+                Styles = new List<IStyle>
+                {
+                    CreatePointStyle(),
+                    new CalloutStyle
+                    {
+                        Title = "Hello ðŸŒ World",
+                        TitleFont = { Size = 15 },
+                        TitleFontColor = Color.Black,
+                        Subtitle = "Party ðŸŽ‰ and Stars â­",
+                        SubtitleFont = { Size = 12 },
+                        SubtitleFontColor = Color.Gray,
+                        Type = CalloutType.Detail,
+                        MaxWidth = 200,
+                        Enabled = true,
+                        Offset = new Offset(0, SymbolStyle.DefaultHeight * 1f),
+                        BalloonDefinition = new CalloutBalloonDefinition
+                        {
+                            RectRadius = 10,
+                            ShadowWidth = 4,
+                        },
+                    }
+                }
+            },
+        };
+
+    private static SymbolStyle CreatePointStyle() =>
+        new()
+        {
+            Fill = new Brush { Color = Color.Gray },
+            Outline = new Pen(Color.Black),
+        };
 }
 </code></pre>
 </div>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/GpsTrackSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/GpsTrackSample.html
@@ -1,0 +1,393 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+        pre { margin: 0; }
+        .code-container { position: relative; }
+        .copy-button { position: absolute; top: 12px; right: 12px; background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 4px; padding: 6px 10px; font-size: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; cursor: pointer; color: #495057; transition: all 0.2s ease; z-index: 10; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .copy-button:hover { background: #e9ecef; border-color: #adb5bd; color: #212529; }
+        .copy-button.copied { background: #d4edda; border-color: #c3e6cb; color: #155724; }
+        .copy-button:active { transform: translateY(1px); }
+    </style>
+</head>
+<body>
+<div class="code-container">
+    <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
+    <pre><code class="csharp">using Mapsui.Animations;
+using Mapsui.Extensions;
+using Mapsui.Layers;
+using Mapsui.Layers.AnimatedLayers;
+using Mapsui.Projections;
+using Mapsui.Providers;
+using Mapsui.Styles;
+using Mapsui.Styles.Thematics;
+using Mapsui.Tiling;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mapsui.Samples.Common.Maps.FeatureAnimations;
+
+public class GpsTrackSample : ISample
+{
+    public string Name => "GPS Track";
+    public string Category => "FeatureAnimations";
+
+    public Task<Map> CreateMapAsync()
+    {
+        // How this sample works:
+        //
+        //   GpsSimulatorProvider  â€” reads a recorded GPS track from a CSV file and replays it
+        //                           one position per second, acting as a stand-in for a real
+        //                           GPS device.  It implements IProvider so any layer can use it.
+        //
+        //   AnimatingProvider     â€” wraps any IProvider and upgrades its point features into
+        //                           AnimatedPointFeature instances.  Each second the underlying
+        //                           provider returns a new position; AnimatingProvider smoothly
+        //                           interpolates the feature between the old and new location.
+        //
+        //   Layer                 â€” a standard layer.  Because its cache contains IAnimatedFeature
+        //                           instances, Layer.UpdateAnimations() automatically drives the
+        //                           per-frame interpolation without any specialised layer type.
+
+        var simulator = new GpsSimulatorProvider();
+        var animatingProvider = new AnimatingProvider(simulator, animationDuration: 1000);
+
+        var map = new Map();
+        map.Layers.Add(OpenStreetMap.CreateTileLayer("GpsTrackSampleUserAgent"));
+        map.Layers.Add(new Layer("GPS Track")
+        {
+            DataSource = animatingProvider,
+            Style = new ThemeStyle(f => new ImageStyle
+            {
+                Image = "embedded://Mapsui.Samples.Common.Images.arrow.svg",
+                SymbolScale = 0.5,
+                SymbolRotation = (double)(f["heading"] ?? 0.0) + 180 // The arrow SVG points down; add 180Â° to make it point in the direction of travel
+            })
+        });
+
+        map.CRS = "EPSG:3857";
+        map.Navigator.CenterOnAndZoomTo(simulator.StartPosition, map.Navigator.Resolutions[19]);
+
+        // Smoothly trail the vehicle with a 5-second linear pan so the map never jumps.
+        simulator.PositionChanged += (_, pos) => map.Navigator.CenterOn(pos, 5000, Easing.Linear);
+
+        return Task.FromResult(map);
+    }
+
+    /// <summary>
+    /// Wraps any <see cref="IProvider"/> and promotes its point features into
+    /// <see cref="AnimatedPointFeature"/> instances so they smoothly interpolate
+    /// between position updates.
+    /// <para>
+    /// Each time the inner provider returns a new position for a feature (matched
+    /// by <see cref="Matches"/>), the corresponding <see cref="AnimatedPointFeature"/>
+    /// is given the new location as its animation target.  The <see cref="Layer"/>
+    /// then drives the per-frame interpolation automatically because it detects
+    /// <see cref="IAnimatedFeature"/> instances in its cache.
+    /// </para>
+    /// </summary>
+    internal class AnimatingProvider : IDynamicProvider, IDisposable
+    {
+        private readonly IProvider _innerProvider;
+        private readonly int _animationDuration;
+        private readonly Easing _easing;
+        private readonly double _distanceThreshold;
+        private readonly List<AnimatedPointFeature> _features = [];
+
+        public event EventHandler? DataChanged;
+
+        public AnimatingProvider(IProvider innerProvider, int animationDuration = 1000, Easing? easing = null,
+            double distanceThreshold = double.MaxValue)
+        {
+            _innerProvider = innerProvider;
+            _animationDuration = animationDuration;
+            _easing = easing ?? Easing.CubicOut;
+            _distanceThreshold = distanceThreshold;
+            if (innerProvider is IDynamic dynamic)
+                dynamic.DataChanged += OnInnerProviderDataChanged;
+        }
+
+        private void OnInnerProviderDataChanged(object? sender, EventArgs e)
+            => DataChanged?.Invoke(this, e);
+
+        void IDynamic.DataHasChanged() => DataChanged?.Invoke(this, EventArgs.Empty);
+
+        public string? CRS { get => _innerProvider.CRS; set => _innerProvider.CRS = value; }
+
+        public MRect? GetExtent() => _innerProvider.GetExtent();
+
+        /// <summary>
+        /// Returns true when <paramref name="existing"/> and <paramref name="incoming"/> represent
+        /// the same entity and the existing animated feature should be updated with the new position.
+        /// The default implementation compares the "ID" field. Override to use a different key.
+        /// </summary>
+        protected virtual bool Matches(IFeature existing, IFeature incoming)
+            => existing["ID"] is { } id && id.Equals(incoming["ID"]);
+
+        public async Task<IEnumerable<IFeature>> GetFeaturesAsync(FetchInfo fetchInfo)
+        {
+            var incoming = await _innerProvider.GetFeaturesAsync(fetchInfo);
+            foreach (var feature in incoming.OfType<PointFeature>())
+            {
+                var existing = _features.FirstOrDefault(f => Matches(f, feature));
+                if (existing is null)
+                {
+                    var animated = new AnimatedPointFeature(feature.Point.X, feature.Point.Y,
+                        _animationDuration, _easing, _distanceThreshold);
+                    CopyFieldsAndStyles(feature, animated);
+                    _features.Add(animated);
+                }
+                else
+                {
+                    existing.SetAnimationTarget(feature.Point);
+                    CopyFieldsAndStyles(feature, existing);
+                }
+            }
+            return _features;
+        }
+
+        private static void CopyFieldsAndStyles(PointFeature source, AnimatedPointFeature target)
+        {
+            foreach (var field in source.Fields)
+                target[field] = source[field];
+            target.Styles = source.Styles.ToList();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_innerProvider is IDynamic dynamic)
+                    dynamic.DataChanged -= OnInnerProviderDataChanged;
+                if (_innerProvider is IDisposable disposable)
+                    disposable.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Simulates a GPS device by replaying a pre-recorded track from a CSV file.
+    /// Every second it advances to the next position that is at least
+    /// <see cref="MinMetresPerStep"/> metres away, mimicking realistic movement speed.
+    /// <para>
+    /// Implements <see cref="IProvider"/> so it can be used as a data source for any
+    /// layer or wrapped by <see cref="AnimatingProvider"/> to add smooth animation.
+    /// Fires <see cref="IDynamic.DataChanged"/> each tick so the layer knows to
+    /// re-fetch, and fires <see cref="PositionChanged"/> so the map can follow the vehicle.
+    /// </para>
+    /// </summary>
+    internal sealed class GpsSimulatorProvider : IDynamicProvider, IDisposable
+    {
+        public event EventHandler? DataChanged;
+        public event EventHandler<MPoint>? PositionChanged;
+
+        private readonly PeriodicTimer _timer = new(TimeSpan.FromSeconds(1));
+        private readonly List<(double Lon, double Lat, double Heading)> _track;
+        private int _currentIndex = 500;
+
+        public string? CRS { get; set; }
+
+        /// <summary>Returns the starting map position (used to initialise the viewport).</summary>
+        public MPoint StartPosition
+        {
+            get
+            {
+                var (lon, lat, _) = _track[_currentIndex];
+                return SphericalMercator.FromLonLat(lon, lat).ToMPoint();
+            }
+        }
+
+        public GpsSimulatorProvider()
+        {
+            _track = LoadTrack();
+            Catch.TaskRun(RunTimerAsync);
+        }
+
+        /// <summary>
+        /// Not used â€” the simulator always returns the single current position regardless
+        /// of the requested extent, so no meaningful bounding box is available.
+        /// </summary>
+        public MRect? GetExtent() => null;
+
+        private static List<(double Lon, double Lat, double Heading)> LoadTrack()
+        {
+            using var stream = typeof(GpsSimulatorProvider).Assembly
+                .GetManifestResourceStream("Mapsui.Samples.Common.GeoData.GpsTracks.gps_luckydaxiang.csv")
+                ?? throw new InvalidOperationException("GPS track resource not found");
+            using var reader = new StreamReader(stream);
+
+            var result = new List<(double Lon, double Lat, double Heading)>();
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (!TryParseLine(line, out var entry)) continue;
+                // Skip consecutive duplicate positions so every emitted point represents real movement
+                if (result.Count > 0)
+                {
+                    var prev = result[^1];
+                    if (Math.Abs(entry.Lon - prev.Lon) < 1e-6 && Math.Abs(entry.Lat - prev.Lat) < 1e-6)
+                        continue;
+                }
+                result.Add(entry);
+            }
+            return result;
+        }
+
+        private static bool TryParseLine(string line, out (double Lon, double Lat, double Heading) entry)
+        {
+            entry = default;
+            var parts = line.Split(',');
+            if (parts.Length < 4) return false;
+            if (!TryParseDm(parts[0], out var lon) || !TryParseDm(parts[1], out var lat)) return false;
+            if (!double.TryParse(parts[3].Trim(), System.Globalization.NumberStyles.Any,
+                    System.Globalization.CultureInfo.InvariantCulture, out var heading)) return false;
+            entry = (lon, lat, heading);
+            return true;
+        }
+
+        private static bool TryParseDm(string value, out double degrees)
+        {
+            // Parses degrees-minutes format: "112Â°20.4314340â€² E"
+            degrees = 0;
+            var s = value.Trim();
+            var degIdx = s.IndexOf('Â°');
+            if (degIdx < 0) return false;
+            if (!int.TryParse(s[..degIdx].Trim(), out var d)) return false;
+            var afterDeg = s[(degIdx + 1)..].Trim();
+            var minEnd = 0;
+            while (minEnd < afterDeg.Length && (char.IsDigit(afterDeg[minEnd]) || afterDeg[minEnd] == '.'))
+                minEnd++;
+            if (!double.TryParse(afterDeg[..minEnd], System.Globalization.CultureInfo.InvariantCulture, out var m)) return false;
+            degrees = d + m / 60.0;
+            if (s.Contains('W') || s.Contains('S')) degrees = -degrees;
+            return true;
+        }
+
+        // Advance at least this many metres per timer tick so the vehicle appears to move
+        // at a realistic speed. Corresponds roughly to 1 second of travel at ~15 km/h.
+        private const double MinMetresPerStep = 5.0;
+
+        private async Task RunTimerAsync()
+        {
+            while (await _timer.WaitForNextTickAsync())
+            {
+                AdvanceOneStep();
+                var (lon, lat, _) = _track[_currentIndex];
+                var pos = SphericalMercator.FromLonLat(lon, lat).ToMPoint();
+                DataChanged?.Invoke(this, EventArgs.Empty);
+                PositionChanged?.Invoke(this, pos);
+            }
+        }
+
+        void IDynamic.DataHasChanged() => DataChanged?.Invoke(this, EventArgs.Empty);
+
+        private void AdvanceOneStep()
+        {
+            var (startLon, startLat, _) = _track[_currentIndex];
+            var start = SphericalMercator.FromLonLat(startLon, startLat).ToMPoint();
+            var startIndex = _currentIndex;
+            do
+            {
+                _currentIndex = (_currentIndex + 1) % _track.Count;
+                var (lon, lat, _) = _track[_currentIndex];
+                var current = SphericalMercator.FromLonLat(lon, lat).ToMPoint();
+                if (start.Distance(current) >= MinMetresPerStep) return;
+            } while (_currentIndex != startIndex); // safety: full loop = no point far enough
+        }
+
+        /// <summary>
+        /// Returns the vehicle's current position as a single <see cref="PointFeature"/>.
+        /// The "ID" field lets <see cref="AnimatingProvider"/> match this feature to the
+        /// same animated feature on the next update.  The "heading" field is read by the
+        /// layer's <see cref="Mapsui.Styles.Thematics.ThemeStyle"/> to rotate the arrow symbol.
+        /// </summary>
+        public Task<IEnumerable<IFeature>> GetFeaturesAsync(FetchInfo fetchInfo)
+        {
+            var (lon, lat, heading) = _track[_currentIndex];
+            var feature = new PointFeature(SphericalMercator.FromLonLat(lon, lat).ToMPoint());
+            feature["ID"] = "gps";
+            feature["heading"] = heading;
+            return Task.FromResult<IEnumerable<IFeature>>([feature]);
+        }
+
+        public void Dispose() => _timer.Dispose();
+    }
+}
+</code></pre>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/csharp.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        hljs.highlightAll();
+        if (window.parent && window.parent !== window) {
+            window.parent.postMessage('highlightjs-highlight', '*');
+        }
+    });
+    function copyCode(button) {
+        try {
+            const codeElement = button.parentElement.querySelector('code');
+            const codeText = codeElement.textContent || codeElement.innerText;
+            if (navigator.clipboard && window.isSecureContext) {
+                navigator.clipboard.writeText(codeText).then(() => {
+                    showCopySuccess(button);
+                }).catch(() => {
+                    fallbackCopy(codeText, button);
+                });
+            } else {
+                fallbackCopy(codeText, button);
+            }
+        } catch (error) {
+            console.error('Copy failed:', error);
+            showCopyError(button);
+        }
+    }
+    function fallbackCopy(text, button) {
+        try {
+            const textArea = document.createElement('textarea');
+            textArea.value = text;
+            textArea.style.position = 'fixed';
+            textArea.style.opacity = '0';
+            document.body.appendChild(textArea);
+            textArea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textArea);
+            showCopySuccess(button);
+        } catch (error) {
+            showCopyError(button);
+        }
+    }
+    function showCopySuccess(button) {
+        const originalText = button.textContent;
+        button.textContent = 'Copied!';
+        button.classList.add('copied');
+        setTimeout(() => {
+            button.textContent = originalText;
+            button.classList.remove('copied');
+        }, 2000);
+    }
+    function showCopyError(button) {
+        const originalText = button.textContent;
+        button.textContent = 'Failed';
+        setTimeout(() => {
+            button.textContent = originalText;
+        }, 2000);
+    }
+</script>
+</body>
+</html>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/GridLayerSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/GridLayerSample.html
@@ -18,50 +18,43 @@
 <div class="code-container">
     <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
     <pre><code class="csharp">using Mapsui.Layers;
-using Mapsui.Rendering;
-using Mapsui.Rendering.Skia;
-using Mapsui.Samples.Common.DataBuilders;
 using Mapsui.Styles;
-using Mapsui.Tiling;
-using SkiaSharp;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
-namespace Mapsui.Samples.Common.Maps.Styles;
+namespace Mapsui.Samples.Common.Maps.Special;
 
-public class CustomPointStyleBasicSample : ISample
+public class GridLayerSample : ISample
 {
-    public string Name => $"Basic";
-    public string Category => $"{nameof(CustomPointStyle)}";
+    public string Name => "GridLayer";
+    public string Category => "Special";
 
     public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
 
     public static Map CreateMap()
     {
         var map = new Map();
-        map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
-        {
-            Features = CreateFeatures(map.Extent!, 32).ToList(),
-            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
-        });
-        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
-        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
-        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
+        map.Layers.Add(new GridLayer { ShowCoordinateLabels = true });
+        map.Layers.Add(CreatePointLayer());
         return map;
     }
 
-    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
+    private static MemoryLayer CreatePointLayer()
     {
-        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
-        canvas.DrawCircle(0f, 0f, 10f, paint);
-    }
+        var random = new Random(42);
+        var features = new List<IFeature>();
+        for (var i = 0; i < 20; i++)
+            features.Add(new PointFeature(new MPoint(
+                (random.NextDouble() - 0.5) * 20_000_000,
+                (random.NextDouble() - 0.5) * 15_000_000)));
 
-    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
-        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
-            .Select(p => new PointFeature(p)).ToList();
+        return new MemoryLayer("Points")
+        {
+            Features = features,
+            Style = new SymbolStyle(),
+        };
+    }
 }
 </code></pre>
 </div>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/PartialRefreshWidgetSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/PartialRefreshWidgetSample.html
@@ -1,0 +1,235 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+        pre { margin: 0; }
+        .code-container { position: relative; }
+        .copy-button { position: absolute; top: 12px; right: 12px; background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 4px; padding: 6px 10px; font-size: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; cursor: pointer; color: #495057; transition: all 0.2s ease; z-index: 10; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .copy-button:hover { background: #e9ecef; border-color: #adb5bd; color: #212529; }
+        .copy-button.copied { background: #d4edda; border-color: #c3e6cb; color: #155724; }
+        .copy-button:active { transform: translateY(1px); }
+    </style>
+</head>
+<body>
+<div class="code-container">
+    <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
+    <pre><code class="csharp">using Mapsui.Experimental.Rendering.Skia;
+using Mapsui.Extensions;
+using Mapsui.Rendering;
+using Mapsui.Styles;
+using Mapsui.Tiling;
+using Mapsui.Widgets;
+using Mapsui.Widgets.BoxWidgets;
+using Mapsui.Widgets.ButtonWidgets;
+using SkiaSharp;
+using System;
+using System.Threading.Tasks;
+
+namespace Mapsui.Samples.Common.Maps.Special;
+
+// This sample demonstrates partial viewport refresh: instead of redrawing the entire map,
+// only a specified rectangle is redrawn. The random-colour full-screen overlay makes it easy
+// to see exactly which area was repainted on each button tap.
+//
+// Two coordinate spaces are shown:
+//   - World (EPSG:3857 metres): the dirty rect is expressed in geographic coordinates.
+//     Use this when refreshing spatial features whose position changes in the real world,
+//     such as a moving GPS marker or a live vehicle track. Panning the map away from the
+//     feature's location means the refresh has no visible effect â€” which is correct.
+//   - Screen (device-independent pixels): the dirty rect is expressed relative to the
+//     top-left corner of the rendered surface. Use this for fixed-position UI elements
+//     such as widgets, overlays, or attribution labels that always occupy the same spot
+//     regardless of where the map is panned or zoomed.
+public sealed class PartialRefreshWidgetSample : ISample
+{
+    public string Name => "PartialRefreshWidget";
+    public string Category => "Special";
+
+    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+
+    public static Map CreateMap()
+    {
+        Mapsui.Rendering.Skia.MapRenderer.RegisterWidgetRenderer(typeof(FullScreenColorWidget), new FullScreenColorWidgetRenderer());
+        MapRenderer.RegisterWidgetRenderer(typeof(FullScreenColorWidget), new FullScreenColorWidgetExperimentalRenderer());
+
+        var map = new Map { CRS = "EPSG:3857" };
+        map.Layers.Add(OpenStreetMap.CreateTileLayer());
+        map.Widgets.Add(new FullScreenColorWidget());
+        map.Widgets.Add(CreateInstructionTextBox());
+        map.Widgets.Add(CreateWorldSpaceRefreshButton());
+        map.Widgets.Add(CreateScreenSpaceRefreshButton());
+        return map;
+    }
+
+    // World-space refresh: the dirty rect is a fixed geographic extent in EPSG:3857 metres.
+    // Only tiles and features that intersect this rectangle are redrawn. If you pan the
+    // viewport outside this area the button has no visible effect, illustrating that the
+    // refresh is tied to geography, not to the screen. This is the right choice for
+    // features that move through the world, e.g. a live GPS position update.
+    private static ButtonWidget CreateWorldSpaceRefreshButton() => new()
+    {
+        Text = "Refresh World Area (World coords)",
+        VerticalAlignment = VerticalAlignment.Bottom,
+        HorizontalAlignment = HorizontalAlignment.Left,
+        CornerRadius = 3,
+        BackColor = new Color(0, 123, 255),
+        TextColor = Color.White,
+        Margin = new MRect(10, 50, 10, 50),
+        Padding = new MRect(8),
+        TextSize = 16,
+        WithTappedEvent = (s, e) =>
+        {
+            // Fixed world-space extent â€” pan away from this area and the button has no effect.
+            var dirtyRect = new MRect(-1_000_000, -1_000_000, 1_000_000, 1_000_000);
+            e.Map.RefreshGraphics(dirtyRect); // CoordinateSpace.World is the default
+            e.Handled = true;
+        }
+    };
+
+    // Screen-space refresh: the dirty rect is expressed in device-independent pixels
+    // relative to the top-left of the rendered surface. The refreshed region stays at
+    // exactly the same spot on screen regardless of how the map is panned or zoomed.
+    // This is the right choice for widgets and overlays â€” e.g. a GPS accuracy badge or
+    // an attribution label â€” whose screen position never changes.
+    private static ButtonWidget CreateScreenSpaceRefreshButton() => new()
+    {
+        Text = "Refresh Bottom-Center (Screen)",
+        VerticalAlignment = VerticalAlignment.Bottom,
+        HorizontalAlignment = HorizontalAlignment.Left,
+        CornerRadius = 3,
+        BackColor = new Color(40, 167, 69),
+        TextColor = Color.White,
+        Margin = new MRect(10),
+        Padding = new MRect(8),
+        TextSize = 16,
+        WithTappedEvent = (s, e) =>
+        {
+            // A fixed pixel rectangle covering the bottom-centre of the screen â€” exactly
+            // where a typical overlay widget (e.g. an attribution bar) would live.
+            var w = e.Map.Navigator.Viewport.Width;
+            var h = e.Map.Navigator.Viewport.Height;
+            var dirtyRect = new MRect(w / 2 - 100, h - 60, w / 2 + 100, h);
+            e.Map.RefreshGraphics(dirtyRect, CoordinateSpace.Screen);
+            e.Handled = true;
+        }
+    };
+
+    private static TextBoxWidget CreateInstructionTextBox() => new()
+    {
+        Text = "Partial viewport refresh in world and screen coordinate space using a random color overlay.",
+        TextSize = 16,
+        VerticalAlignment = VerticalAlignment.Top,
+        HorizontalAlignment = HorizontalAlignment.Center,
+        Margin = new MRect(10),
+        Padding = new MRect(8),
+        CornerRadius = 3,
+        BackColor = new Color(108, 117, 125, 128),
+        TextColor = Color.White,
+    };
+
+
+}
+
+internal sealed class FullScreenColorWidget : BaseWidget { }
+
+internal sealed class FullScreenColorWidgetRenderer : Mapsui.Rendering.Skia.SkiaWidgets.ISkiaWidgetRenderer
+{
+    private static readonly Random _random = new();
+
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity)
+    {
+        widget.Envelope = new MRect(0, 0, viewport.Width, viewport.Height);
+        // A new random colour on every draw call â€” this is intentional: it makes each
+        // render cycle visually distinct, which clearly demonstrates when a partial vs
+        // full repaint occurs.
+        var alpha = (byte)Math.Clamp((int)Math.Round(80 * layerOpacity), 0, 255);
+        var color = new SKColor((byte)_random.Next(256), (byte)_random.Next(256), (byte)_random.Next(256), alpha);
+        using var paint = new SKPaint { Color = color };
+        canvas.DrawRect(new SKRect(0, 0, (float)viewport.Width, (float)viewport.Height), paint);
+    }
+}
+
+internal sealed class FullScreenColorWidgetExperimentalRenderer : Mapsui.Experimental.Rendering.Skia.SkiaWidgets.ISkiaWidgetRenderer
+{
+    private static readonly Random _random = new();
+
+    public void Draw(SKCanvas canvas, Viewport viewport, IWidget widget, RenderService renderService, float layerOpacity, SKRect? dirtyScreenRect)
+    {
+        widget.Envelope = new MRect(0, 0, viewport.Width, viewport.Height);
+        // A new random colour on every draw call â€” this is intentional: it makes each
+        // render cycle visually distinct, which clearly demonstrates when a partial vs
+        // full repaint occurs.
+        var alpha = (byte)Math.Clamp((int)Math.Round(80 * layerOpacity), 0, 255);
+        var color = new SKColor((byte)_random.Next(256), (byte)_random.Next(256), (byte)_random.Next(256), alpha);
+        using var paint = new SKPaint { Color = color };
+        canvas.DrawRect(new SKRect(0, 0, (float)viewport.Width, (float)viewport.Height), paint);
+    }
+}
+</code></pre>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/csharp.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        hljs.highlightAll();
+        if (window.parent && window.parent !== window) {
+            window.parent.postMessage('highlightjs-highlight', '*');
+        }
+    });
+    function copyCode(button) {
+        try {
+            const codeElement = button.parentElement.querySelector('code');
+            const codeText = codeElement.textContent || codeElement.innerText;
+            if (navigator.clipboard && window.isSecureContext) {
+                navigator.clipboard.writeText(codeText).then(() => {
+                    showCopySuccess(button);
+                }).catch(() => {
+                    fallbackCopy(codeText, button);
+                });
+            } else {
+                fallbackCopy(codeText, button);
+            }
+        } catch (error) {
+            console.error('Copy failed:', error);
+            showCopyError(button);
+        }
+    }
+    function fallbackCopy(text, button) {
+        try {
+            const textArea = document.createElement('textarea');
+            textArea.value = text;
+            textArea.style.position = 'fixed';
+            textArea.style.opacity = '0';
+            document.body.appendChild(textArea);
+            textArea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textArea);
+            showCopySuccess(button);
+        } catch (error) {
+            showCopyError(button);
+        }
+    }
+    function showCopySuccess(button) {
+        const originalText = button.textContent;
+        button.textContent = 'Copied!';
+        button.classList.add('copied');
+        setTimeout(() => {
+            button.textContent = originalText;
+            button.classList.remove('copied');
+        }, 2000);
+    }
+    function showCopyError(button) {
+        const originalText = button.textContent;
+        button.textContent = 'Failed';
+        setTimeout(() => {
+            button.textContent = originalText;
+        }, 2000);
+    }
+</script>
+</body>
+</html>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/RasterizingTileLayerWithCustomPointStyleSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/RasterizingTileLayerWithCustomPointStyleSample.html
@@ -19,49 +19,73 @@
     <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
     <pre><code class="csharp">using Mapsui.Layers;
 using Mapsui.Rendering;
-using Mapsui.Rendering.Skia;
-using Mapsui.Samples.Common.DataBuilders;
 using Mapsui.Styles;
 using Mapsui.Tiling;
+using Mapsui.Tiling.Layers;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
-namespace Mapsui.Samples.Common.Maps.Styles;
+namespace Mapsui.Samples.Common.Maps.Performance;
 
-public class CustomPointStyleBasicSample : ISample
+/// <summary>
+/// This sample demonstrates how to use a RasterizingTileLayer with a CustomPointStyle renderer for improved 
+/// performance when rendering one million points.
+/// </summary>
+public sealed class RasterizingTileLayerWithCustomPointStyleSample : ISample
 {
-    public string Name => $"Basic";
-    public string Category => $"{nameof(CustomPointStyle)}";
+    public string Name => "RasterizingTileLayerUsingCustomPointStyle";
+    public string Category => "Performance";
 
-    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+    static readonly SKPaint _paint = new() { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
 
-    public static Map CreateMap()
+    public Task<Map> CreateMapAsync()
     {
         var map = new Map();
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
-        {
-            Features = CreateFeatures(map.Extent!, 32).ToList(),
-            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
-        });
-        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
-        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
-        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
-        return map;
+        map.Layers.Add(CreateRasterizingTileLayer());
+        var extent = map.Layers.Get(1).Extent!.Grow(map.Layers.Get(1).Extent!.Width * 0.1);
+        map.Navigator.ZoomToBox(extent);
+
+        Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
+        // To use the experimental renderer you need to add the Mapsui.Experimental.Rendering.Skia package. It adds the IFeature parameter.
+        // Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyExperimentalBasicCustomStyleRenderer);
+
+        return Task.FromResult(map);
     }
+
+    private static RasterizingTileLayer CreateRasterizingTileLayer() => new(CreateRandomPointLayer())
+    {
+        Style = new RasterStyle { Outline = new Pen(Color.Gray, 1) },
+    };
 
     private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
     {
-        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
-        canvas.DrawCircle(0f, 0f, 10f, paint);
+        canvas.DrawRect(-5f, -5f, 10f, 10f, _paint);
     }
 
-    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
-        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
-            .Select(p => new PointFeature(p)).ToList();
+    private static void MyExperimentalBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, IFeature feature, RenderService renderService, float opacity)
+    {
+        canvas.DrawRect(-5f, -5f, 10f, 10f, _paint);
+    }
+
+    private static MemoryLayer CreateRandomPointLayer()
+    {
+        var rnd = new Random(3462); // Fix the random seed so the features don't move after a refresh
+        var features = new List<IFeature>();
+        for (var i = 0; i < 1_000_000; i++)
+        {
+            features.Add(new PointFeature(new MPoint(rnd.Next(-3_000_000, 3_000_000), rnd.Next(-3_000_000, 3_000_000))));
+        }
+
+        return new MemoryLayer
+        {
+            Name = "Points",
+            Features = features,
+            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
+        };
+    }
 }
 </code></pre>
 </div>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/RightToLeftSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/RightToLeftSample.html
@@ -17,51 +17,101 @@
 <body>
 <div class="code-container">
     <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
-    <pre><code class="csharp">using Mapsui.Layers;
-using Mapsui.Rendering;
-using Mapsui.Rendering.Skia;
-using Mapsui.Samples.Common.DataBuilders;
-using Mapsui.Styles;
-using Mapsui.Tiling;
-using SkiaSharp;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+    <pre><code class="csharp">using System.Collections.Generic;
 using System.Threading.Tasks;
+using Mapsui.Layers;
+using Mapsui.Styles;
+using Mapsui.Widgets;
 
-namespace Mapsui.Samples.Common.Maps.Styles;
+namespace Mapsui.Samples.Common.Maps.Tests;
 
-public class CustomPointStyleBasicSample : ISample
+public class RightToLeftSample : ISample
 {
-    public string Name => $"Basic";
-    public string Category => $"{nameof(CustomPointStyle)}";
+    public string Name => "Right to Left";
+
+    public string Category => "Tests";
+
+    // Noto Sans Arabic covers Arabic script and is licensed under OFL.
+    public const string NotoSansArabicSource = "embedded://Mapsui.Samples.Common.Resources.Fonts.NotoSansArabic-Regular.ttf";
 
     public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
 
     public static Map CreateMap()
     {
-        var map = new Map();
-        map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
+        var layer = CreateLayer();
+
+        var map = new Map
         {
-            Features = CreateFeatures(map.Extent!, 32).ToList(),
-            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
-        });
-        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
-        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
-        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
+            BackColor = Color.WhiteSmoke,
+        };
+
+        map.Navigator.ZoomToBox(layer.Extent!.Grow(layer.Extent.Width * 2));
+        map.Layers.Add(layer);
+
         return map;
     }
 
-    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
-    {
-        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
-        canvas.DrawCircle(0f, 0f, 10f, paint);
-    }
+    private static MemoryLayer CreateLayer() =>
+        new()
+        {
+            Features = CreateFeatures(),
+            Name = "RTL Text",
+            Style = null
+        };
 
-    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
-        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
-            .Select(p => new PointFeature(p)).ToList();
+    private static IEnumerable<IFeature> CreateFeatures() =>
+        new List<IFeature>
+        {
+            new PointFeature(new MPoint(-50, 50))
+            {
+                Styles = new List<IStyle>
+                {
+                    new LabelStyle
+                    {
+                        Text = "Ù…Ø±Ø­Ø¨Ø§ Ø¨Ø§Ù„Ø¹Ø§Ù„Ù…",
+                        Font = { Size = 18, FontSource = NotoSansArabicSource },
+                        BackColor = new Brush(Color.White),
+                        ForeColor = Color.Black,
+                        HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+                        TextAlignment = Alignment.Right,
+                    }
+                }
+            },
+            new PointFeature(new MPoint(50, -50))
+            {
+                Styles = new List<IStyle>
+                {
+                    CreatePointStyle(),
+                    new CalloutStyle
+                    {
+                        Title = "Ù…Ø±Ø­Ø¨Ø§ Ø¨Ø§Ù„Ø¹Ø§Ù„Ù…",
+                        TitleFont = { Size = 15, FontSource = NotoSansArabicSource },
+                        TitleFontColor = Color.Black,
+                        TitleTextAlignment = Alignment.Right,
+                        Subtitle = "Hello Ù…Ø±Ø­Ø¨Ø§ World",
+                        SubtitleFont = { Size = 12, FontSource = NotoSansArabicSource },
+                        SubtitleFontColor = Color.Gray,
+                        SubtitleTextAlignment = Alignment.Right,
+                        Type = CalloutType.Detail,
+                        MaxWidth = 200,
+                        Enabled = true,
+                        Offset = new Offset(0, SymbolStyle.DefaultHeight * 1f),
+                        BalloonDefinition = new CalloutBalloonDefinition
+                        {
+                            RectRadius = 10,
+                            ShadowWidth = 4,
+                        },
+                    }
+                }
+            },
+        };
+
+    private static SymbolStyle CreatePointStyle() =>
+        new()
+        {
+            Fill = new Brush { Color = Color.Gray },
+            Outline = new Pen(Color.Black),
+        };
 }
 </code></pre>
 </div>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/ThemeStyleSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/ThemeStyleSample.html
@@ -72,38 +72,54 @@ public class ThemeStyleSample : ISample
 
     private static ThemeStyle CreateThemeStyle()
     {
+        // Pre-create styles to enable caching. Each style instance has a stable GenerationId,
+        // allowing the drawable cache to reuse cached drawables for features with the same style.
+        // Creating new style instances on every call would defeat caching since each would have
+        // a different GenerationId.
+        var brazilStyle = new VectorStyle
+        {
+            Fill = new Brush(Color.Green),
+            Outline = new Pen(Color.Black)
+        };
+
+        var usaStyle = new VectorStyle
+        {
+            Fill = new Brush(Color.Violet),
+            Outline = new Pen(Color.Black)
+        };
+
+        var chinaStyle = new VectorStyle
+        {
+            Fill = new Brush(Color.Orange),
+            Outline = new Pen(Color.Black)
+        };
+
+        var japanStyle = new VectorStyle
+        {
+            Fill = new Brush(Color.Cyan),
+            Outline = new Pen(Color.Black)
+        };
+
+        var defaultStyle = new VectorStyle
+        {
+            Fill = new Brush(Color.Gray),
+            Outline = new Pen(Color.FromArgb(0, 64, 64, 64))
+        };
+
         return new ThemeStyle(f =>
         {
             if (f is GeometryFeature geometryFeature)
                 if (geometryFeature.Geometry is Point)
                     return null;
 
-            var style = new VectorStyle();
-
-            switch (f["NAME"]?.ToString()?.ToLower())
+            return f["NAME"]?.ToString()?.ToLower() switch
             {
-                case "brazil": //If country name is Brazil, fill it with green
-                    style.Fill = new Brush(Color.Green);
-                    style.Outline = new Pen(Color.Black);
-                    break;
-                case "united states": //If country name is USA, fill it with violet
-                    style.Fill = new Brush(Color.Violet);
-                    style.Outline = new Pen(Color.Black);
-                    break;
-                case "china": //If country name is China, fill it with orange
-                    style.Fill = new Brush(Color.Orange);
-                    style.Outline = new Pen(Color.Black);
-                    break;
-                case "japan": //If country name is Japan, fill it with cyan
-                    style.Fill = new Brush(Color.Cyan);
-                    style.Outline = new Pen(Color.Black);
-                    break;
-                default:
-                    style.Fill = new Brush(Color.Gray);
-                    style.Outline = new Pen(Color.FromArgb(0, 64, 64, 64));
-                    break;
-            }
-            return style;
+                "brazil" => brazilStyle,
+                "united states" => usaStyle,
+                "china" => chinaStyle,
+                "japan" => japanStyle,
+                _ => defaultStyle
+            };
         });
     }
 

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/VexTileAsPngCodeStyleSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/VexTileAsPngCodeStyleSample.html
@@ -17,51 +17,94 @@
 <body>
 <div class="code-container">
     <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
-    <pre><code class="csharp">using Mapsui.Layers;
-using Mapsui.Rendering;
-using Mapsui.Rendering.Skia;
-using Mapsui.Samples.Common.DataBuilders;
-using Mapsui.Styles;
+    <pre><code class="csharp">using Mapsui.Experimental.VectorTiles;
+using Mapsui.Experimental.VectorTiles.VexTileCopies;
+using Mapsui.Samples.Common.Utilities;
 using Mapsui.Tiling;
-using SkiaSharp;
+using Mapsui.Tiling.Fetcher;
+using Mapsui.Tiling.Layers;
+using SQLite;
 using System;
-using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using VexTile.Common.Enums;
+using VexTile.Data.Sources;
 
-namespace Mapsui.Samples.Common.Maps.Styles;
+namespace Mapsui.Samples.Common.Maps.Tiles;
 
-public class CustomPointStyleBasicSample : ISample
+public sealed class VexTileAsPngCodeStyleSample : ISample, IDisposable
 {
-    public string Name => $"Basic";
-    public string Category => $"{nameof(CustomPointStyle)}";
+    SqliteDataSource _sqliteDataSource;
 
-    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+    static VexTileAsPngCodeStyleSample()
+    {
+        MbTilesDeployer.CopyEmbeddedResourceToFile("zurich.mbtiles");
+        SQLitePCL.Batteries.Init();
+    }
 
-    public static Map CreateMap()
+    public VexTileAsPngCodeStyleSample()
+    {
+        _sqliteDataSource = CreateSqliteDataSource();
+    }
+
+    public string Name => "VexTileAsPngCodeStyle";
+    public string Category => "ExperimentalVectorTiles";
+
+    public Task<Map> CreateMapAsync()
+    {
+        return Task.FromResult(CreateMap(_sqliteDataSource));
+    }
+
+    public static Map CreateMap(SqliteDataSource sqliteDataSource)
     {
         var map = new Map();
+
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
-        {
-            Features = CreateFeatures(map.Extent!, 32).ToList(),
-            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
-        });
-        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
-        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
-        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
+        map.Layers.Add(CreateLayer(sqliteDataSource));
+
         return map;
     }
 
-    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
+    private static TileLayer CreateLayer(SqliteDataSource sqliteDataSource)
     {
-        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
-        canvas.DrawCircle(0f, 0f, 10f, paint);
+        var style = CreateCustomStyle();
+        var tileSource = new RasterizedVectorTileSource(sqliteDataSource, style: style);
+        return new TileLayer(tileSource, dataFetchStrategy: new MinimalDataFetchStrategy())
+        {
+            Name = "VexTile.TileSource.Mvt",
+        };
     }
 
-    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
-        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
-            .Select(p => new PointFeature(p)).ToList();
+    private static VectorStyle CreateCustomStyle()
+    {
+        var style = new VectorStyle(VectorStyleKind.Default);
+
+        // Remove all symbol layers so no text labels are rendered.
+        // Symbol layers render place names, road labels, POI icons, etc.
+        style.Layers.RemoveAll(l => l.Type == "symbol");
+
+        // Change water fill color to a more vivid blue.
+        // All style modifications must be done before the first tile renders
+        // because VectorStyle caches the computed paint values per layer+zoom.
+        var water = style.Layers.FirstOrDefault(l => l.ID == "water");
+        if (water?.Paint != null)
+            water.Paint["fill-color"] = "rgba(64, 164, 223, 1)";
+
+        return style;
+    }
+
+    private static SqliteDataSource CreateSqliteDataSource()
+    {
+        var path = Path.Combine(MbTilesDeployer.MbTilesLocation, "zurich.mbtiles");
+        SQLiteConnectionString val = new SQLiteConnectionString(path, (SQLiteOpenFlags)1, false);
+        return new SqliteDataSource(val);
+    }
+
+    void IDisposable.Dispose()
+    {
+        _sqliteDataSource.Dispose();
+    }
 }
 </code></pre>
 </div>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/VexTileAsPngCustomStyleSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/VexTileAsPngCustomStyleSample.html
@@ -1,0 +1,164 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+        pre { margin: 0; }
+        .code-container { position: relative; }
+        .copy-button { position: absolute; top: 12px; right: 12px; background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 4px; padding: 6px 10px; font-size: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; cursor: pointer; color: #495057; transition: all 0.2s ease; z-index: 10; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .copy-button:hover { background: #e9ecef; border-color: #adb5bd; color: #212529; }
+        .copy-button.copied { background: #d4edda; border-color: #c3e6cb; color: #155724; }
+        .copy-button:active { transform: translateY(1px); }
+    </style>
+</head>
+<body>
+<div class="code-container">
+    <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
+    <pre><code class="csharp">using Mapsui.Experimental.VectorTiles;
+using Mapsui.Experimental.VectorTiles.VexTileCopies;
+using Mapsui.Samples.Common.Utilities;
+using Mapsui.Tiling;
+using Mapsui.Tiling.Fetcher;
+using Mapsui.Tiling.Layers;
+using SQLite;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using VexTile.Common.Enums;
+using VexTile.Data.Sources;
+
+namespace Mapsui.Samples.Common.Maps.Tiles;
+
+public sealed class VexTileAsPngCustomStyleSample : ISample, IDisposable
+{
+    SqliteDataSource _sqliteDataSource;
+
+    static VexTileAsPngCustomStyleSample()
+    {
+        MbTilesDeployer.CopyEmbeddedResourceToFile("zurich.mbtiles");
+        SQLitePCL.Batteries.Init();
+    }
+
+    public VexTileAsPngCustomStyleSample()
+    {
+        _sqliteDataSource = CreateSqliteDataSource();
+    }
+
+    public string Name => "VexTileAsPngCustomStyle";
+    public string Category => "ExperimentalVectorTiles";
+
+    public Task<Map> CreateMapAsync()
+    {
+        return Task.FromResult(CreateMap(_sqliteDataSource));
+    }
+
+    public static Map CreateMap(SqliteDataSource sqliteDataSource)
+    {
+        var map = new Map();
+
+        map.Layers.Add(OpenStreetMap.CreateTileLayer());
+        map.Layers.Add(CreateLayer(sqliteDataSource));
+
+        return map;
+    }
+
+    private static TileLayer CreateLayer(SqliteDataSource sqliteDataSource)
+    {
+        // This is the default style JSON with all symbol layers (labels) removed.
+        // Symbol layers have type "symbol" and render text labels on the map.
+        // Edit the JSON below to customize colors, widths, visibility, etc.
+        var style = new VectorStyle(VectorStyleKind.Custom, customStyle: StyleJson);
+        var tileSource = new RasterizedVectorTileSource(sqliteDataSource, style: style);
+        return new TileLayer(tileSource, dataFetchStrategy: new MinimalDataFetchStrategy())
+        {
+            Name = "VexTile.TileSource.Mvt",
+        };
+    }
+
+    private static SqliteDataSource CreateSqliteDataSource()
+    {
+        var path = Path.Combine(MbTilesDeployer.MbTilesLocation, "zurich.mbtiles");
+        SQLiteConnectionString val = new SQLiteConnectionString(path, (SQLiteOpenFlags)1, false);
+        return new SqliteDataSource(val);
+    }
+
+    void IDisposable.Dispose()
+    {
+        _sqliteDataSource.Dispose();
+    }
+
+    // Default style JSON (from VexTile.Renderer.Mvt.AliFlux embedded resource) with all
+    // symbol layers removed so no labels are rendered. To re-enable labels, add back
+    // layers with "type":"symbol". To change a color, find the layer by "id" and edit
+    // the "paint" values â€” e.g. change "fill-color" on the "water" layer to make water red.
+    private const string StyleJson = """
+        {"version":8,"name":"AliFlux","metadata":{},"center":[8.54806714892635,47.37180823552663],"zoom":12.241790506353492,"bearing":0,"pitch":0,"sources":{"openmaptiles":{"type":"vector","url":"https://api.maptiler.com/tiles/v3/tiles.json?key={key}"}},"sprite":"https://openmaptiles.github.io/osm-bright-gl-style/sprite","glyphs":"https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key={key}","layers":[{"id":"background","type":"background","paint":{"background-color":{"stops":[[0,"rgba(236, 238, 241, 1)"],[6,"rgba(236, 238, 241, 1)"],[10,"rgba(236, 238, 241, 1)"]]}}},{"id":"landuse-residential","type":"fill","source":"openmaptiles","source-layer":"landuse","filter":["all",["==","$type","Polygon"],["==","class","residential"]],"layout":{"visibility":"visible"},"paint":{"fill-color":{"stops":[[0,"rgba(216, 221, 223, 1)"],[6,"rgba(216, 221, 223, 1)"],[10,"rgba(216, 221, 223, 1)"]]},"fill-opacity":0.7}},{"id":"landcover_grass","type":"fill","source":"openmaptiles","source-layer":"landcover","filter":["==","class","grass"],"paint":{"fill-color":"hsl(100, 58%, 76%)","fill-opacity":{"stops":[[5,0],[6,1]]}}},{"id":"park","type":"fill","source":"openmaptiles","source-layer":"park","paint":{"fill-color":"rgba(192, 216, 151, 0.53)","fill-opacity":1}},{"id":"landcover_wood","type":"fill","source":"openmaptiles","source-layer":"landcover","filter":["==","class","wood"],"paint":{"fill-color":"hsl(100, 58%, 76%)","fill-opacity":{"base":1,"stops":[[8,0.6],[12,0.6]]}}},{"id":"water","type":"fill","source":"openmaptiles","source-layer":"water","filter":["==","$type","Polygon"],"paint":{"fill-color":"rgba(103, 166, 196, 1)","fill-opacity":0.5}},{"id":"landcover-ice-shelf","type":"fill","source":"openmaptiles","source-layer":"landcover","filter":["==","subclass","ice_shelf"],"layout":{"visibility":"visible"},"paint":{"fill-color":"hsl(47, 26%, 88%)","fill-opacity":0.8}},{"id":"landcover-glacier","type":"fill","source":"openmaptiles","source-layer":"landcover","filter":["==","subclass","glacier"],"layout":{"visibility":"visible"},"paint":{"fill-color":"hsl(47, 22%, 94%)","fill-opacity":{"base":1,"stops":[[0,1],[8,0.5]]}}},{"id":"landuse","type":"fill","source":"openmaptiles","source-layer":"landuse","filter":["==","class","agriculture"],"layout":{"visibility":"visible"},"paint":{"fill-color":"#eae0d0"}},{"id":"landuse_overlay_national_park","type":"fill","source":"openmaptiles","source-layer":"landcover","filter":["==","class","national_park"],"paint":{"fill-color":"#E1EBB0","fill-opacity":{"base":1,"stops":[[5,0],[9,0.75]]}}},{"id":"park_outline","type":"line","source":"openmaptiles","source-layer":"park","layout":{},"paint":{"line-color":"rgba(159, 183, 118, 0.69)","line-dasharray":[0.5,1]}},{"id":"waterway-tunnel","type":"line","source":"openmaptiles","source-layer":"waterway","filter":["all",["==","$type","LineString"],["==","brunnel","tunnel"]],"paint":{"line-color":"hsl(205, 56%, 73%)","line-width":{"base":1.4,"stops":[[8,1],[20,2]]},"line-opacity":1,"line-gap-width":{"stops":[[12,0],[20,6]]},"line-dasharray":[3,3]}},{"id":"waterway","type":"line","source":"openmaptiles","source-layer":"waterway","filter":["all",["==","$type","LineString"],["!in","brunnel","tunnel","bridge"]],"paint":{"line-color":"hsl(205, 56%, 73%)","line-width":{"base":1.4,"stops":[[8,1],[20,8],[21,8]]},"line-opacity":1}},{"id":"tunnel_railway_transit","type":"line","source":"openmaptiles","source-layer":"transportation","minzoom":0,"filter":["all",["==","$type","LineString"],["==","brunnel","tunnel"],["==","class","transit"]],"layout":{"line-cap":"butt","line-join":"miter"},"paint":{"line-color":"hsl(34, 12%, 66%)","line-opacity":{"base":1,"stops":[[11,0],[16,1]]},"line-dasharray":[3,3]}},{"id":"building","type":"fill","source":"openmaptiles","source-layer":"building","paint":{"fill-color":"rgba(210, 223, 228, 1)","fill-outline-color":{"stops":[[15,"rgba(212, 177, 146, 0)"],[16,"rgba(212, 177, 146, 0.5)"]]},"fill-opacity":{"base":1,"stops":[[13,0],[15,1]]},"fill-antialias":true}},{"id":"road_path","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["all",["==","$type","LineString"],["in","class","path","track"]],"layout":{"line-cap":"square","line-join":"bevel"},"paint":{"line-color":"hsl(0, 0%, 97%)","line-dasharray":[1,1],"line-width":{"base":1.55,"stops":[[4,0.25],[20,10]]}}},{"id":"road_minor","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["all",["==","$type","LineString"],["in","class","minor","service"]],"layout":{"line-cap":"round","line-join":"round"},"paint":{"line-color":"hsl(0, 0%, 97%)","line-width":{"base":1.55,"stops":[[4,0.25],[20,30]]}}},{"id":"tunnel_minor","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["all",["==","$type","LineString"],["==","brunnel","tunnel"],["==","class","minor_road"]],"layout":{"line-cap":"butt","line-join":"miter"},"paint":{"line-color":"#efefef","line-width":{"base":1.55,"stops":[[4,0.25],[20,30]]},"line-dasharray":[0.36,0.18]}},{"id":"tunnel_major","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["all",["==","$type","LineString"],["==","brunnel","tunnel"],["in","class","primary","secondary","tertiary","trunk"]],"layout":{"line-cap":"butt","line-join":"miter"},"paint":{"line-color":"#fff","line-width":{"base":1.4,"stops":[[6,0.5],[20,30]]},"line-dasharray":[0.28,0.14]}},{"id":"aeroway-area","type":"fill","metadata":{"mapbox:group":"1444849345966.4436"},"source":"openmaptiles","source-layer":"aeroway","minzoom":4,"filter":["all",["==","$type","Polygon"],["in","class","runway","taxiway"]],"layout":{"visibility":"visible"},"paint":{"fill-opacity":{"base":1,"stops":[[13,0],[14,1]]},"fill-color":"rgba(255, 255, 255, 1)"}},{"id":"aeroway-taxiway","type":"line","metadata":{"mapbox:group":"1444849345966.4436"},"source":"openmaptiles","source-layer":"aeroway","minzoom":12,"filter":["all",["in","class","taxiway"],["==","$type","LineString"]],"layout":{"line-cap":"round","line-join":"round","visibility":"visible"},"paint":{"line-color":"rgba(255, 255, 255, 1)","line-width":{"base":1.5,"stops":[[12,1],[17,10]]},"line-opacity":1}},{"id":"aeroway-runway","type":"line","metadata":{"mapbox:group":"1444849345966.4436"},"source":"openmaptiles","source-layer":"aeroway","minzoom":4,"filter":["all",["in","class","runway"],["==","$type","LineString"]],"layout":{"line-cap":"round","line-join":"round","visibility":"visible"},"paint":{"line-color":"hsl(230, 23%, 82%)","line-width":{"base":1.5,"stops":[[11,4],[17,50]]},"line-opacity":1}},{"id":"road_trunk_primary","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["all",["==","$type","LineString"],["in","class","trunk","primary"]],"layout":{"line-cap":"round","line-join":"round"},"paint":{"line-color":{"base":1,"stops":[[9,"hsl(0, 0%, 100%)"],[11,"#fed330"]]},"line-width":{"base":1.4,"stops":[[6,0.5],[20,30]]}}},{"id":"road_secondary_tertiary","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["all",["==","$type","LineString"],["in","class","secondary","tertiary"]],"layout":{"line-cap":"round","line-join":"round"},"paint":{"line-color":"#fff","line-width":{"base":1.4,"stops":[[6,0.5],[20,20]]}}},{"id":"road_major_motorway","type":"line","source":"openmaptiles","source-layer":"transportation","minzoom":9,"filter":["all",["==","$type","LineString"],["==","class","motorway"]],"layout":{"line-cap":"round","line-join":"round"},"paint":{"line-color":{"stops":[[6,"rgba(230, 126, 34,1.0)"],[10,"#fed330"],[11,"#ff7f50"]]},"line-width":{"base":1.4,"stops":[[8,1],[16,10]]},"line-offset":0}},{"id":"railway-transit","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["all",["==","class","transit"],["!=","brunnel","tunnel"]],"layout":{"visibility":"visible"},"paint":{"line-color":"hsl(34, 12%, 66%)","line-opacity":{"base":1,"stops":[[11,0],[16,1]]}}},{"id":"railway","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["==","class","rail"],"layout":{"visibility":"visible"},"paint":{"line-color":"hsl(34, 12%, 66%)","line-opacity":{"base":1,"stops":[[11,0],[16,1]]}}},{"id":"waterway-bridge-case","type":"line","source":"openmaptiles","source-layer":"waterway","filter":["all",["==","$type","LineString"],["==","brunnel","bridge"]],"layout":{"line-cap":"butt","line-join":"miter"},"paint":{"line-color":"#bbbbbb","line-width":{"base":1.6,"stops":[[12,0.5],[20,10]]},"line-gap-width":{"base":1.55,"stops":[[4,0.25],[20,30]]}}},{"id":"waterway-bridge","type":"line","source":"openmaptiles","source-layer":"waterway","filter":["all",["==","$type","LineString"],["==","brunnel","bridge"]],"layout":{"line-cap":"round","line-join":"round"},"paint":{"line-color":"hsl(205, 56%, 73%)","line-width":{"base":1.55,"stops":[[4,0.25],[20,30]]}}},{"id":"bridge_minor case","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["all",["==","$type","LineString"],["==","brunnel","bridge"],["==","class","minor_road"]],"layout":{"line-cap":"butt","line-join":"miter","visibility":"none"},"paint":{"line-color":"#dedede","line-width":{"base":1.6,"stops":[[12,0.5],[20,10]]},"line-gap-width":{"base":1.55,"stops":[[4,0.25],[20,30]]}}},{"id":"bridge_major case","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["all",["==","$type","LineString"],["==","brunnel","bridge"],["in","class","primary","secondary","tertiary","trunk"]],"layout":{"line-cap":"butt","line-join":"miter","visibility":"none"},"paint":{"line-color":"#dedede","line-width":{"base":1.6,"stops":[[12,0.5],[20,10]]},"line-gap-width":{"base":1.55,"stops":[[4,0.25],[20,30]]}}},{"id":"bridge_minor","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["all",["==","$type","LineString"],["==","brunnel","bridge"],["==","class","minor_road"]],"layout":{"line-cap":"round","line-join":"round"},"paint":{"line-color":"#efefef","line-width":{"base":1.55,"stops":[[4,0.25],[20,30]]}}},{"id":"bridge_major","type":"line","source":"openmaptiles","source-layer":"transportation","filter":["all",["==","$type","LineString"],["==","brunnel","bridge"],["in","class","primary","secondary","tertiary","trunk"]],"layout":{"line-cap":"round","line-join":"round"},"paint":{"line-color":{"base":1,"stops":[[6,"hsl(0, 0%, 100%)"],[9,"#fed330"]]},"line-width":{"base":1.4,"stops":[[6,0.5],[20,30]]}}},{"id":"admin_sub","type":"line","source":"openmaptiles","source-layer":"boundary","filter":["in","admin_level",4,6,8],"layout":{"visibility":"visible"},"paint":{"line-color":"#34495e","line-dasharray":[2,1],"line-opacity":0.5}},{"id":"admin_country","type":"line","metadata":{"mapbox:group":"a14c9607bc7954ba1df7205bf660433f"},"source":"openmaptiles","source-layer":"boundary","filter":["all",["==","admin_level",2]],"layout":{"line-join":"round"},"paint":{"line-color":"rgb(80, 100, 110)","line-width":{"base":1.1,"stops":[[3,1],[22,20]]},"line-opacity":0.6}}],"id":"klokantech-basic"}
+        """;
+}
+</code></pre>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/csharp.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        hljs.highlightAll();
+        if (window.parent && window.parent !== window) {
+            window.parent.postMessage('highlightjs-highlight', '*');
+        }
+    });
+    function copyCode(button) {
+        try {
+            const codeElement = button.parentElement.querySelector('code');
+            const codeText = codeElement.textContent || codeElement.innerText;
+            if (navigator.clipboard && window.isSecureContext) {
+                navigator.clipboard.writeText(codeText).then(() => {
+                    showCopySuccess(button);
+                }).catch(() => {
+                    fallbackCopy(codeText, button);
+                });
+            } else {
+                fallbackCopy(codeText, button);
+            }
+        } catch (error) {
+            console.error('Copy failed:', error);
+            showCopyError(button);
+        }
+    }
+    function fallbackCopy(text, button) {
+        try {
+            const textArea = document.createElement('textarea');
+            textArea.value = text;
+            textArea.style.position = 'fixed';
+            textArea.style.opacity = '0';
+            document.body.appendChild(textArea);
+            textArea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textArea);
+            showCopySuccess(button);
+        } catch (error) {
+            showCopyError(button);
+        }
+    }
+    function showCopySuccess(button) {
+        const originalText = button.textContent;
+        button.textContent = 'Copied!';
+        button.classList.add('copied');
+        setTimeout(() => {
+            button.textContent = originalText;
+            button.classList.remove('copied');
+        }, 2000);
+    }
+    function showCopyError(button) {
+        const originalText = button.textContent;
+        button.textContent = 'Failed';
+        setTimeout(() => {
+            button.textContent = originalText;
+        }, 2000);
+    }
+</script>
+</body>
+</html>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/VexTileAsPngSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/VexTileAsPngSample.html
@@ -17,51 +17,73 @@
 <body>
 <div class="code-container">
     <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
-    <pre><code class="csharp">using Mapsui.Layers;
-using Mapsui.Rendering;
-using Mapsui.Rendering.Skia;
-using Mapsui.Samples.Common.DataBuilders;
-using Mapsui.Styles;
+    <pre><code class="csharp">using Mapsui.Experimental.VectorTiles;
+using Mapsui.Samples.Common.Utilities;
 using Mapsui.Tiling;
-using SkiaSharp;
+using Mapsui.Tiling.Fetcher;
+using Mapsui.Tiling.Layers;
+using SQLite;
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.IO;
 using System.Threading.Tasks;
+using VexTile.Data.Sources;
 
-namespace Mapsui.Samples.Common.Maps.Styles;
+namespace Mapsui.Samples.Common.Maps.Tiles;
 
-public class CustomPointStyleBasicSample : ISample
+public sealed class VexTileAsPngSample : ISample, IDisposable
 {
-    public string Name => $"Basic";
-    public string Category => $"{nameof(CustomPointStyle)}";
+    SqliteDataSource _sqliteDataSource;
 
-    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+    static VexTileAsPngSample()
+    {
+        MbTilesDeployer.CopyEmbeddedResourceToFile("zurich.mbtiles");
+        SQLitePCL.Batteries.Init();
+    }
 
-    public static Map CreateMap()
+    public VexTileAsPngSample()
+    {
+        _sqliteDataSource = CreateSqliteDataSource();
+    }
+
+    public string Name => "VexTileAsPng";
+    public string Category => "ExperimentalVectorTiles";
+
+    public Task<Map> CreateMapAsync()
+    {
+        return Task.FromResult(CreateMap(_sqliteDataSource));
+    }
+
+    public static Map CreateMap(SqliteDataSource sqliteDataSource)
     {
         var map = new Map();
+
         map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
-        {
-            Features = CreateFeatures(map.Extent!, 32).ToList(),
-            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
-        });
-        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
-        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
-        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
+        map.Layers.Add(CreateLayer(sqliteDataSource));
+
         return map;
     }
 
-    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
+    private static TileLayer CreateLayer(SqliteDataSource sqliteDataSource)
     {
-        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
-        canvas.DrawCircle(0f, 0f, 10f, paint);
+
+        var tileSource = new RasterizedVectorTileSource(sqliteDataSource);
+        return new TileLayer(tileSource, dataFetchStrategy: new MinimalDataFetchStrategy()) // DataFetchStrategy prefetches tiles from higher levels
+        {
+            Name = "VexTile.TileSource.Mvt",
+        };
     }
 
-    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
-        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
-            .Select(p => new PointFeature(p)).ToList();
+    private static SqliteDataSource CreateSqliteDataSource()
+    {
+        var path = Path.Combine(MbTilesDeployer.MbTilesLocation, "zurich.mbtiles");
+        SQLiteConnectionString val = new SQLiteConnectionString(path, (SQLiteOpenFlags)1, false);
+        return new SqliteDataSource(val);
+    }
+
+    void IDisposable.Dispose()
+    {
+        _sqliteDataSource.Dispose();
+    }
 }
 </code></pre>
 </div>

--- a/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/VexTileAsSKImageSample.html
+++ b/Samples/Mapsui.Samples.Blazor/wwwroot/codesamples/VexTileAsSKImageSample.html
@@ -17,51 +17,81 @@
 <body>
 <div class="code-container">
     <button class="copy-button" onclick="copyCode(this)" title="Copy code to clipboard">Copy</button>
-    <pre><code class="csharp">using Mapsui.Layers;
-using Mapsui.Rendering;
-using Mapsui.Rendering.Skia;
-using Mapsui.Samples.Common.DataBuilders;
-using Mapsui.Styles;
-using Mapsui.Tiling;
-using SkiaSharp;
+    <pre><code class="csharp">using Mapsui.Experimental.VectorTiles;
+using Mapsui.Experimental.VectorTiles.Tiling;
+using Mapsui.Samples.Common.Utilities;
+using SQLite;
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.IO;
 using System.Threading.Tasks;
+using VexTile.Common.Enums;
+using VexTile.Data.Sources;
+using Mapsui.Experimental.VectorTiles.VexTileCopies;
+using TileLayer = Mapsui.Experimental.VectorTiles.Tiling.TileLayer;
 
-namespace Mapsui.Samples.Common.Maps.Styles;
+namespace Mapsui.Samples.Common.Maps.Tiles;
 
-public class CustomPointStyleBasicSample : ISample
+/// <summary>
+/// Sample demonstrating the VexTileSource which fetches vector tile data
+/// and renders it using TwoStepVexTileStyleRenderer with caching.
+/// </summary>
+public sealed class VexTileAsSKImageSample : ISample, IDisposable
 {
-    public string Name => $"Basic";
-    public string Category => $"{nameof(CustomPointStyle)}";
+    private SqliteDataSource? _sqliteDataSource;
 
-    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+    static VexTileAsSKImageSample()
+    {
+        MbTilesDeployer.CopyEmbeddedResourceToFile("zurich.mbtiles");
+        SQLitePCL.Batteries.Init();
+    }
 
-    public static Map CreateMap()
+    public VexTileAsSKImageSample()
+    {
+        _sqliteDataSource = CreateSqliteDataSource();
+    }
+
+    public string Name => "VexTileAsSKImage";
+    public string Category => "ExperimentalVectorTiles";
+
+    public Task<Map> CreateMapAsync()
+    {
+        return Task.FromResult(CreateMap(_sqliteDataSource!));
+    }
+
+    public static Map CreateMap(SqliteDataSource sqliteDataSource)
     {
         var map = new Map();
-        map.Layers.Add(OpenStreetMap.CreateTileLayer());
-        map.Layers.Add(new MemoryLayer($"{nameof(CustomPointStyle)}")
-        {
-            Features = CreateFeatures(map.Extent!, 32).ToList(),
-            Style = new CustomPointStyle { RendererName = "custom-style-basic" },
-        });
-        MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
-        // Also register for the experimental renderer (needed when running with LocalRendererConfig.cs).
-        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-basic", MyBasicCustomStyleRenderer);
+        map.Layers.Add(CreateLayer(sqliteDataSource));
         return map;
     }
 
-    private static void MyBasicCustomStyleRenderer(SKCanvas canvas, IPointStyle style, RenderService renderService, float opacity)
+    private static TileLayer CreateLayer(SqliteDataSource sqliteDataSource)
     {
-        using var paint = new SKPaint { Color = new SKColor(79, 10, 107, 192), IsAntialias = true };
-        canvas.DrawCircle(0f, 0f, 10f, paint);
+        // Create the VexTile vector style (contains styling rules)
+        var vectorStyle = new VectorStyle(VectorStyleKind.Default);
+
+        // Create the tile source (fetches vector tile data)
+        var tileSource = new VexTileSource(sqliteDataSource);
+
+        return new TileLayer(tileSource)
+        {
+            Name = "VexTile",
+            Style = new VexTileStyle(vectorStyle),
+        };
     }
 
-    private static List<PointFeature> CreateFeatures(MRect envelope, int count) =>
-        RandomPointsBuilder.GenerateRandomPoints(envelope, count, new Random(934))
-            .Select(p => new PointFeature(p)).ToList();
+    private static SqliteDataSource CreateSqliteDataSource()
+    {
+        var path = Path.Combine(MbTilesDeployer.MbTilesLocation, "zurich.mbtiles");
+        var connectionString = new SQLiteConnectionString(path, SQLiteOpenFlags.ReadOnly, false);
+        return new SqliteDataSource(connectionString);
+    }
+
+    public void Dispose()
+    {
+        _sqliteDataSource?.Dispose();
+        _sqliteDataSource = null;
+    }
 }
 </code></pre>
 </div>

--- a/Samples/Mapsui.Samples.Common/Maps/Special/GridLayerSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/GridLayerSample.cs
@@ -8,7 +8,7 @@ namespace Mapsui.Samples.Common.Maps.Special;
 
 public class GridLayerSample : ISample
 {
-    public string Name => "Grid Layer";
+    public string Name => "GridLayer";
     public string Category => "Special";
 
     public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());


### PR DESCRIPTION
## Summary

- Regenerate missing Blazor code sample HTML pages for many samples (BigShapefilesSample, CalloutWrapAroundSample, CustomFontSample, CustomFontWidgetSample, EmojiSample, GpsTrackSample, GridLayerSample, PartialRefreshWidgetSample, RasterizingTileLayerWithCustomPointStyleSample, RightToLeftSample, VexTile* samples, and others)
- Fix `GridLayerSample.cs`: remove space from the `Name` property that caused a broken source-code link in the docs