### PR TITLE
Update SkiaSharp to 3.119.2 and HarfBuzzSharp to 8.3.1.3

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -141,8 +141,9 @@ jobs:
     - name: install Android SDK
       run: uno-check -v --ci --non-interactive --fix --target android --skip androidemulator --skip dotnetworkloads-10.0.101 --dotnet 9.0.305
     - name: Install Android API 34
-      # macos-26 runner ships Android 35+ only; net8.0-android targets API 34 so install it explicitly
-      run: $ANDROID_HOME/cmdline-tools/16.0/bin/sdkmanager "platforms;android-34"
+      # macos-26 runner ships Android 35+ only; net8.0-android targets API 34 so install it explicitly.
+      # Use find to locate sdkmanager regardless of cmdline-tools version; pipe yes for license acceptance.
+      run: yes | $(find $ANDROID_HOME/cmdline-tools -name sdkmanager -type f | sort | tail -1) "platforms;android-34"
     - name: Uno Check
       run: uno-check -v --ci --non-interactive --fix --skip xcode --skip androidemulator --skip dotnetworkloads-10.0.101 --dotnet 9.0.305
     - name: Restore dependencies Mapsui.Mac

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -125,7 +125,7 @@ jobs:
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '26.3'          
+        xcode-version: '26.4'          
     # .Net 9 update     
     - name: Setup .NET 9 SDK
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -125,7 +125,7 @@ jobs:
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '26.4'          
+        xcode-version: '26.3'          
     # .Net 9 update     
     - name: Setup .NET 9 SDK
       uses: actions/setup-dotnet@v4
@@ -142,7 +142,7 @@ jobs:
     - name: install Android SDK
       run: uno-check -v --ci --non-interactive --fix --target android --skip androidemulator --skip dotnetworkloads-10.0.101 --dotnet 9.0.305
     - name: Uno Check
-      run: uno-check -v --ci --non-interactive --fix --skip xcode --skip androidemulator --skip dotnetworkloads-10.0.101 --dotnet 9.0.305
+      run: uno-check -v --ci --non-interactive --fix --skip xcode --skip androidemulator --skip dotnetworkloads-10.0.101 --skip dotnetworkloads-9.0.305 --dotnet 9.0.305
     - name: Restore dependencies Mapsui.Mac
       run: dotnet restore Mapsui.Mac.slnf -p:MapsuiSkipUnoMacCatalyst=true       
     # Build        

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -140,6 +140,9 @@ jobs:
       run: dotnet tool install --global Uno.Check --version 1.34.1
     - name: install Android SDK
       run: uno-check -v --ci --non-interactive --fix --target android --skip androidemulator --skip dotnetworkloads-10.0.101 --dotnet 9.0.305
+    - name: Install Android API 34
+      # macos-26 runner ships Android 35+ only; net8.0-android targets API 34 so install it explicitly
+      run: $ANDROID_HOME/cmdline-tools/16.0/bin/sdkmanager "platforms;android-34"
     - name: Uno Check
       run: uno-check -v --ci --non-interactive --fix --skip xcode --skip androidemulator --skip dotnetworkloads-10.0.101 --dotnet 9.0.305
     - name: Restore dependencies Mapsui.Mac

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -102,8 +102,7 @@ jobs:
         path: Artifacts/*.nupkg
   
   macBuild:  
-    # macos-15 is currently macos-13
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
       with:
@@ -125,7 +124,7 @@ jobs:
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '26.3'          
+        xcode-version: '26.4'          
     # .Net 9 update     
     - name: Setup .NET 9 SDK
       uses: actions/setup-dotnet@v4
@@ -136,13 +135,13 @@ jobs:
     - name: Set MSBuildEnableWorkloadResolver
       run: echo "MSBuildEnableWorkloadResolver=true" >> $GITHUB_ENV
     - name: install workloads maui macos android ios maccatalyst wasm-tools wasm-tools-net8
-      run: dotnet workload install maui macos android ios maccatalyst wasm-tools wasm-tools-net8 --skip-manifest-update
+      run: dotnet workload install maui macos android ios maccatalyst wasm-tools wasm-tools-net8
     - name: install Uno.Check 
       run: dotnet tool install --global Uno.Check --version 1.34.1
     - name: install Android SDK
       run: uno-check -v --ci --non-interactive --fix --target android --skip androidemulator --skip dotnetworkloads-10.0.101 --dotnet 9.0.305
     - name: Uno Check
-      run: uno-check -v --ci --non-interactive --fix --skip xcode --skip androidemulator --skip dotnetworkloads-10.0.101 --skip dotnetworkloads-9.0.305 --dotnet 9.0.305
+      run: uno-check -v --ci --non-interactive --fix --skip xcode --skip androidemulator --skip dotnetworkloads-10.0.101 --dotnet 9.0.305
     - name: Restore dependencies Mapsui.Mac
       run: dotnet restore Mapsui.Mac.slnf -p:MapsuiSkipUnoMacCatalyst=true       
     # Build        

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -136,7 +136,7 @@ jobs:
     - name: Set MSBuildEnableWorkloadResolver
       run: echo "MSBuildEnableWorkloadResolver=true" >> $GITHUB_ENV
     - name: install workloads maui macos android ios maccatalyst wasm-tools wasm-tools-net8
-      run: dotnet workload install maui macos android ios maccatalyst wasm-tools wasm-tools-net8
+      run: dotnet workload install maui macos android ios maccatalyst wasm-tools wasm-tools-net8 --skip-manifest-update
     - name: install Uno.Check 
       run: dotnet tool install --global Uno.Check --version 1.34.1
     - name: install Android SDK

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,8 +33,8 @@
     <PackageVersion Include="Eto.Platform.XamMac2" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.Platform.Gtk" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.SkiaDraw" Version="[0.2.0,0.3.0)" />
-    <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.2" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.2" />
+    <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.3" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.3" />
     <PackageVersion Include="IDisposableAnalyzers" Version="[4.0.8,5.0.0)" />
     <PackageVersion Include="Mapsui.Android" Version="5.0.0-beta.8" />
     <PackageVersion Include="Mapsui.ArcGIS" Version="5.0.0-beta.8" />
@@ -65,20 +65,20 @@
     <PackageVersion Include="NetTopologySuite.IO.VectorTiles.Mapbox" Version="1.1.0" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageVersion Include="SkiaSharp" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.Skottie" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.Views" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.Views.Uno" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.Views.WinUI" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.Views.WPF" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="3.119.1" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.Skottie" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.Views" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.Views.Uno" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.Views.WinUI" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.Views.WPF" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="3.119.2" />
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
 	<PackageVersion Include="SourceGear.sqlite3" Version="3.50.4.2" />


### PR DESCRIPTION
## Summary

Bumps NuGet packages in `Directory.Packages.props`:

| Package | From | To |
|---|---|---|
| `SkiaSharp` (and all `SkiaSharp.*` variants) | 3.119.1 | 3.119.2 |
| `HarfBuzzSharp` | 8.3.1.2 | 8.3.1.3 |
| `HarfBuzzSharp.NativeAssets.WebAssembly` | 8.3.1.2 | 8.3.1.3 |

## Test results

- ✅ Full solution build — all projects succeeded
- ✅ `Mapsui.Nts.Tests` — passed
- ✅ `Mapsui.Tests` — 265/265 passed
- ⚠️ `Mapsui.Rendering.Skia.Tests` — 21 rendering regression failures on Windows due to minor pixel-level rendering differences introduced by the SkiaSharp update. So on Windows, but not in Linux. It is related to subpixel rendering (also called ClearType on Windows, or LCD subpixel antialiasing). Not sure how to solve this yet.