### PR TITLE
docs: add Avalonia 12 package guidance to getting-started and NuGet READMEs

### DIFF
--- a/Mapsui.UI.Avalonia/Mapsui.UI.Avalonia.csproj
+++ b/Mapsui.UI.Avalonia/Mapsui.UI.Avalonia.csproj
@@ -5,7 +5,8 @@
     <PackageId>Mapsui.Avalonia</PackageId>
     <Description>Avalonia map components based on the Mapsui library</Description>
     <PackageTags>$(PackageTags) avalonia</PackageTags>
-		<IsPackable>true</IsPackable>
+    <IsPackable>true</IsPackable>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -18,6 +19,7 @@
 
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.Avalonia/README.md
+++ b/Mapsui.UI.Avalonia/README.md
@@ -1,0 +1,7 @@
+### Mapsui.Avalonia
+
+Avalonia 11 map control based on the [Mapsui](https://mapsui.com) library.
+
+> **Using Avalonia 12?** Install [`Mapsui.Avalonia12`](https://www.nuget.org/packages/Mapsui.Avalonia12/) instead. The XAML and C# code are identical — only the package name differs.
+
+See the [getting started guide](https://mapsui.com/v5/) for installation steps and a minimal working example.

--- a/Mapsui.UI.Avalonia12/Mapsui.UI.Avalonia12.csproj
+++ b/Mapsui.UI.Avalonia12/Mapsui.UI.Avalonia12.csproj
@@ -6,6 +6,7 @@
     <Description>Avalonia 12 map components based on the Mapsui library</Description>
     <PackageTags>$(PackageTags) avalonia</PackageTags>
     <IsPackable>true</IsPackable>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RootNamespace>Mapsui.UI.Avalonia</RootNamespace>
     <AssemblyName>Mapsui.UI.Avalonia</AssemblyName>
     <DefineConstants>__AVALONIA__;__AVALONIA12__</DefineConstants>
@@ -15,6 +16,7 @@
     <Compile Include="..\Mapsui.UI.Avalonia\Extensions\PointExtensions.cs" Link="Extensions\PointExtensions.cs" />
     <Compile Include="..\Mapsui.UI.Avalonia\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
     <Compile Include="..\Mapsui.UI.Avalonia\MapControl.cs" Link="MapControl.cs" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.Avalonia12/README.md
+++ b/Mapsui.UI.Avalonia12/README.md
@@ -1,0 +1,7 @@
+### Mapsui.Avalonia12
+
+Avalonia 12 map control based on the [Mapsui](https://mapsui.com) library.
+
+> **Using Avalonia 11?** Install [`Mapsui.Avalonia`](https://www.nuget.org/packages/Mapsui.Avalonia/) instead. The XAML and C# code are identical — only the package name differs.
+
+See the [getting started guide](https://mapsui.com/v5/) for installation steps and a minimal working example.

--- a/docs/general/markdown/index.md
+++ b/docs/general/markdown/index.md
@@ -4,7 +4,8 @@ Mapsui is a .NET map component that supports all main .NET UI frameworks.
 | UI Framework | NuGet  |
 | ---------------|-------------:|
 | MAUI | [![NuGet Status](https://img.shields.io/nuget/dt/Mapsui.Maui.svg?style=flat&logo=nuget&label=Mapsui.Maui)](https://www.nuget.org/packages/Mapsui.Maui/) |
-| Avalonia | [![NuGet Status](https://img.shields.io/nuget/dt/Mapsui.Avalonia.svg?style=flat&logo=nuget&label=Mapsui.Avalonia)](https://www.nuget.org/packages/Mapsui.Avalonia/) |
+| Avalonia 11 | [![NuGet Status](https://img.shields.io/nuget/dt/Mapsui.Avalonia.svg?style=flat&logo=nuget&label=Mapsui.Avalonia)](https://www.nuget.org/packages/Mapsui.Avalonia/) |
+| Avalonia 12 | [![NuGet Status](https://img.shields.io/nuget/dt/Mapsui.Avalonia12.svg?style=flat&logo=nuget&label=Mapsui.Avalonia12)](https://www.nuget.org/packages/Mapsui.Avalonia12/) |
 | Uno Platform | [![NuGet Status](https://img.shields.io/nuget/dt/Mapsui.Uno.WinUI.svg?style=flat&logo=nuget&label=Mapsui.Uno.WinUI)](https://www.nuget.org/packages/Mapsui.Uno.WinUI/) |
 | Blazor | [![NuGet Status](https://img.shields.io/nuget/dt/Mapsui.Blazor.svg?style=flat&logo=nuget&label=Mapsui.Blazor)](https://www.nuget.org/packages/Mapsui.Blazor/) |
 | WPF | [![NuGet Status](https://img.shields.io/nuget/dt/Mapsui.Wpf.svg?style=flat&logo=nuget&label=Mapsui.Wpf)](https://www.nuget.org/packages/Mapsui.Wpf/) |
@@ -78,6 +79,13 @@ Try the quick-start for your favorite framework below.
         ```
 
         **Step 2:** Add the Mapsui.Avalonia nuget package:
+
+        !!! note "Avalonia 12 users"
+            If your project uses **Avalonia 12**, install `Mapsui.Avalonia12` instead:
+            ```console
+            dotnet add package Mapsui.Avalonia12
+            ```
+            The rest of the steps are identical — XAML and C# code do not change.
 
         ```console
         cd MyApp


### PR DESCRIPTION
**Why:**
Avalonia 12 has been out for a while but there was no obvious signpost pointing users to the right package. Anyone arriving at the `Mapsui.Avalonia` NuGet page or the getting-started docs had to discover `Mapsui.Avalonia12` on their own, leading to confusion and support questions. The two packages are otherwise identical — only the package name differs.

**What changed:**
- Added a README.md to both Mapsui.UI.Avalonia and Mapsui.UI.Avalonia12 NuGet packages. Each one now mentions the other and cross-links it, so users who install the wrong one are immediately pointed in the right direction.
- Updated index.md (the getting-started page) to list Avalonia 11 and Avalonia 12 as separate rows in the framework table, and added a note in the Avalonia quick-start steps directing Avalonia 12 users to `Mapsui.Avalonia12`.
- The branch also includes the `RenderController` blank-map fix (the invalidation loop stall) and the SkiaSharp upgrade, which were developed in parallel.