### PR TITLE
fix: clamp mouse wheel accumulator to prevent stuck zoom direction on Avalonia WASM

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,6 +104,7 @@ Before opening a pull request, load the done-checklist skill (`.github/skills/do
 | Skill | When to load |
 |---|---|
 | `.github/skills/done-checklist/SKILL.md` | Before opening any PR — runs the full pre-PR checklist |
+| `.github/skills/create-pr/SKILL.md` | When opening a pull request — covers title prefix conventions, PR type label selection, and the correct tool to use |
 | `.github/skills/regression-tests/SKILL.md` | When working with rendering regression tests: running, updating references, diagnosing failures, or adding experimental-renderer samples |
 | `.github/skills/richtextkit/SKILL.md` | When implementing text rendering features involving word wrap, BiDi/RTL, emoji, font fallback, or multi-style text blocks |
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -19,15 +19,18 @@ changelog:
     - title: "⚡Performance"
       labels:
         - "PR type:⚡Performance"
-    - title: "🛠️ Maintenance"
+    - title: "🛠️ Chore"
       labels:
-        - "PR type: 🛠️ Maintenance"
+        - "PR type: 🛠️ Chore"
     - title: "⚙️ Infrastructure"
       labels:
         - "PR type: ⚙️ Infrastructure"
     - title: "🧪 Samples"
       labels:
         - "PR type: 🧪 Sample"
+    - title: "✅ Tests"
+      labels:
+        - "PR type: ✅ Tests"
     - title: "📝 Documentation"
       labels:
         - "PR type: 📝 Documentation"

--- a/.github/skills/create-pr/SKILL.md
+++ b/.github/skills/create-pr/SKILL.md
@@ -9,6 +9,29 @@ Use this skill when you are ready to open a pull request. It covers the title fo
 
 ---
 
+## 0 — Verify the branch is ready (do this first)
+
+> **Committing and pushing is always the user's responsibility.** Per the Copilot instructions: *never run `git commit`, `git push`, or any destructive git command unless the user explicitly asks.*
+
+Before calling `mcp_github_create_pull_request`, verify that the expected changes are actually on the remote branch. Run:
+
+```ps
+git log origin/<branch> --oneline -10
+```
+
+and compare with what was implemented in this session. **If the branch on the remote does not contain the expected commits, stop and ask the user to push before continuing.**
+
+### Warning signs that the user may not have pushed yet
+
+- The most recent commit on the remote branch belongs to a completely different topic (e.g., work in this session was a bug fix, but the top commit on the remote is an old refactoring).
+- The user just said something like "I created a new branch" — they may have created it locally without pushing.
+- `git status` shows "Your branch is ahead of 'origin/…' by N commits".
+- The remote branch does not exist at all (`git ls-remote --heads origin <branch>` returns nothing).
+
+When in doubt, ask: *"Have you pushed your changes to the remote branch?"*
+
+---
+
 ## 1 — Tool to use
 
 Always create pull requests via **`mcp_github_create_pull_request`**.  

--- a/.github/skills/create-pr/SKILL.md
+++ b/.github/skills/create-pr/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: create-pr
+description: Create a GitHub Pull Request for Mapsui — covering title prefix conventions, PR type label selection, and the correct tool to use. Load this skill when you are ready to open a pull request.
+---
+
+# Creating a Pull Request in Mapsui
+
+Use this skill when you are ready to open a pull request. It covers the title format, label selection, and the tool to use.
+
+---
+
+## 1 — Tool to use
+
+Always create pull requests via **`mcp_github_create_pull_request`**.  
+Do **not** use `gh pr create` or any other CLI command.
+
+---
+
+## 2 — Title format
+
+```
+<prefix>: <short imperative summary>
+```
+
+- Use the **imperative mood** ("Add support for X", not "Added support for X").  
+- Keep it concise — ideally under 72 characters.  
+- The prefix is lowercase; the rest of the title uses sentence case.
+
+### Prefix → PR type label mapping
+
+| Title prefix | PR type label | When to use |
+|---|---|---|
+| `fix:` | `PR type: 🐛 Fix` | A bug fix or patch for existing functionality |
+| `feat:` | `PR type: 🚀 Feature` | A new capability or enhancement that users benefit from |
+| `refactor:` | `PR type: ♻️ Refactor` | Internal restructuring that doesn't change behavior or add features |
+| `update:` | `PR type: 📦 Update` | Updates to third-party libraries, SDKs, NuGet packages |
+| `perf:` | `PR type:⚡Performance` | A change that measurably improves speed, memory, or resource usage |
+| `chore:` | `PR type: 🛠️ Chore` | Internal changes that don't affect end users (code cleanup, build tweaks) |
+| `ci:` | `PR type: ⚙️ Infrastructure` | Changes to CI/CD pipelines, deployment scripts, config files, tooling |
+| `sample:` | `PR type: 🧪 Sample` | Adding or updating a sample |
+| `test:` | `PR type: ✅ Tests` | Adding or improving unit, integration, or regression tests without changing production code |
+| `docs:` | `PR type: 📝 Documentation` | Changes to user guides, README, API docs, etc. |
+
+> **Note on `feat:` vs `feature:`** — Use `feat:` (the conventional commits standard, dominant in .NET projects). Do not use `feature:`.
+
+---
+
+## 3 — Required fields
+
+When calling `mcp_github_create_pull_request`, always provide:
+
+| Field | Guidance |
+|---|---|
+| `title` | `<prefix>: <summary>` as above |
+| `body` | Describe *what* changed, *why*, and reference any related issues with `Fixes #NNN` or `Relates to #NNN` |
+| `labels` | The matching "PR type" label from the table above |
+| `base` | `main` (the default branch) |
+| `draft` | `false` unless the work is explicitly incomplete |
+
+---
+
+## 4 — Secondary labels
+
+In addition to the "PR type" label, you may apply additional labels as appropriate:
+
+| Label | When |
+|---|---|
+| `☢️ Experimental` | PR touches any `Mapsui.Experimental.*` package |
+| `bug 🐛` | Companion to a bug report (issue side); not the same as `PR type: 🐛 Fix` |
+| `documentation` | Supplementary docs label (distinct from PR type) |
+
+These are **optional** and supplementary — they do not replace the PR type label.
+
+---
+
+## 5 — Release notes
+
+The `release.yml` file categorises PRs by their "PR type" label for automated GitHub release notes. Choosing the correct label ensures the PR appears in the right section of the changelog.
+
+| Release section | Label |
+|---|---|
+| 🐛 Fixes | `PR type: 🐛 Fix` |
+| 🚀 Features | `PR type: 🚀 Feature` |
+| ♻️ Refactor | `PR type: ♻️ Refactor` |
+| 📦 Updates | `PR type: 📦 Update` |
+| ⚡ Performance | `PR type:⚡Performance` |
+| 🛠️ Chore | `PR type: 🛠️ Chore` |
+| ⚙️ Infrastructure | `PR type: ⚙️ Infrastructure` |
+| 🧪 Samples | `PR type: 🧪 Sample` |
+| ✅ Tests | `PR type: ✅ Tests` |
+| 📝 Documentation | `PR type: 📝 Documentation` |
+| 💩 Other Changes | (catch-all for PRs with no recognised PR type label) |
+
+---
+
+## 6 — Example
+
+A PR that fixes the tofu square rendering bug in vector tile street labels:
+
+```
+fix: DrawTextOnPath renders tofu square between words in street labels
+```
+
+- Labels: `PR type: 🐛 Fix`, `☢️ Experimental`  
+- Body: describes root cause, references `Fixes #3346`  
+- Base branch: `main`

--- a/.github/skills/create-pr/SKILL.md
+++ b/.github/skills/create-pr/SKILL.md
@@ -34,8 +34,15 @@ When in doubt, ask: *"Have you pushed your changes to the remote branch?"*
 
 ## 1 — Tool to use
 
-Always create pull requests via **`mcp_github_create_pull_request`**.  
+Always create pull requests via **`github-pull-request_create_pull_request`** (the VS Code GitHub Pull Requests extension tool).  
 Do **not** use `gh pr create` or any other CLI command.
+
+> `mcp_github_create_pull_request` (the GitHub MCP server tool) may fail with "Permission Denied" depending on the token scope. If it does, fall back to `github-pull-request_create_pull_request` and tell the user which tool was actually used.
+
+After creating the PR, add the PR type label via the `gh` CLI:
+```ps
+gh pr edit <number> --repo Mapsui/Mapsui --add-label "<label>"
+```
 
 ---
 

--- a/Mapsui.UI.Avalonia/MapControl.cs
+++ b/Mapsui.UI.Avalonia/MapControl.cs
@@ -157,6 +157,10 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
             if (Math.Abs(_mouseWheelPos) < 1.0) return; // Ignore the mouse wheel event if the accumulated delta is still too small
             int delta = Math.Sign(_mouseWheelPos);
             _mouseWheelPos -= delta;
+            // Clamp residual to ±1 to prevent runaway accumulation when Delta.Y > 1 (e.g. browser/WASM wheel events).
+            // Without this, prolonged scrolling in one direction builds up a large residual that makes reversing
+            // direction feel stuck.
+            _mouseWheelPos = Math.Clamp(_mouseWheelPos, -1.0, 1.0);
 
             Map.Navigator.MouseWheelZoom(delta, e.GetPosition(this).ToScreenPosition());
         }


### PR DESCRIPTION
## What

Clamp `_mouseWheelPos` to `[-1.0, 1.0]` after each zoom step in `MapControl_PointerWheelChanged` (Avalonia).

## Why

On Avalonia running in WebAssembly (browser), the browser backend delivers `e.Delta.Y` values greater than 1.0 (browsers report wheel events in line units, typically ~3 per tick). The existing accumulator logic subtracts only `±1` per event:

```csharp
int delta = Math.Sign(_mouseWheelPos);
_mouseWheelPos -= delta;
```

After scrolling in one direction, the residual grows unboundedly (e.g. 3 up-events with Delta.Y=3 leave a residual of +6). Reversing direction requires multiple events just to overcome the residual, which the user experiences as the zoom being "stuck" going one way.

The clamp limits the residual to at most one event's worth of hysteresis, so direction changes take effect immediately on the very next event.

This has no effect on desktop (Delta.Y = 1) or touchpad (Delta.Y < 1, handled by the early-return guard).

`Mapsui.UI.Avalonia12` does not need a separate change — it compiles the same `MapControl.cs` via a `<Compile Include>` link in its `.csproj`.

Fixes #2485