### PR TITLE
fix: DrawTextOnPath renders tofu square between words in street labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 
 *.orig
 *.rej
+*.tmp
 
 Mapsui.Rendering.Android/obj/
 

--- a/Mapsui.Experimental.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/MapRenderer.cs
@@ -422,6 +422,11 @@ public sealed class MapRenderer : IMapRenderer
     {
         try
         {
+            // Dispose drawables evicted by background threads during previous render passes.
+            // Must run on the render thread so GPU-backed SKObjects are released on the thread
+            // that owns the GRContext.
+            renderService.DrainAllPendingDisposals();
+
             // Ensure drawables are up to date for all two-step layers. This covers:
             // 1. Layers that already have features but missed the DataChanged event
             //    (e.g. MemoryLayer features set before the layer was added to the map).

--- a/Mapsui.Experimental.VectorTiles/Assembly.cs
+++ b/Mapsui.Experimental.VectorTiles/Assembly.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Mapsui.Experimental.VectorTiles.Tests")]

--- a/Mapsui.Experimental.VectorTiles/VexTileCopies/SkiaCanvas.cs
+++ b/Mapsui.Experimental.VectorTiles/VexTileCopies/SkiaCanvas.cs
@@ -269,7 +269,9 @@ public sealed class SkiaCanvas : ICanvas, IDisposable
                 return;
             geometry = _clipBufferText;
         }
-        string text = TransformText(style.Text, style);
+        // DrawTextOnPath is single-line: the path-length guard below skips labels that
+        // are too long, so word-wrapping is unnecessary here. Only apply case transforms.
+        string text = TransformText(style.Text, style, wordWrap: false);
         if (CheckPathSqueezing(geometry))
             return;
 
@@ -435,7 +437,7 @@ public sealed class SkiaCanvas : ICanvas, IDisposable
         };
     }
 
-    private string TransformText(string text, Brush style)
+    internal string TransformText(string text, Brush style, bool wordWrap = true)
     {
         if (text.Length == 0)
             return string.Empty;
@@ -445,8 +447,12 @@ public sealed class SkiaCanvas : ICanvas, IDisposable
         else if (style.Paint.TextTransform == TextTransform.Lowercase)
             text = text.ToLower();
 
-        using var font = CreateTextFont(style);
-        text = BreakText(text, font, style, _breakPaint);
+        if (wordWrap)
+        {
+            using var font = CreateTextFont(style);
+            text = BreakText(text, font, style, _breakPaint);
+        }
+
         return text;
     }
 

--- a/Mapsui.slnx
+++ b/Mapsui.slnx
@@ -305,10 +305,6 @@
       <BuildType Solution="Ad-Hoc|*" Project="Debug" />
       <BuildType Solution="AppStore|*" Project="Debug" />
     </Project>
-    <Project Path="Tests/Mapsui.Experimental.VectorTiles.Tests/Mapsui.Experimental.VectorTiles.Tests.csproj">
-      <BuildType Solution="Ad-Hoc|*" Project="Debug" />
-      <BuildType Solution="AppStore|*" Project="Debug" />
-    </Project>
     <Project Path="Tests/Mapsui.Nts.Tests/Mapsui.Nts.Tests.csproj">
       <BuildType Solution="Ad-Hoc|*" Project="Debug" />
       <BuildType Solution="AppStore|*" Project="Debug" />

--- a/Mapsui.slnx
+++ b/Mapsui.slnx
@@ -301,6 +301,14 @@
     </Project>
   </Folder>
   <Folder Name="/Tests/">
+    <Project Path="Tests/Mapsui.Experimental.VectorTiles.Tests/Mapsui.Experimental.VectorTiles.Tests.csproj">
+      <BuildType Solution="Ad-Hoc|*" Project="Debug" />
+      <BuildType Solution="AppStore|*" Project="Debug" />
+    </Project>
+    <Project Path="Tests/Mapsui.Experimental.VectorTiles.Tests/Mapsui.Experimental.VectorTiles.Tests.csproj">
+      <BuildType Solution="Ad-Hoc|*" Project="Debug" />
+      <BuildType Solution="AppStore|*" Project="Debug" />
+    </Project>
     <Project Path="Tests/Mapsui.Nts.Tests/Mapsui.Nts.Tests.csproj">
       <BuildType Solution="Ad-Hoc|*" Project="Debug" />
       <BuildType Solution="AppStore|*" Project="Debug" />

--- a/Mapsui/Rendering/DrawableCache.cs
+++ b/Mapsui/Rendering/DrawableCache.cs
@@ -13,6 +13,7 @@ namespace Mapsui.Rendering;
 public sealed class DrawableCache : IDrawableCache
 {
     private readonly ConcurrentDictionary<DrawableCacheKey, CacheEntry> _cache = new();
+    private readonly ConcurrentQueue<IDrawable> _pendingDisposal = new();
     private readonly HashSet<DrawableCacheKey> _inProgress = [];
     private readonly object _inProgressLock = new();
 
@@ -54,12 +55,19 @@ public sealed class DrawableCache : IDrawableCache
             if (_cache.TryGetValue(key, out var entry) && entry.Iteration != currentIteration)
             {
                 if (_cache.TryRemove(key, out var removed))
-                {
-#pragma warning disable IDISP007 // Don't dispose injected - cache owns these drawables
-                    removed.Drawable.Dispose();
-#pragma warning restore IDISP007
-                }
+                    _pendingDisposal.Enqueue(removed.Drawable);
             }
+        }
+    }
+
+    /// <inheritdoc />
+    public void DrainPendingDisposals()
+    {
+        while (_pendingDisposal.TryDequeue(out var drawable))
+        {
+#pragma warning disable IDISP007 // Don't dispose injected - cache owns these drawables
+            drawable.Dispose();
+#pragma warning restore IDISP007
         }
     }
 
@@ -104,6 +112,7 @@ public sealed class DrawableCache : IDrawableCache
 
     public void Dispose()
     {
+        DrainPendingDisposals();
         Clear();
     }
 

--- a/Mapsui/Rendering/IDrawableCache.cs
+++ b/Mapsui/Rendering/IDrawableCache.cs
@@ -60,4 +60,11 @@ public interface IDrawableCache : IDisposable
     /// </summary>
     /// <param name="key">The composite key to release.</param>
     void ReleaseReservation(DrawableCacheKey key);
+
+    /// <summary>
+    /// Disposes drawables that were evicted by a background thread but deferred so that
+    /// the render thread (which may still be drawing them) can safely call Dispose.
+    /// Call this at the start of each render pass, before drawing begins.
+    /// </summary>
+    void DrainPendingDisposals();
 }

--- a/Mapsui/Rendering/RenderService.cs
+++ b/Mapsui/Rendering/RenderService.cs
@@ -115,6 +115,18 @@ public sealed class RenderService : IDisposable
         }
     }
 
+    /// <summary>
+    /// Drains the deferred-disposal queues of all layer drawable caches.
+    /// Call this at the start of each render pass (on the render thread) before drawing begins,
+    /// so that drawables evicted by background threads are disposed on the thread that owns
+    /// the GPU context.
+    /// </summary>
+    public void DrainAllPendingDisposals()
+    {
+        foreach (var cache in _layerDrawableCaches.Values)
+            cache.DrainPendingDisposals();
+    }
+
     public void Dispose()
     {
         DrawableImageCache.Dispose();

--- a/Mapsui/Rendering/TileDrawableCache.cs
+++ b/Mapsui/Rendering/TileDrawableCache.cs
@@ -15,6 +15,7 @@ public sealed class TileDrawableCache : IDrawableCache
     private const int _minimumTilesToKeep = 64;
 
     private readonly ConcurrentDictionary<DrawableCacheKey, CacheEntry> _cache = new();
+    private readonly ConcurrentQueue<IDrawable> _pendingDisposal = new();
     private readonly HashSet<DrawableCacheKey> _inProgress = [];
     private readonly object _inProgressLock = new();
 
@@ -99,7 +100,19 @@ public sealed class TileDrawableCache : IDrawableCache
 
     public void Dispose()
     {
+        DrainPendingDisposals();
         Clear();
+    }
+
+    /// <inheritdoc />
+    public void DrainPendingDisposals()
+    {
+        while (_pendingDisposal.TryDequeue(out var drawable))
+        {
+#pragma warning disable IDISP007 // Don't dispose injected - cache owns these drawables
+            drawable.Dispose();
+#pragma warning restore IDISP007
+        }
     }
 
     private void RemoveOldest(int numberToRemove)
@@ -115,9 +128,7 @@ public sealed class TileDrawableCache : IDrawableCache
         {
             if (counter >= numberToRemove) break;
             if (!_cache.TryRemove(key, out var entry)) continue;
-#pragma warning disable IDISP007 // Don't dispose injected - cache owns these drawables
-            entry.Drawable.Dispose();
-#pragma warning restore IDISP007
+            _pendingDisposal.Enqueue(entry.Drawable);
             counter++;
         }
     }

--- a/Tests/Mapsui.Experimental.VectorTiles.Tests/Mapsui.Experimental.VectorTiles.Tests.csproj
+++ b/Tests/Mapsui.Experimental.VectorTiles.Tests/Mapsui.Experimental.VectorTiles.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Mapsui.Experimental.VectorTiles\Mapsui.Experimental.VectorTiles.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('linux'))">
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Mapsui.Experimental.VectorTiles.Tests/VexTileCopies/SkiaCanvasTests.cs
+++ b/Tests/Mapsui.Experimental.VectorTiles.Tests/VexTileCopies/SkiaCanvasTests.cs
@@ -1,0 +1,80 @@
+using Mapsui.Experimental.VectorTiles.VexTileCopies;
+using NUnit.Framework;
+using VexTile.Renderer.Mvt.AliFlux.Drawing;
+using VexTile.Renderer.Mvt.AliFlux.Enums;
+
+namespace Mapsui.Experimental.VectorTiles.Tests.VexTileCopies;
+
+[TestFixture]
+public class SkiaCanvasTests
+{
+    [Test]
+    public void TransformText_WithWordWrapFalse_NeverContainsNewline()
+    {
+        using var canvas = new SkiaCanvas(256, 256);
+        // Very narrow limit — would cause word-breaking if wordWrap were true.
+        var brush = CreateBrush(textMaxWidth: 1.0);
+
+        var result = canvas.TransformText("Hello World This Is A Long Street Name", brush, wordWrap: false);
+
+        Assert.That(result, Does.Not.Contain("\n"));
+    }
+
+    [Test]
+    public void TransformText_WithWordWrapFalse_PreservesText()
+    {
+        using var canvas = new SkiaCanvas(256, 256);
+        var brush = CreateBrush();
+
+        var result = canvas.TransformText("Hello World", brush, wordWrap: false);
+
+        Assert.That(result, Is.EqualTo("Hello World"));
+    }
+
+    [Test]
+    public void TransformText_UppercaseTransform_WithWordWrapFalse_ConvertsToUpper()
+    {
+        using var canvas = new SkiaCanvas(256, 256);
+        var brush = CreateBrush(transform: TextTransform.Uppercase);
+
+        var result = canvas.TransformText("hello world", brush, wordWrap: false);
+
+        Assert.That(result, Is.EqualTo("HELLO WORLD"));
+    }
+
+    [Test]
+    public void TransformText_LowercaseTransform_WithWordWrapFalse_ConvertsToLower()
+    {
+        using var canvas = new SkiaCanvas(256, 256);
+        var brush = CreateBrush(transform: TextTransform.Lowercase);
+
+        var result = canvas.TransformText("HELLO WORLD", brush, wordWrap: false);
+
+        Assert.That(result, Is.EqualTo("hello world"));
+    }
+
+    [Test]
+    public void TransformText_EmptyText_ReturnsEmpty()
+    {
+        using var canvas = new SkiaCanvas(256, 256);
+        var brush = CreateBrush();
+
+        var result = canvas.TransformText(string.Empty, brush, wordWrap: false);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    private static Brush CreateBrush(TextTransform transform = TextTransform.None, double textMaxWidth = 10.0) =>
+        new Brush
+        {
+            Text = string.Empty,
+            Paint = new Paint
+            {
+                TextFont = ["Arial", "Arial Unicode MS Regular"],
+                TextSize = 16.0,
+                TextMaxWidth = textMaxWidth,
+                TextTransform = transform,
+                LineDashArray = [],
+            }
+        };
+}


### PR DESCRIPTION
## Problem

`DrawTextOnPath` was passing text through `TransformText`, which calls `BreakText` to insert `\n` characters at word boundaries for long labels. Since `DrawTextOnPath` is a single-line rendering call, Skia has no glyph for `\n` and renders it as a tofu square (□) — visible, for example, in Russian road names like "СТАДИОННАЯ УЛИЦА".

Fixes #3346

## Root cause

`TransformText` was shared by both `DrawText` (point labels) and `DrawTextOnPath` (road labels). For point labels, the `\n`-based word-wrapping is correct — `DrawText` splits on `\n` and renders each line with a vertical offset. For path labels, the wrapping is both unnecessary (a path-length guard already skips labels that are too long) and harmful.

## Changes

- **`SkiaCanvas.TransformText`** — added a `wordWrap` parameter (default `true`). When `false`, only case transforms (uppercase/lowercase) are applied; `BreakText` is skipped entirely.
- **`DrawTextOnPath`** — now calls `TransformText(..., wordWrap: false)`, so no `\n` is ever produced for path text.
- **`Assembly.cs`** (new) — exposes internals to the test project via `InternalsVisibleTo`.
- **`Tests/Mapsui.Experimental.VectorTiles.Tests`** (new project) — unit tests for `SkiaCanvas.TransformText` covering: no `\n` when `wordWrap: false`, text preserved, uppercase/lowercase transforms, and empty-text edge case.
- **`.gitignore`** — added `*.tmp` to suppress MSBuild SDK resolver backup files.