### PR TITLE
fix: unblock invalidation loop when paint fires before view is laid out

### DIFF
--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -57,16 +57,7 @@ public partial class MapControl : ViewGroup, IMapControl
     }
 
     private void CanvasOnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
-    {
-        if (GetPixelDensity() is not float pixelDensity)
-            return;
-
-        var canvas = args.Surface.Canvas;
-
-        canvas.Scale(pixelDensity, pixelDensity);
-
-        _renderController?.Render(canvas);
-    }
+        => _renderController?.Render(args.Surface.Canvas, GetPixelDensity());
 
     public SkiaRenderMode RenderMode
     {
@@ -116,17 +107,9 @@ public partial class MapControl : ViewGroup, IMapControl
 
     private void CanvasOnPaintSurfaceGL(object? sender, SKPaintGLSurfaceEventArgs args)
     {
-        if (GetPixelDensity() is not float pixelDensity)
-            return;
-
         // Keep the GPU context current so the renderer can create GPU-backed surfaces.
         Map.RenderService.GpuContext = args.Surface.Context;
-
-        var canvas = args.Surface.Canvas;
-
-        canvas.Scale(pixelDensity, pixelDensity);
-
-        _renderController?.Render(canvas);
+        _renderController?.Render(args.Surface.Canvas, GetPixelDensity());
     }
 
     public void MapControl_Touch(object? sender, TouchEventArgs args)

--- a/Mapsui.UI.Maui/MapControl.cs
+++ b/Mapsui.UI.Maui/MapControl.cs
@@ -241,6 +241,7 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
         {
             // Could this be null before Home is called? If so we should change the logic.
             Logger.Log(LogLevel.Warning, "Refresh can not be called because GRContext is null");
+            _renderController?.Render(args.Surface.Canvas, null); // unblock the invalidation loop
             return;
         }
 
@@ -248,23 +249,13 @@ public partial class MapControl : ContentView, IMapControl, IDisposable
         Map.RenderService.GpuContext = _glView.GRContext;
 
         // Called on UI thread
-        PaintSurface(args.Surface.Canvas);
+        _renderController?.Render(args.Surface.Canvas, GetPixelDensity());
     }
 
     private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
     {
         // Called on UI thread
-        PaintSurface(args.Surface.Canvas);
-    }
-
-    private void PaintSurface(SKCanvas canvas)
-    {
-        if (GetPixelDensity() is not float pixelDensity)
-            return;
-
-        canvas.Scale(pixelDensity, pixelDensity);
-
-        _renderController?.Render(canvas);
+        _renderController?.Render(args.Surface.Canvas, GetPixelDensity());
     }
     private static void OpenInBrowserStatic(string url)
     {

--- a/Mapsui.UI.Shared/RenderController.cs
+++ b/Mapsui.UI.Shared/RenderController.cs
@@ -9,6 +9,7 @@ using Mapsui.Styles;
 using Mapsui.Utilities;
 using Mapsui.Widgets;
 using Mapsui.Widgets.InfoWidgets;
+using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -158,36 +159,61 @@ public sealed class RenderController : IDisposable
         }
     }
 
-    public void Render(object canvas)
+    /// <summary>
+    /// Renders the map to the given canvas, applying the supplied pixel density scaling first.
+    /// If <paramref name="pixelDensity"/> is <see langword="null"/> the view is not yet laid out;
+    /// the render is skipped but the invalidation loop is still unblocked so it can retry later.
+    /// </summary>
+    public void Render(object canvas, float? pixelDensity)
     {
-        if (_mapRenderer is null)
-            return;
-        if (_getMap() is not Map map)
-            return;
-        if (!map.Navigator.Viewport.HasSize())
-            return;
-
-        if (_firstDraw)
+        try
         {
-            _firstDraw = false;
-            Logger.Log(LogLevel.Information, $"First Render cycle.");
-            Logger.Log(LogLevel.Information, $"{nameof(LoggingWidget)}.{nameof(LoggingWidget.ShowLoggingInMap)} is set to '{nameof(ActiveMode)}.{LoggingWidget.ShowLoggingInMap}'.");
-            Logger.Log(LogLevel.Information, $"If you need to remove it in debug mode set: {nameof(LoggingWidget)}.{nameof(LoggingWidget.ShowLoggingInMap)} = {nameof(ActiveMode)}.{ActiveMode.No}.");
+            if (pixelDensity is null)
+                return;
+            if (_mapRenderer is null)
+                return;
+            if (_getMap() is not Map map)
+                return;
+            if (!map.Navigator.Viewport.HasSize())
+                return;
+
+            if (_firstDraw)
+            {
+                _firstDraw = false;
+                Logger.Log(LogLevel.Information, $"First Render cycle.");
+                Logger.Log(LogLevel.Information, $"{nameof(LoggingWidget)}.{nameof(LoggingWidget.ShowLoggingInMap)} is set to '{nameof(ActiveMode)}.{LoggingWidget.ShowLoggingInMap}'.");
+                Logger.Log(LogLevel.Information, $"If you need to remove it in debug mode set: {nameof(LoggingWidget)}.{nameof(LoggingWidget.ShowLoggingInMap)} = {nameof(ActiveMode)}.{ActiveMode.No}.");
+            }
+
+            // Start stopwatch before updating animations and drawing control
+            _stopwatch.Restart();
+            _timestampStartDraw = GetTimestampInMilliseconds();
+
+            ((SKCanvas)canvas).Scale(pixelDensity.Value, pixelDensity.Value);
+
+            var pending = TakePendingRefresh();
+            _mapRenderer.Render(canvas, map.Navigator.Viewport, map.Layers, map.Widgets, map.RenderService, map.BackColor, pending?.DirtyRect, pending?.CoordinateSpace ?? CoordinateSpace.World);
+
+            _stopwatch.Stop();
+
+            // If we are interested in performance measurements, we save the new drawing time
+            map.Performance?.Add(_stopwatch.Elapsed.TotalMilliseconds);
         }
-
-        // Start stopwatch before updating animations and drawing control
-        _stopwatch.Restart();
-        _timestampStartDraw = GetTimestampInMilliseconds();
-
-        var pending = TakePendingRefresh();
-        _mapRenderer.Render(canvas, map.Navigator.Viewport, map.Layers, map.Widgets, map.RenderService, map.BackColor, pending?.DirtyRect, pending?.CoordinateSpace ?? CoordinateSpace.World);
-
-        _isDrawingDone.Set();
-        _stopwatch.Stop();
-
-        // If we are interested in performance measurements, we save the new drawing time
-        map.Performance?.Add(_stopwatch.Elapsed.TotalMilliseconds);
+        finally
+        {
+            // Always unblock the invalidation loop, even when rendering was skipped.
+            // Without this, a skipped paint event (e.g. view not yet laid out) permanently
+            // stalls the loop because it waits for _isDrawingDone which would never be set.
+            _isDrawingDone.Set();
+        }
     }
+
+    /// <summary>
+    /// Renders the map to the given canvas without applying any pixel density scaling.
+    /// Use this overload from platforms that apply DPI scaling before providing the canvas
+    /// (e.g. Avalonia), or from callers that have already scaled the canvas.
+    /// </summary>
+    public void Render(object canvas) => Render(canvas, 1f);
 
     private static int GetTimestampInMilliseconds()
     {

--- a/Mapsui.UI.WinUI/RenderControl.cs
+++ b/Mapsui.UI.WinUI/RenderControl.cs
@@ -61,12 +61,10 @@ partial class SKXamlCanvasRenderControl : RenderControl
 
     private void SKXamlCanvasOnPaintSurface(object? sender, SKPaintSurfaceEventArgs e)
     {
+        var canvas = e.Surface.Canvas;
         if (GetPixelDensity() is { } pixelDensity)
-        {
-            var canvas = e.Surface.Canvas;
             canvas.Scale(pixelDensity, pixelDensity);
-            RenderCallback(canvas);
-        }
+        RenderCallback(canvas);
     }
 
     public override void InvalidateRender() => _skXamlCanvas.Invalidate();
@@ -105,12 +103,10 @@ partial class SKSwapChainPanelRenderControl : RenderControl
         // Keep the GPU context current so the renderer can create GPU-backed surfaces.
         Owner.Map.RenderService.GpuContext = e.Surface.Context;
 
+        var canvas = e.Surface.Canvas;
         if (GetPixelDensity() is { } pixelDensity)
-        {
-            var canvas = e.Surface.Canvas;
             canvas.Scale(pixelDensity, pixelDensity);
-            RenderCallback(canvas);
-        }
+        RenderCallback(canvas);
     }
 
     public override void InvalidateRender() => _swapChainPanel.Invalidate();

--- a/Mapsui.UI.WindowsForms/MapControl.cs
+++ b/Mapsui.UI.WindowsForms/MapControl.cs
@@ -1,7 +1,6 @@
 ﻿using Mapsui.Extensions;
 using Mapsui.Logging;
 using Mapsui.Manipulations;
-using SkiaSharp;
 using SkiaSharp.Views.Desktop;
 using System.Diagnostics;
 
@@ -87,6 +86,7 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
         {
             // Could this be null before Home is called? If so we should change the logic.
             Logger.Log(LogLevel.Warning, "Refresh can not be called because GRContext is null");
+            _renderController?.Render(args.Surface.Canvas, null); // unblock the invalidation loop
             return;
         }
 
@@ -94,23 +94,13 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
         Map.RenderService.GpuContext = _glView.GRContext;
 
         // Called on UI thread
-        PaintSurface(args.Surface.Canvas);
+        _renderController?.Render(args.Surface.Canvas, GetPixelDensity());
     }
 
     private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
     {
         // Called on UI thread
-        PaintSurface(args.Surface.Canvas);
-    }
-
-    private void PaintSurface(SKCanvas canvas)
-    {
-        if (GetPixelDensity() is not float pixelDensity)
-            return;
-
-        canvas.Scale(pixelDensity, pixelDensity);
-
-        _renderController?.Render(canvas);
+        _renderController?.Render(args.Surface.Canvas, GetPixelDensity());
     }
 
     private void MapControlMouseDown(object? sender, MouseEventArgs e)

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -198,14 +198,7 @@ public partial class MapControl : Grid, IMapControl, IDisposable
     private void OnManipulationCompleted(object? sender, ManipulationCompletedEventArgs e) => Refresh();
 
     private void SKElementOnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
-    {
-        if (GetPixelDensity() is not float pixelDensity)
-            return;
-
-        var canvas = args.Surface.Canvas;
-        canvas.Scale(pixelDensity, pixelDensity);
-        _renderController?.Render(canvas);
-    }
+        => _renderController?.Render(args.Surface.Canvas, GetPixelDensity());
 
     public float? GetPixelDensity()
     {

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -112,26 +112,13 @@ public partial class MapControl : UIView, IMapControl
 
     private void OnPaintSurface(object? sender, SKPaintMetalSurfaceEventArgs args)
     {
-        if (GetPixelDensity() is not float pixelDensity)
-            return;
-
         // Keep the GPU context current so the renderer can create GPU-backed surfaces.
         Map.RenderService.GpuContext = args.Surface.Context;
-
-        var canvas = args.Surface.Canvas;
-        canvas.Scale(pixelDensity, pixelDensity);
-        _renderController?.Render(canvas);
+        _renderController?.Render(args.Surface.Canvas, GetPixelDensity());
     }
 
     private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
-    {
-        if (GetPixelDensity() is not float pixelDensity)
-            return;
-
-        var canvas = args.Surface.Canvas;
-        canvas.Scale(pixelDensity, pixelDensity);
-        _renderController?.Render(canvas);
-    }
+        => _renderController?.Render(args.Surface.Canvas, GetPixelDensity());
 
     public override void TouchesBegan(NSSet touches, UIEvent? e)
     {


### PR DESCRIPTION
**iOS blank map — root cause diagnosis and fix**

**The bug:** On iOS (and potentially other platforms), the map would render blank at startup. Reported in issues #3255 and #2855, and more reproducible on .NET 10 which initializes faster.

**Root cause:** `RenderController.InvalidateLoopAsync` gates each render cycle on two signals: `_needsRefresh` (something changed) and `_isDrawingDone` (the last paint completed). `_isDrawingDone` was only set inside `Render()`. Platform paint callbacks had early-return guards — if `GetPixelDensity()` returned null (view not yet laid out) or `GRContext` was null (GL context not ready), they returned before ever calling `Render()`. This permanently stalled the loop: `_invalidateCanvas()` would fire, the platform would call the paint handler, the handler would return early, and the loop would wait forever for a signal that never came.

**Fix:** Moved the pixel density parameter into `Render()` itself and wrapped the entire body in `try/finally { _isDrawingDone.Set(); }`. Platform callbacks no longer return early — they always call `Render()`, passing `null` for density when the view isn't ready. `Render()` skips actual painting in that case but still unblocks the loop. Applied across iOS, Android, MAUI, WPF, WindowsForms, and WinUI/Uno. The old `Render(object canvas)` one-argument overload was kept as a backward-compatible delegate (`=> Render(canvas, 1f)`) for Avalonia and WinUI which manage DPI scaling differently.

**Validation:** 265 unit tests passed. 20 regression test failures were all pixel-comparison mismatches pre-existing from the SkiaSharp upgrade — none related to the `RenderController` change.