### PR TITLE
Add clustering sample with ClusteringProvider

### DIFF
--- a/Samples/Mapsui.Samples.Common/Maps/Special/ClusteringSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/ClusteringSample.cs
@@ -1,0 +1,233 @@
+using BruTile.Predefined;
+using Mapsui.Layers;
+using Mapsui.Projections;
+using Mapsui.Providers;
+using Mapsui.Styles;
+using Mapsui.Styles.Thematics;
+using Mapsui.Tiling;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mapsui.Samples.Common.Maps.Special;
+
+public class ClusteringSample : ISample
+{
+    public string Name => "Clustering";
+    public string Category => "Special";
+
+    public Task<Map> CreateMapAsync() => Task.FromResult(CreateMap());
+
+    private static Map CreateMap()
+    {
+        var features = CreateRandomFeatures(3000);
+        var map = new Map();
+        map.Layers.Add(OpenStreetMap.CreateTileLayer());
+        map.Layers.Add(new Layer("Clusters")
+        {
+            DataSource = new ClusteringProvider(new MemoryProvider(features)),
+            Style = CreateClusterStyle(),
+        });
+        return map;
+    }
+
+    private static IEnumerable<IFeature> CreateRandomFeatures(int count)
+    {
+        var random = new Random(42);
+        var features = new List<PointFeature>(count);
+
+        // Two geographic clusters — radius is roughly half the width of Germany (~320 km)
+        (double Lon, double Lat, double RadiusMeters)[] centers =
+        [
+            (13.405,  52.520, 320_000),  // Berlin
+            (77.209,  28.614, 320_000),  // Delhi
+            (-99.133, 19.433, 320_000),  // Mexico City
+        ];
+
+        var pointsPerCenter = count / centers.Length;
+
+        foreach (var (lon, lat, radiusMeters) in centers)
+        {
+            var (cx, cy) = SphericalMercator.FromLonLat(lon, lat);
+            for (var i = 0; i < pointsPerCenter; i++)
+            {
+                var angle = random.NextDouble() * Math.PI * 2;
+                var r = random.NextDouble() * radiusMeters;
+                features.Add(new PointFeature(cx + r * Math.Cos(angle), cy + r * Math.Sin(angle)));
+            }
+        }
+
+        return features;
+    }
+
+    private static IStyle CreateClusterStyle()
+    {
+        var singlePointStyle = new SymbolStyle
+        {
+            Fill = new Brush(Color.CornflowerBlue),
+            Outline = new Pen(Color.White, 1.5f),
+            SymbolScale = 0.5,
+        };
+
+        // For clusters return a LabelStyle so the BackColor provides a visible grey pill/circle
+        // behind the white count number. For single points, fall back to the blue dot.
+        return new ThemeStyle(f =>
+        {
+            if (f.Data is not ClusterData d) return singlePointStyle;
+            return new LabelStyle
+            {
+                LabelMethod = _ => d.Count.ToString(),
+                ForeColor = Color.White,
+                BackColor = new Brush(new Color(70, 70, 70, 230)),
+                CornerRounding = 100,   // fully rounded → circle/pill
+                Font = new Font { Bold = true, Size = 12 },
+                VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+                HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+            };
+        });
+    }
+}
+
+/// <summary>
+/// A decorator provider that clusters features from an inner provider using a
+/// grid-based algorithm. Clustering results are cached per tile-schema level.
+/// </summary>
+public class ClusteringProvider : IProvider
+{
+    private readonly IProvider _innerProvider;
+    private readonly double _clusterCellPixels;
+    private readonly IDictionary<int, BruTile.Resolution> _resolutions;
+    private readonly Dictionary<int, Task<List<IFeature>>> _cache = [];
+    private readonly SemaphoreSlim _cacheLock = new(1, 1);
+    private int _dataVersion;
+
+    public ClusteringProvider(IProvider innerProvider, double clusterCellPixels = 40, IDictionary<int, BruTile.Resolution>? resolutions = null)
+    {
+        _innerProvider = innerProvider;
+        _clusterCellPixels = clusterCellPixels;
+        _resolutions = resolutions ?? new GlobalSphericalMercator().Resolutions;
+    }
+
+    public string? CRS
+    {
+        get => _innerProvider.CRS;
+        set => _innerProvider.CRS = value;
+    }
+
+    public MRect? GetExtent() => _innerProvider.GetExtent();
+
+    /// <summary>
+    /// Call this when the underlying data changes to invalidate the cache.
+    /// </summary>
+    public void InvalidateCache()
+    {
+        Interlocked.Increment(ref _dataVersion);
+        _cacheLock.Wait();
+        try { _cache.Clear(); }
+        finally { _cacheLock.Release(); }
+    }
+
+    public async Task<IEnumerable<IFeature>> GetFeaturesAsync(FetchInfo fetchInfo)
+    {
+        var level = BruTile.Utilities.GetNearestLevel(_resolutions, fetchInfo.Resolution);
+        var cellSize = _resolutions[level].UnitsPerPixel * _clusterCellPixels;
+
+        // If cell size is small enough that clustering has no practical effect, pass through.
+        if (cellSize < 1)
+            return await _innerProvider.GetFeaturesAsync(fetchInfo);
+
+        var clustered = await GetOrBuildClustersAsync(level, fetchInfo, cellSize);
+
+        var extent = fetchInfo.Extent;
+        if (extent == null) return clustered;
+        return clustered.Where(f => f.Extent?.Intersects(extent) ?? false);
+    }
+
+    private async Task<List<IFeature>> GetOrBuildClustersAsync(int level, FetchInfo fetchInfo, double cellSize)
+    {
+        await _cacheLock.WaitAsync();
+        try
+        {
+            if (!_cache.TryGetValue(level, out var task))
+            {
+                task = BuildClustersAsync(fetchInfo, cellSize);
+                _cache[level] = task;
+            }
+            return await task;
+        }
+        finally
+        {
+            _cacheLock.Release();
+        }
+    }
+
+    private async Task<List<IFeature>> BuildClustersAsync(FetchInfo fetchInfo, double cellSize)
+    {
+        // Fetch all features using the coarsest resolution to avoid exceeding MSection.MaxPixels.
+        var allExtent = GetExtent();
+        if (allExtent == null) return [];
+
+        var coarseResolution = _resolutions[0].UnitsPerPixel;
+        var allFetchInfo = new FetchInfo(new MSection(allExtent, coarseResolution), fetchInfo.CRS);
+        var allFeatures = await _innerProvider.GetFeaturesAsync(allFetchInfo);
+
+        var grid = new Dictionary<(int, int), ClusterCell>();
+
+        foreach (var feature in allFeatures)
+        {
+            var point = feature.Extent?.Centroid;
+            if (point == null) continue;
+
+            var cellX = (int)Math.Floor(point.X / cellSize);
+            var cellY = (int)Math.Floor(point.Y / cellSize);
+            var key = (cellX, cellY);
+
+            if (!grid.TryGetValue(key, out var cell))
+            {
+                cell = new ClusterCell();
+                grid[key] = cell;
+            }
+
+            cell.SumX += point.X;
+            cell.SumY += point.Y;
+            cell.Count++;
+            cell.Features.Add(feature);
+        }
+
+        var result = new List<IFeature>(grid.Count);
+
+        foreach (var cell in grid.Values)
+        {
+            if (cell.Count == 1)
+            {
+                result.Add(cell.Features[0]);
+            }
+            else
+            {
+                var cx = cell.SumX / cell.Count;
+                var cy = cell.SumY / cell.Count;
+                var cluster = new PointFeature(cx, cy);
+                cluster.Data = new ClusterData { Count = cell.Count, Features = cell.Features };
+                result.Add(cluster);
+            }
+        }
+
+        return result;
+    }
+
+    private sealed class ClusterCell
+    {
+        public double SumX;
+        public double SumY;
+        public int Count;
+        public List<IFeature> Features = [];
+    }
+}
+
+public class ClusterData
+{
+    public int Count { get; set; }
+    public List<IFeature> Features { get; set; } = [];
+}

--- a/Samples/Mapsui.Samples.Common/Maps/Special/ClusteringSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Special/ClusteringSample.cs
@@ -101,7 +101,6 @@ public class ClusteringProvider : IProvider
     private readonly IDictionary<int, BruTile.Resolution> _resolutions;
     private readonly Dictionary<int, Task<List<IFeature>>> _cache = [];
     private readonly SemaphoreSlim _cacheLock = new(1, 1);
-    private int _dataVersion;
 
     public ClusteringProvider(IProvider innerProvider, double clusterCellPixels = 40, IDictionary<int, BruTile.Resolution>? resolutions = null)
     {
@@ -123,7 +122,6 @@ public class ClusteringProvider : IProvider
     /// </summary>
     public void InvalidateCache()
     {
-        Interlocked.Increment(ref _dataVersion);
         _cacheLock.Wait();
         try { _cache.Clear(); }
         finally { _cacheLock.Release(); }
@@ -147,19 +145,34 @@ public class ClusteringProvider : IProvider
 
     private async Task<List<IFeature>> GetOrBuildClustersAsync(int level, FetchInfo fetchInfo, double cellSize)
     {
+        // Hold the lock only while reading/writing the dictionary, not during the actual build.
+        // This allows concurrent builds for different zoom levels.
+        Task<List<IFeature>> task;
         await _cacheLock.WaitAsync();
         try
         {
-            if (!_cache.TryGetValue(level, out var task))
+            if (!_cache.TryGetValue(level, out task!))
             {
                 task = BuildClustersAsync(fetchInfo, cellSize);
                 _cache[level] = task;
             }
-            return await task;
         }
         finally
         {
             _cacheLock.Release();
+        }
+
+        try
+        {
+            return await task;
+        }
+        catch
+        {
+            // Don't cache failures — remove so the next request retries.
+            await _cacheLock.WaitAsync();
+            try { _cache.Remove(level); }
+            finally { _cacheLock.Release(); }
+            throw;
         }
     }
 

--- a/docs/general/markdown/working-with-samples.md
+++ b/docs/general/markdown/working-with-samples.md
@@ -1,0 +1,96 @@
+# Working with Samples
+
+This page explains how the Mapsui sample system works, both for users who want to find a sample and for contributors who want to add one.
+
+## Finding and running samples
+
+All samples are available as a live Blazor demo at [mapsui.com/samples](https://mapsui.com/samples/). Each sample there has a **Source code** tab showing the relevant code.
+
+To run samples locally, clone the repository and open the `.slnf` for your preferred UI framework (e.g. `Mapsui.Wpf.slnf`). Set `Mapsui.Samples.<YourFramework>` as the startup project and run it. The sample app lets you pick a category and then a specific sample.
+
+Every sample in the app corresponds to a single C# class. To find the class for a particular sample, search the codebase for the displayed name in quotes — for example, searching for `"Points"` leads to `PointsSample.cs`.
+
+## How the sample system is structured
+
+### The sample interfaces
+
+All sample classes live in `Samples/Mapsui.Samples.Common/` and implement one of these interfaces:
+
+| Interface | Use when |
+|---|---|
+| `ISample` | The common case — cross-platform map samples. Implement `Task<Map> CreateMapAsync()`. |
+| `IMapControlSample` | You need direct access to the `IMapControl` during setup. Implement `void Setup(IMapControl)`. |
+| `IMapViewSample` | MAUI MapView-specific samples (extends `IMapControlSample`). |
+| `ISampleTest` | The sample needs extra initialization before a regression test runs. |
+| `IPrepareSampleTest` | The sample needs synchronous pre-test preparation. |
+
+Both `ISample` and `IMapControlSample` extend `ISampleBase`, which provides the `Name` and `Category` properties that identify the sample in the UI.
+
+### Automatic registration
+
+Samples **do not need to be manually registered**. The `Mapsui.Sample.SourceGenerator` (in `SourceGenerators/`) scans every class implementing any of the sample interfaces at build time and generates a `Samples.Register()` method for the assembly. Adding a class that implements `ISample` is sufficient — no call to `AllSamples.Register()` is needed.
+
+### Categories and folder structure
+
+The `Category` property on the sample class controls which group it appears in across all sample apps. The folder under `Maps/` is a mirror of the category name for navigation convenience, but the category the app uses comes from the property, not the folder.
+
+Existing categories:
+
+`Basic` · `DataFormats` · `Editing` · `FeatureAnimations` · `Geometries` · `MapBuilders` · `MapInfo` · `Navigation` · `Performance` · `Projection` · `Special` · `Styles` · `Tests` · `Tiles` · `ViewportAnimations` · `WFS` · `Widgets` · `Wms` · `WMTS`
+
+## Adding a new sample
+
+### 1. Create the class
+
+Add a `.cs` file in `Samples/Mapsui.Samples.Common/Maps/<CategoryFolder>/`. Name the class `<DescriptiveName>Sample` and the file to match.
+
+Implement `ISample` for the common case:
+
+```csharp
+namespace Mapsui.Samples.Common.Maps.Special;
+
+public class MyFeatureSample : ISample
+{
+    public string Name => "My Feature";
+    public string Category => "Special";
+
+    public Task<Map> CreateMapAsync()
+    {
+        var map = new Map();
+        // build the map...
+        return Task.FromResult(map);
+    }
+}
+```
+
+The source generator picks it up automatically on the next build.
+
+### Keep each sample file self-contained
+
+A sample file should contain everything needed to understand and use it. If the sample relies on a helper class (a custom provider, a data generator, etc.), put that class in the **same `.cs` file** rather than a separate one. This is an intentional exception to the one-class-per-file convention used elsewhere in the codebase. The goal is that someone reading the sample on the website, or copy-pasting it into their own project, gets all the code they need without having to hunt for additional files.
+
+### 2. Add the code-sample doc page
+
+Every sample should have a matching one-line file in `docs/codesamples/` so the website can show the source on the **Source code** tab:
+
+```markdown
+[!code-csharp[Main](../../Samples/Mapsui.Samples.Common/Maps/Special/MyFeatureSample.cs "MyFeatureSample")]
+```
+
+Save it as `docs/codesamples/MyFeatureSample.md`.
+
+### 3. Run the rendering regression test
+
+Every sample is automatically picked up by the rendering regression tests in `Tests/Mapsui.Rendering.Skia.Tests`. Run the test for the new sample:
+
+```ps
+dotnet test Tests/Mapsui.Rendering.Skia.Tests --filter "FullyQualifiedName~MyFeatureSample"
+```
+
+The first run will be **Inconclusive** because no reference image exists yet — the test generates one in `GeneratedRegression/`. Copy it to `OriginalRegression/` using the helper script:
+
+```ps
+.\Scripts\CopyGeneratedImagesOverOriginalImages.ps1
+```
+
+Then revert any files that were not touched by your change to keep binary diffs minimal. Subsequent runs should report **Passed**.

--- a/docs/general/mkdocs.yml
+++ b/docs/general/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
 
   - Contributing to Mapsui:
     - 'contributors-guidelines.md'
+    - 'working-with-samples.md'
     - 'rendering-tests.md'
     - 'documentation.md'
     - 'touch-and-mouse-handling.md'


### PR DESCRIPTION
Adds a new `ClusteringSample` demonstrating grid-based feature clustering on a map.

**Changes:**
- `ClusteringSample.cs` — new sample in the `Special` category with an embedded `ClusteringProvider` (decorator over `IProvider`) that clusters features per zoom level using a grid algorithm. Cache is per zoom level, correctly invalidated on data change, releases lock before awaiting builds (parallel zoom levels), and evicts faulted tasks so they are retried.
- `docs/general/markdown/working-with-samples.md` — new documentation page explaining how the sample system works and how to add a new sample.
- `docs/general/mkdocs.yml` — wires the new page into the Contributing nav section.