### PR TITLE
fix: prevent duplicate concurrent fetches and white images in RasterizingLayer

### DIFF
--- a/.github/skills/regression-tests/SKILL.md
+++ b/.github/skills/regression-tests/SKILL.md
@@ -40,6 +40,10 @@ Image paths:
 
 ## Updating reference images after intentional changes
 
+> **Only run this script when you have made a deliberate functional rendering change** (e.g. fixing a visual bug, changing a style default, adding a new rendering feature).
+> Do **not** run it to "fix" failures caused by renderer differences — if the experimental renderer produces different output for a standard sample, that is a bug to be fixed in the renderer, not papered over with new reference images.
+> There is only **one** set of reference images. The experimental renderer is expected to produce pixel-identical output to the standard renderer for all samples that are not in `ExperimentalOnlySamples`.
+
 ```powershell
 .\Scripts\CopyGeneratedImagesOverOriginalImages.ps1
 ```
@@ -56,20 +60,18 @@ Copy-Item "Tests\Mapsui.Rendering.Skia.Tests\bin\Debug\net9.0\Resources\Images\G
 
 ## Standard vs. experimental renderer
 
-The test suite can run with **either** renderer. The active renderer is determined by config files, searched in priority order:
+The test suite can run with **either** renderer. The active renderer is determined by config files at the **repository root**, searched in priority order:
 
-1. `config.local.json` in the test binary output dir (created by copying the project-level file)
-2. `config.json` in the test binary output dir (committed — default `experimentalRenderer: false`)
-3. `config.local.json` at the repository root (git-ignored, per-machine)
-4. `config.json` at the repository root
+1. `config.local.json` at the repository root (git-ignored, per-machine override)
+2. `config.json` at the repository root (committed — default `experimentalRenderer: false`)
 
 **CI always runs with the standard renderer** (`experimentalRenderer: false`). Do not assume CI uses the experimental renderer.
 
-To run locally with the experimental renderer, create `Tests/Mapsui.Rendering.Skia.Tests/config.local.json`:
+To run locally with the experimental renderer, create `config.local.json` at the **repository root**:
 ```json
 { "experimentalRenderer": true }
 ```
-This file is git-ignored and automatically copied to the binary output dir at build time.
+This file is git-ignored.
 
 ---
 
@@ -130,7 +132,7 @@ The project `.csproj` must have a matching `<EmbeddedResource>` entry. Mismatch 
 1. **Check which renderer is active**: read `Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net9.0/config.local.json` and `config.json`.
 2. **Visually compare** the generated image against the reference image — the failure message prints both paths.
 3. **Font issues**: if text is boxes, the typeface is null. Check: (a) TTF magic bytes, (b) `FetchAllFontDataAsync` was awaited, (c) `Font.FontSource` URI matches the embedded resource name, (d) renderer is experimental.
-4. **Pre-existing failures**: when running with the experimental renderer, some non-related samples may fail because their reference images were generated with the standard renderer. Only fix failures in samples you changed.
+4. **Experimental renderer failures**: the experimental renderer must produce pixel-identical output to the standard renderer for all samples **not** in `ExperimentalOnlySamples`. If a sample fails only with the experimental renderer, that is a bug in the experimental renderer — investigate and fix it. Common causes: a custom style renderer registered only on `Mapsui.Rendering.Skia.MapRenderer` but not on `Mapsui.Experimental.Rendering.Skia.MapRenderer` (fix: add the registration call for both); or a genuine rendering difference in a two-step drawable renderer.
 
 ---
 

--- a/Mapsui.Experimental.Rendering.Skia/DrawableRenderers/TwoStepSymbolStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/DrawableRenderers/TwoStepSymbolStyleRenderer.cs
@@ -19,11 +19,17 @@ namespace Mapsui.Experimental.Rendering.Skia.DrawableRenderers;
 ///   <item><description><see cref="DrawDrawable"/>: Applies viewport transform and draws
 ///         (fast, render thread).</description></item>
 /// </list>
-/// Does NOT implement <c>ISkiaStyleRenderer</c> — features that haven't been prepared yet
-/// simply won't render until the background thread catches up.
+/// Also implements <see cref="ISkiaStyleRenderer"/> as a fallback for cache misses
+/// (e.g. when a <c>ThemeStyle</c> creates a new style instance on every call).
 /// </summary>
-public class TwoStepSymbolStyleRenderer : ITwoStepStyleRenderer
+public class TwoStepSymbolStyleRenderer : ITwoStepStyleRenderer, ISkiaStyleRenderer
 {
+    private readonly SymbolStyleRenderer _fallbackRenderer = new();
+
+    /// <inheritdoc />
+    public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, IStyle style,
+        Mapsui.Rendering.RenderService renderService, long iteration)
+        => _fallbackRenderer.Draw(canvas, viewport, layer, feature, style, renderService, iteration);
     /// <inheritdoc />
     public IDrawableCache CreateCache() => new DrawableCache();
 

--- a/Mapsui.Experimental.Rendering.Skia/DrawableRenderers/TwoStepVectorStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/DrawableRenderers/TwoStepVectorStyleRenderer.cs
@@ -23,9 +23,17 @@ namespace Mapsui.Experimental.Rendering.Skia.DrawableRenderers;
 ///   <item><description><see cref="DrawDrawable"/>: Transforms and draws a single pre-created drawable
 ///         (fast, render thread).</description></item>
 /// </list>
+/// Also implements <see cref="ISkiaStyleRenderer"/> as a fallback for cache misses
+/// (e.g. when a <c>ThemeStyle</c> creates a new style instance on every call).
 /// </summary>
-public class TwoStepVectorStyleRenderer : ITwoStepStyleRenderer
+public class TwoStepVectorStyleRenderer : ITwoStepStyleRenderer, ISkiaStyleRenderer
 {
+    private readonly Mapsui.Experimental.Rendering.Skia.VectorStyleRenderer _fallbackRenderer = new();
+
+    /// <inheritdoc />
+    public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, IStyle style,
+        Mapsui.Rendering.RenderService renderService, long iteration)
+        => _fallbackRenderer.Draw(canvas, viewport, layer, feature, style, renderService, iteration);
     /// <inheritdoc />
     public IDrawableCache CreateCache() => new DrawableCache();
 

--- a/Mapsui/Layers/RasterizingLayer.cs
+++ b/Mapsui/Layers/RasterizingLayer.cs
@@ -92,12 +92,13 @@ public class RasterizingLayer : BaseLayer, IFetchableSource, ISourceLayer
                     return;
 
                 _currentSection = _fetchInfo.Section;
-
-                using var bitmapStream = _rasterizer.RenderToBitmapStream(ToViewport(_currentSection),
+                var innerViewport = ToViewport(_currentSection);
+                using var bitmapStream = _rasterizer.RenderToBitmapStream(innerViewport,
                     [_sourceLayer], _renderService, pixelDensity: _pixelDensity, renderFormat: _renderFormat);
 
                 _cache.Clear();
-                var rasterFeature = new RasterFeature(new MRaster(bitmapStream.ToArray(), _currentSection.Extent));
+                var bitmapBytes = bitmapStream.ToArray();
+                var rasterFeature = new RasterFeature(new MRaster(bitmapBytes, _currentSection.Extent));
                 _cache.PushRange([rasterFeature]);
                 OnDataChanged(new DataChangedEventArgs(Name));
             }
@@ -142,13 +143,19 @@ public class RasterizingLayer : BaseLayer, IFetchableSource, ISourceLayer
 
     public FetchJob[] GetFetchJobs(int activeFetchCount, int availableFetchSlots)
     {
+        // Prevent duplicate concurrent fetches for this layer, matching the same guard in Layer.GetFetchJobs.
+        // Without this, DataFetcher.ViewportChangedAsync could start a second task that calls RasterizeAsync
+        // on an empty cache while the first task is still loading data, producing a white image.
+        if (activeFetchCount > 0)
+            return [];
+
         if (_latestFetchInfo.TryTake(out var fetchInfo))
         {
             _fetchInfo = fetchInfo;
 
             if (_sourceLayer is IFetchableSource fetchableSource)
                 return [
-                    new FetchJob(_sourceLayer.Id, async () =>
+                    new FetchJob(Id, async () =>
                     {
                         var fetchJobs = fetchableSource.GetFetchJobs(activeFetchCount, availableFetchSlots);
                         foreach (var fetchJob in fetchJobs)
@@ -159,7 +166,7 @@ public class RasterizingLayer : BaseLayer, IFetchableSource, ISourceLayer
                     })
                 ];
             else
-                return [new FetchJob(_sourceLayer.Id, RasterizeAsync)];
+                return [new FetchJob(Id, RasterizeAsync)];
         }
         return [];
     }

--- a/Mapsui/Rendering/VisibleFeatureIterator.cs
+++ b/Mapsui/Rendering/VisibleFeatureIterator.cs
@@ -52,9 +52,9 @@ public static class VisibleFeatureIterator
         var features = layer.SortFeatures(layer.GetFeatures(extent, viewport.Resolution)).ToList();
 
         // Part 1. Styles on the layer
-        var layerStyles = layer.Style.GetStylesToApply(viewport.Resolution);
+        var layerStylesList = layer.Style.GetStylesToApply(viewport.Resolution).ToList();
 
-        foreach (var layerStyle in layerStyles)
+        foreach (var layerStyle in layerStylesList)
         {
             foreach (var feature in features)
             {
@@ -66,8 +66,7 @@ public static class VisibleFeatureIterator
                 // }
                 if (layerStyle is IThemeStyle themeStyle)
                 {
-                    var stylesFromThemeStyle = themeStyle.GetStyle(feature, viewport).GetStylesToApply(viewport.Resolution);
-                    foreach (var styleFromThemeStyle in stylesFromThemeStyle)
+                    foreach (var styleFromThemeStyle in themeStyle.GetStyle(feature, viewport).GetStylesToApply(viewport.Resolution))
                     {
                         callback(viewport, layer, styleFromThemeStyle, feature, (float)layer.Opacity, iteration);
                     }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/CustomPointStyleShaderSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/CustomPointStyleShaderSample.cs
@@ -35,6 +35,7 @@ public class CustomPointStyleShaderSample : ISample
         map.Widgets.Add(new MapInfoWidget(map, [map.Layers.Last()]));
 
         MapRenderer.RegisterPointStyleRenderer("custom-style-shader", MyBasicCustomStyleRenderer);
+        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-shader", MyBasicCustomStyleRenderer);
         return map;
     }
 

--- a/Tests/Mapsui.Rendering.Skia.Tests/Mapsui.Rendering.Skia.Tests.csproj
+++ b/Tests/Mapsui.Rendering.Skia.Tests/Mapsui.Rendering.Skia.Tests.csproj
@@ -43,17 +43,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- config.json is committed and contains default test settings (see TestConfiguration.cs). -->
-    <!-- config.local.json is git-ignored and overrides config.json when present. -->
-    <None Include="config.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="config.local.json" Condition="Exists('config.local.json')">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="Resources\Cache\ArcGisImageServiceSample.sqlite">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Tests/Mapsui.Rendering.Skia.Tests/TestConfiguration.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/TestConfiguration.cs
@@ -1,17 +1,13 @@
 // TestConfiguration runs once before any test in this assembly (NUnit SetUpFixture).
-// It reads config files in priority order:
-//   1. config.local.json in the test binary directory   — per-machine override, git-ignored
-//   2. config.json in the test binary directory         — project-level default (experimentalRenderer: false)
-//   3. config.local.json at the repository root         — per-machine override, git-ignored
-//   4. config.json at the repository root               — repo-wide default
+// It reads config files at the repository root in priority order:
+//   1. config.local.json at the repository root  — per-machine override, git-ignored
+//   2. config.json at the repository root         — repo-wide default (experimentalRenderer: false)
 //
 // The repository root is located by walking up from the test binary directory until
 // a directory containing Mapsui.slnx is found.
 //
 // To switch to the experimental renderer locally:
-//   - Create config.local.json at the repository root with { "experimentalRenderer": true }, or
-//   - Create config.local.json next to the .csproj with { "experimentalRenderer": true }
-//     and rebuild — the file is copied to the output directory automatically.
+//   Create config.local.json at the repository root with { "experimentalRenderer": true }
 
 using Mapsui.Experimental.Rendering.Skia;
 using Mapsui.Rendering.Skia.Tests;
@@ -37,15 +33,10 @@ public class TestConfiguration
         var dir = System.IO.Path.GetDirectoryName(typeof(TestConfiguration).Assembly.Location)
                   ?? System.AppDomain.CurrentDomain.BaseDirectory;
 
-        // Binary-dir configs take priority (allow per-project overrides).
-        var cfg = ReadConfig(System.IO.Path.Combine(dir, "config.local.json"))
-                  ?? ReadConfig(System.IO.Path.Combine(dir, "config.json"));
-        if (cfg != null) return cfg.ExperimentalRenderer;
-
-        // Fall back to the repository-root config.
         var root = FindRepoRoot(dir);
-        if (root != null)
-            cfg = ReadConfig(System.IO.Path.Combine(root, "config.local.json"))
+        if (root == null) return false;
+
+        var cfg = ReadConfig(System.IO.Path.Combine(root, "config.local.json"))
                   ?? ReadConfig(System.IO.Path.Combine(root, "config.json"));
         return cfg?.ExperimentalRenderer == true;
     }

--- a/Tests/Mapsui.Rendering.Skia.Tests/config.json
+++ b/Tests/Mapsui.Rendering.Skia.Tests/config.json
@@ -1,3 +1,0 @@
-{
-  "experimentalRenderer": false
-}


### PR DESCRIPTION
## What changed

Several issues were found while investigating failures in the rendering regression tests.

### `RasterizingLayer` (main fix)
- **Prevent duplicate concurrent fetches**: `GetFetchJobs` now returns an empty array when `activeFetchCount > 0`, matching the same guard already present in `Layer.GetFetchJobs`. Without this, `DataFetcher.ViewportChangedAsync` could start a second rasterize task while the first was still loading data, causing the layer to render a white image.
- **Use the correct `FetchJob` ID**: `FetchJob` was constructed with `_sourceLayer.Id` instead of the rasterizing layer's own `Id`. This made the `activeFetchCount` guard ineffective because job tracking is keyed by layer ID.

### `TwoStepSymbolStyleRenderer` / `TwoStepVectorStyleRenderer` (experimental renderer)
- Both now implement `ISkiaStyleRenderer` as a **fallback for cache misses**. A `ThemeStyle` creates a new style instance on every `GetStyle()` call, producing a new `GenerationId` each time — so the drawable cache always misses, and features were silently not rendered. The fallback delegates directly to the underlying `SymbolStyleRenderer` / `VectorStyleRenderer` and fixes this case (e.g. `SelectionStyleSample`).

### `VisibleFeatureIterator`
- `layerStyles` is now materialised to a list before iteration (minor cleanup, no behavioral change).

### `CustomPointStyleShaderSample`
- The custom renderer was only registered on `Mapsui.Rendering.Skia.MapRenderer`. Added the matching registration on `Mapsui.Experimental.Rendering.Skia.MapRenderer`, consistent with `CustomPointStyleBasicSample` and `CustomPointStyleAdvancedSample`.

### Regression test config
- Removed the test-project-level `config.json` / `config.local.json` lookup. `TestConfiguration` now reads only from the repository root, so there is a single authoritative config location.

### Skill / documentation
- Updated `regression-tests` skill to clarify that the copy-images script is for intentional rendering changes only, and that the experimental renderer must produce pixel-identical output to the standard renderer for all non-`ExperimentalOnlySamples` samples.