### PR TITLE
fix: deferred disposal to prevent race condition on drawable cache eviction

### DIFF
--- a/Mapsui.Experimental.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/MapRenderer.cs
@@ -422,6 +422,11 @@ public sealed class MapRenderer : IMapRenderer
     {
         try
         {
+            // Dispose drawables evicted by background threads during previous render passes.
+            // Must run on the render thread so GPU-backed SKObjects are released on the thread
+            // that owns the GRContext.
+            renderService.DrainAllPendingDisposals();
+
             // Ensure drawables are up to date for all two-step layers. This covers:
             // 1. Layers that already have features but missed the DataChanged event
             //    (e.g. MemoryLayer features set before the layer was added to the map).

--- a/Mapsui/Rendering/DrawableCache.cs
+++ b/Mapsui/Rendering/DrawableCache.cs
@@ -13,6 +13,7 @@ namespace Mapsui.Rendering;
 public sealed class DrawableCache : IDrawableCache
 {
     private readonly ConcurrentDictionary<DrawableCacheKey, CacheEntry> _cache = new();
+    private readonly ConcurrentQueue<IDrawable> _pendingDisposal = new();
     private readonly HashSet<DrawableCacheKey> _inProgress = [];
     private readonly object _inProgressLock = new();
 
@@ -54,12 +55,19 @@ public sealed class DrawableCache : IDrawableCache
             if (_cache.TryGetValue(key, out var entry) && entry.Iteration != currentIteration)
             {
                 if (_cache.TryRemove(key, out var removed))
-                {
-#pragma warning disable IDISP007 // Don't dispose injected - cache owns these drawables
-                    removed.Drawable.Dispose();
-#pragma warning restore IDISP007
-                }
+                    _pendingDisposal.Enqueue(removed.Drawable);
             }
+        }
+    }
+
+    /// <inheritdoc />
+    public void DrainPendingDisposals()
+    {
+        while (_pendingDisposal.TryDequeue(out var drawable))
+        {
+#pragma warning disable IDISP007 // Don't dispose injected - cache owns these drawables
+            drawable.Dispose();
+#pragma warning restore IDISP007
         }
     }
 
@@ -104,6 +112,7 @@ public sealed class DrawableCache : IDrawableCache
 
     public void Dispose()
     {
+        DrainPendingDisposals();
         Clear();
     }
 

--- a/Mapsui/Rendering/IDrawableCache.cs
+++ b/Mapsui/Rendering/IDrawableCache.cs
@@ -60,4 +60,11 @@ public interface IDrawableCache : IDisposable
     /// </summary>
     /// <param name="key">The composite key to release.</param>
     void ReleaseReservation(DrawableCacheKey key);
+
+    /// <summary>
+    /// Disposes drawables that were evicted by a background thread but deferred so that
+    /// the render thread (which may still be drawing them) can safely call Dispose.
+    /// Call this at the start of each render pass, before drawing begins.
+    /// </summary>
+    void DrainPendingDisposals();
 }

--- a/Mapsui/Rendering/RenderService.cs
+++ b/Mapsui/Rendering/RenderService.cs
@@ -115,6 +115,18 @@ public sealed class RenderService : IDisposable
         }
     }
 
+    /// <summary>
+    /// Drains the deferred-disposal queues of all layer drawable caches.
+    /// Call this at the start of each render pass (on the render thread) before drawing begins,
+    /// so that drawables evicted by background threads are disposed on the thread that owns
+    /// the GPU context.
+    /// </summary>
+    public void DrainAllPendingDisposals()
+    {
+        foreach (var cache in _layerDrawableCaches.Values)
+            cache.DrainPendingDisposals();
+    }
+
     public void Dispose()
     {
         DrawableImageCache.Dispose();

--- a/Mapsui/Rendering/TileDrawableCache.cs
+++ b/Mapsui/Rendering/TileDrawableCache.cs
@@ -15,6 +15,7 @@ public sealed class TileDrawableCache : IDrawableCache
     private const int _minimumTilesToKeep = 64;
 
     private readonly ConcurrentDictionary<DrawableCacheKey, CacheEntry> _cache = new();
+    private readonly ConcurrentQueue<IDrawable> _pendingDisposal = new();
     private readonly HashSet<DrawableCacheKey> _inProgress = [];
     private readonly object _inProgressLock = new();
 
@@ -99,7 +100,19 @@ public sealed class TileDrawableCache : IDrawableCache
 
     public void Dispose()
     {
+        DrainPendingDisposals();
         Clear();
+    }
+
+    /// <inheritdoc />
+    public void DrainPendingDisposals()
+    {
+        while (_pendingDisposal.TryDequeue(out var drawable))
+        {
+#pragma warning disable IDISP007 // Don't dispose injected - cache owns these drawables
+            drawable.Dispose();
+#pragma warning restore IDISP007
+        }
     }
 
     private void RemoveOldest(int numberToRemove)
@@ -115,9 +128,7 @@ public sealed class TileDrawableCache : IDrawableCache
         {
             if (counter >= numberToRemove) break;
             if (!_cache.TryRemove(key, out var entry)) continue;
-#pragma warning disable IDISP007 // Don't dispose injected - cache owns these drawables
-            entry.Drawable.Dispose();
-#pragma warning restore IDISP007
+            _pendingDisposal.Enqueue(entry.Drawable);
             counter++;
         }
     }


### PR DESCRIPTION
## Problem

Background threads (fetch pipeline / `UpdateDrawables`) were calling `Dispose()` on `SKImage`/`SKPicture`-backed drawables via `DrawableCache.Cleanup` and `TileDrawableCache.RemoveOldest` while the render thread was still drawing them. This caused intermittent crashes and GPU resource corruption.

## Solution

Introduce a deferred-disposal queue (`ConcurrentQueue<IDrawable> _pendingDisposal`) in both `DrawableCache` and `TileDrawableCache`.

Instead of disposing evicted drawables immediately on the background thread, they are **enqueued**. At the start of each render pass, `RenderService.DrainAllPendingDisposals()` is called on the render thread — before any drawing begins — which dequeues and safely disposes them on the thread that owns the GPU context.

## Changed files

| File | Change |
|---|---|
| `Mapsui/Rendering/IDrawableCache.cs` | Add `DrainPendingDisposals()` to interface |
| `Mapsui/Rendering/DrawableCache.cs` | Enqueue evicted drawables; add `DrainPendingDisposals()`; call drain in `Dispose()` |
| `Mapsui/Rendering/TileDrawableCache.cs` | Same pattern as `DrawableCache` |
| `Mapsui/Rendering/RenderService.cs` | Add `DrainAllPendingDisposals()` to drain all layer caches |
| `Mapsui.Experimental.Rendering.Skia/MapRenderer.cs` | Call `renderService.DrainAllPendingDisposals()` at the top of `Render()` |