### PR TITLE
feat: add image comparison tool with overlay diff and colour picker

### DIFF
--- a/.github/skills/regression-tests/SKILL.md
+++ b/.github/skills/regression-tests/SKILL.md
@@ -40,6 +40,10 @@ Image paths:
 
 ## Updating reference images after intentional changes
 
+> **Only run this script when you have made a deliberate functional rendering change** (e.g. fixing a visual bug, changing a style default, adding a new rendering feature).
+> Do **not** run it to "fix" failures caused by renderer differences — if the experimental renderer produces different output for a standard sample, that is a bug to be fixed in the renderer, not papered over with new reference images.
+> There is only **one** set of reference images. The experimental renderer is expected to produce pixel-identical output to the standard renderer for all samples that are not in `ExperimentalOnlySamples`.
+
 ```powershell
 .\Scripts\CopyGeneratedImagesOverOriginalImages.ps1
 ```
@@ -56,20 +60,18 @@ Copy-Item "Tests\Mapsui.Rendering.Skia.Tests\bin\Debug\net9.0\Resources\Images\G
 
 ## Standard vs. experimental renderer
 
-The test suite can run with **either** renderer. The active renderer is determined by config files, searched in priority order:
+The test suite can run with **either** renderer. The active renderer is determined by config files at the **repository root**, searched in priority order:
 
-1. `config.local.json` in the test binary output dir (created by copying the project-level file)
-2. `config.json` in the test binary output dir (committed — default `experimentalRenderer: false`)
-3. `config.local.json` at the repository root (git-ignored, per-machine)
-4. `config.json` at the repository root
+1. `config.local.json` at the repository root (git-ignored, per-machine override)
+2. `config.json` at the repository root (committed — default `experimentalRenderer: false`)
 
 **CI always runs with the standard renderer** (`experimentalRenderer: false`). Do not assume CI uses the experimental renderer.
 
-To run locally with the experimental renderer, create `Tests/Mapsui.Rendering.Skia.Tests/config.local.json`:
+To run locally with the experimental renderer, create `config.local.json` at the **repository root**:
 ```json
 { "experimentalRenderer": true }
 ```
-This file is git-ignored and automatically copied to the binary output dir at build time.
+This file is git-ignored.
 
 ---
 
@@ -130,7 +132,7 @@ The project `.csproj` must have a matching `<EmbeddedResource>` entry. Mismatch 
 1. **Check which renderer is active**: read `Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net9.0/config.local.json` and `config.json`.
 2. **Visually compare** the generated image against the reference image — the failure message prints both paths.
 3. **Font issues**: if text is boxes, the typeface is null. Check: (a) TTF magic bytes, (b) `FetchAllFontDataAsync` was awaited, (c) `Font.FontSource` URI matches the embedded resource name, (d) renderer is experimental.
-4. **Pre-existing failures**: when running with the experimental renderer, some non-related samples may fail because their reference images were generated with the standard renderer. Only fix failures in samples you changed.
+4. **Experimental renderer failures**: the experimental renderer must produce pixel-identical output to the standard renderer for all samples **not** in `ExperimentalOnlySamples`. If a sample fails only with the experimental renderer, that is a bug in the experimental renderer — investigate and fix it. Common causes: a custom style renderer registered only on `Mapsui.Rendering.Skia.MapRenderer` but not on `Mapsui.Experimental.Rendering.Skia.MapRenderer` (fix: add the registration call for both); or a genuine rendering difference in a two-step drawable renderer.
 
 ---
 

--- a/Mapsui.Experimental.Rendering.Skia/DrawableRenderers/TwoStepSymbolStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/DrawableRenderers/TwoStepSymbolStyleRenderer.cs
@@ -19,11 +19,17 @@ namespace Mapsui.Experimental.Rendering.Skia.DrawableRenderers;
 ///   <item><description><see cref="DrawDrawable"/>: Applies viewport transform and draws
 ///         (fast, render thread).</description></item>
 /// </list>
-/// Does NOT implement <c>ISkiaStyleRenderer</c> — features that haven't been prepared yet
-/// simply won't render until the background thread catches up.
+/// Also implements <see cref="ISkiaStyleRenderer"/> as a fallback for cache misses
+/// (e.g. when a <c>ThemeStyle</c> creates a new style instance on every call).
 /// </summary>
-public class TwoStepSymbolStyleRenderer : ITwoStepStyleRenderer
+public class TwoStepSymbolStyleRenderer : ITwoStepStyleRenderer, ISkiaStyleRenderer
 {
+    private readonly SymbolStyleRenderer _fallbackRenderer = new();
+
+    /// <inheritdoc />
+    public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, IStyle style,
+        Mapsui.Rendering.RenderService renderService, long iteration)
+        => _fallbackRenderer.Draw(canvas, viewport, layer, feature, style, renderService, iteration);
     /// <inheritdoc />
     public IDrawableCache CreateCache() => new DrawableCache();
 

--- a/Mapsui.Experimental.Rendering.Skia/DrawableRenderers/TwoStepVectorStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/DrawableRenderers/TwoStepVectorStyleRenderer.cs
@@ -23,9 +23,17 @@ namespace Mapsui.Experimental.Rendering.Skia.DrawableRenderers;
 ///   <item><description><see cref="DrawDrawable"/>: Transforms and draws a single pre-created drawable
 ///         (fast, render thread).</description></item>
 /// </list>
+/// Also implements <see cref="ISkiaStyleRenderer"/> as a fallback for cache misses
+/// (e.g. when a <c>ThemeStyle</c> creates a new style instance on every call).
 /// </summary>
-public class TwoStepVectorStyleRenderer : ITwoStepStyleRenderer
+public class TwoStepVectorStyleRenderer : ITwoStepStyleRenderer, ISkiaStyleRenderer
 {
+    private readonly Mapsui.Experimental.Rendering.Skia.VectorStyleRenderer _fallbackRenderer = new();
+
+    /// <inheritdoc />
+    public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, IStyle style,
+        Mapsui.Rendering.RenderService renderService, long iteration)
+        => _fallbackRenderer.Draw(canvas, viewport, layer, feature, style, renderService, iteration);
     /// <inheritdoc />
     public IDrawableCache CreateCache() => new DrawableCache();
 

--- a/Mapsui.slnx
+++ b/Mapsui.slnx
@@ -334,6 +334,12 @@
       <BuildType Solution="AppStore|*" Project="Debug" />
     </Project>
   </Folder>
+  <Folder Name="/Tools/">
+    <Project Path="Tools/Mapsui.Tools.ImageComparison/Mapsui.Tools.ImageComparison.csproj">
+      <BuildType Solution="Ad-Hoc|*" Project="Debug" />
+      <BuildType Solution="AppStore|*" Project="Debug" />
+    </Project>
+  </Folder>
   <Project Path="Mapsui.ArcGIS/Mapsui.ArcGIS.csproj">
     <BuildType Solution="Ad-Hoc|*" Project="Debug" />
     <BuildType Solution="AppStore|*" Project="Debug" />

--- a/Mapsui/Layers/RasterizingLayer.cs
+++ b/Mapsui/Layers/RasterizingLayer.cs
@@ -92,12 +92,13 @@ public class RasterizingLayer : BaseLayer, IFetchableSource, ISourceLayer
                     return;
 
                 _currentSection = _fetchInfo.Section;
-
-                using var bitmapStream = _rasterizer.RenderToBitmapStream(ToViewport(_currentSection),
+                var innerViewport = ToViewport(_currentSection);
+                using var bitmapStream = _rasterizer.RenderToBitmapStream(innerViewport,
                     [_sourceLayer], _renderService, pixelDensity: _pixelDensity, renderFormat: _renderFormat);
 
                 _cache.Clear();
-                var rasterFeature = new RasterFeature(new MRaster(bitmapStream.ToArray(), _currentSection.Extent));
+                var bitmapBytes = bitmapStream.ToArray();
+                var rasterFeature = new RasterFeature(new MRaster(bitmapBytes, _currentSection.Extent));
                 _cache.PushRange([rasterFeature]);
                 OnDataChanged(new DataChangedEventArgs(Name));
             }
@@ -142,13 +143,19 @@ public class RasterizingLayer : BaseLayer, IFetchableSource, ISourceLayer
 
     public FetchJob[] GetFetchJobs(int activeFetchCount, int availableFetchSlots)
     {
+        // Prevent duplicate concurrent fetches for this layer, matching the same guard in Layer.GetFetchJobs.
+        // Without this, DataFetcher.ViewportChangedAsync could start a second task that calls RasterizeAsync
+        // on an empty cache while the first task is still loading data, producing a white image.
+        if (activeFetchCount > 0)
+            return [];
+
         if (_latestFetchInfo.TryTake(out var fetchInfo))
         {
             _fetchInfo = fetchInfo;
 
             if (_sourceLayer is IFetchableSource fetchableSource)
                 return [
-                    new FetchJob(_sourceLayer.Id, async () =>
+                    new FetchJob(Id, async () =>
                     {
                         var fetchJobs = fetchableSource.GetFetchJobs(activeFetchCount, availableFetchSlots);
                         foreach (var fetchJob in fetchJobs)
@@ -159,7 +166,7 @@ public class RasterizingLayer : BaseLayer, IFetchableSource, ISourceLayer
                     })
                 ];
             else
-                return [new FetchJob(_sourceLayer.Id, RasterizeAsync)];
+                return [new FetchJob(Id, RasterizeAsync)];
         }
         return [];
     }

--- a/Mapsui/Rendering/VisibleFeatureIterator.cs
+++ b/Mapsui/Rendering/VisibleFeatureIterator.cs
@@ -52,9 +52,9 @@ public static class VisibleFeatureIterator
         var features = layer.SortFeatures(layer.GetFeatures(extent, viewport.Resolution)).ToList();
 
         // Part 1. Styles on the layer
-        var layerStyles = layer.Style.GetStylesToApply(viewport.Resolution);
+        var layerStylesList = layer.Style.GetStylesToApply(viewport.Resolution).ToList();
 
-        foreach (var layerStyle in layerStyles)
+        foreach (var layerStyle in layerStylesList)
         {
             foreach (var feature in features)
             {
@@ -66,8 +66,7 @@ public static class VisibleFeatureIterator
                 // }
                 if (layerStyle is IThemeStyle themeStyle)
                 {
-                    var stylesFromThemeStyle = themeStyle.GetStyle(feature, viewport).GetStylesToApply(viewport.Resolution);
-                    foreach (var styleFromThemeStyle in stylesFromThemeStyle)
+                    foreach (var styleFromThemeStyle in themeStyle.GetStyle(feature, viewport).GetStylesToApply(viewport.Resolution))
                     {
                         callback(viewport, layer, styleFromThemeStyle, feature, (float)layer.Opacity, iteration);
                     }

--- a/Samples/Mapsui.Samples.Common/Maps/Styles/CustomPointStyleShaderSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/Styles/CustomPointStyleShaderSample.cs
@@ -35,6 +35,7 @@ public class CustomPointStyleShaderSample : ISample
         map.Widgets.Add(new MapInfoWidget(map, [map.Layers.Last()]));
 
         MapRenderer.RegisterPointStyleRenderer("custom-style-shader", MyBasicCustomStyleRenderer);
+        Mapsui.Experimental.Rendering.Skia.MapRenderer.RegisterPointStyleRenderer("custom-style-shader", MyBasicCustomStyleRenderer);
         return map;
     }
 

--- a/Tests/Mapsui.Rendering.Skia.Tests/Mapsui.Rendering.Skia.Tests.csproj
+++ b/Tests/Mapsui.Rendering.Skia.Tests/Mapsui.Rendering.Skia.Tests.csproj
@@ -43,17 +43,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- config.json is committed and contains default test settings (see TestConfiguration.cs). -->
-    <!-- config.local.json is git-ignored and overrides config.json when present. -->
-    <None Include="config.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="config.local.json" Condition="Exists('config.local.json')">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="Resources\Cache\ArcGisImageServiceSample.sqlite">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Tests/Mapsui.Rendering.Skia.Tests/TestConfiguration.cs
+++ b/Tests/Mapsui.Rendering.Skia.Tests/TestConfiguration.cs
@@ -1,17 +1,13 @@
 // TestConfiguration runs once before any test in this assembly (NUnit SetUpFixture).
-// It reads config files in priority order:
-//   1. config.local.json in the test binary directory   — per-machine override, git-ignored
-//   2. config.json in the test binary directory         — project-level default (experimentalRenderer: false)
-//   3. config.local.json at the repository root         — per-machine override, git-ignored
-//   4. config.json at the repository root               — repo-wide default
+// It reads config files at the repository root in priority order:
+//   1. config.local.json at the repository root  — per-machine override, git-ignored
+//   2. config.json at the repository root         — repo-wide default (experimentalRenderer: false)
 //
 // The repository root is located by walking up from the test binary directory until
 // a directory containing Mapsui.slnx is found.
 //
 // To switch to the experimental renderer locally:
-//   - Create config.local.json at the repository root with { "experimentalRenderer": true }, or
-//   - Create config.local.json next to the .csproj with { "experimentalRenderer": true }
-//     and rebuild — the file is copied to the output directory automatically.
+//   Create config.local.json at the repository root with { "experimentalRenderer": true }
 
 using Mapsui.Experimental.Rendering.Skia;
 using Mapsui.Rendering.Skia.Tests;
@@ -37,15 +33,10 @@ public class TestConfiguration
         var dir = System.IO.Path.GetDirectoryName(typeof(TestConfiguration).Assembly.Location)
                   ?? System.AppDomain.CurrentDomain.BaseDirectory;
 
-        // Binary-dir configs take priority (allow per-project overrides).
-        var cfg = ReadConfig(System.IO.Path.Combine(dir, "config.local.json"))
-                  ?? ReadConfig(System.IO.Path.Combine(dir, "config.json"));
-        if (cfg != null) return cfg.ExperimentalRenderer;
-
-        // Fall back to the repository-root config.
         var root = FindRepoRoot(dir);
-        if (root != null)
-            cfg = ReadConfig(System.IO.Path.Combine(root, "config.local.json"))
+        if (root == null) return false;
+
+        var cfg = ReadConfig(System.IO.Path.Combine(root, "config.local.json"))
                   ?? ReadConfig(System.IO.Path.Combine(root, "config.json"));
         return cfg?.ExperimentalRenderer == true;
     }

--- a/Tests/Mapsui.Rendering.Skia.Tests/config.json
+++ b/Tests/Mapsui.Rendering.Skia.Tests/config.json
@@ -1,3 +1,0 @@
-{
-  "experimentalRenderer": false
-}

--- a/Tools/Mapsui.Tools.ImageComparison/App.axaml
+++ b/Tools/Mapsui.Tools.ImageComparison/App.axaml
@@ -1,0 +1,8 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Mapsui.Tools.ImageComparison.App"
+             RequestedThemeVariant="Default">
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/Tools/Mapsui.Tools.ImageComparison/App.axaml.cs
+++ b/Tools/Mapsui.Tools.ImageComparison/App.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using Mapsui.Tools.ImageComparison.Views;
+
+namespace Mapsui.Tools.ImageComparison;
+
+public partial class App : Application
+{
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            desktop.MainWindow = new MainWindow();
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/Tools/Mapsui.Tools.ImageComparison/Config.cs
+++ b/Tools/Mapsui.Tools.ImageComparison/Config.cs
@@ -1,0 +1,9 @@
+namespace Mapsui.Tools.ImageComparison;
+
+static class Config
+{
+    public const string RootPath = @"C:\code\github\Mapsui\Tests\Mapsui.Rendering.Skia.Tests";
+    public const string OriginalRelPath = "Resources/Images/OriginalRegression";
+    // NOTE: 'net9.0' must match the test project TFM; update if .NET version changes
+    public const string GenRelPath = "bin/Debug/net9.0/Resources/Images/GeneratedRegression";
+}

--- a/Tools/Mapsui.Tools.ImageComparison/Mapsui.Tools.ImageComparison.csproj
+++ b/Tools/Mapsui.Tools.ImageComparison/Mapsui.Tools.ImageComparison.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" VersionOverride="$(Avalonia12Version)" />
+    <PackageReference Include="Avalonia.Desktop" VersionOverride="$(Avalonia12Version)" />
+    <PackageReference Include="Avalonia.Skia" VersionOverride="$(Avalonia12Version)" />
+    <PackageReference Include="Avalonia.Themes.Fluent" VersionOverride="$(Avalonia12Version)" />
+    <PackageReference Include="Avalonia.Fonts.Inter" VersionOverride="$(Avalonia12Version)" />
+    <PackageReference Include="ReactiveUI.Avalonia" VersionOverride="12.0.1" />
+    <PackageReference Include="SkiaSharp" VersionOverride="$(Avalonia12SkiaSharpVersion)" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" VersionOverride="$(Avalonia12SkiaSharpVersion)" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" VersionOverride="$(Avalonia12SkiaSharpVersion)" />
+    <PackageReference Include="HarfBuzzSharp" VersionOverride="$(Avalonia12HarfBuzzSharpVersion)" />
+  </ItemGroup>
+</Project>

--- a/Tools/Mapsui.Tools.ImageComparison/Program.cs
+++ b/Tools/Mapsui.Tools.ImageComparison/Program.cs
@@ -1,0 +1,28 @@
+using System;
+using Avalonia;
+using ReactiveUI.Avalonia;
+
+namespace Mapsui.Tools.ImageComparison;
+
+class Program
+{
+    [STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp()
+        .StartWithClassicDesktopLifetime(args);
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .With(new Win32PlatformOptions
+            {
+                RenderingMode = [
+                    Win32RenderingMode.Vulkan,
+                    Win32RenderingMode.AngleEgl,
+                    Win32RenderingMode.Wgl,
+                    Win32RenderingMode.Software,
+                ],
+            })
+            .LogToTrace()
+            .WithInterFont()
+            .UseReactiveUI(_ => { });
+}

--- a/Tools/Mapsui.Tools.ImageComparison/Services/ImageDiffService.cs
+++ b/Tools/Mapsui.Tools.ImageComparison/Services/ImageDiffService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using Avalonia.Media.Imaging;
+using SkiaSharp;
+
+namespace Mapsui.Tools.ImageComparison.Services;
+
+static class ImageDiffService
+{
+    public static Bitmap? LoadThumbnail(string path, int maxWidth = 140)
+    {
+        using var original = LoadSkBitmap(path);
+        if (original is null) return null;
+
+        var scale = (float)maxWidth / original.Width;
+        var newHeight = (int)(original.Height * scale);
+        using var resized = original.Resize(new SKImageInfo(maxWidth, newHeight), SKSamplingOptions.Default);
+        return resized is null ? null : ToAvaloniaBitmap(resized);
+    }
+
+    public static SKBitmap? LoadSkBitmap(string path)
+    {
+        if (!File.Exists(path)) return null;
+        return SKBitmap.Decode(path);
+    }
+
+    // Returns a bitmap with diffColor pixels where images differ, transparent elsewhere.
+    public static (SKBitmap Overlay, int DiffPixels) ComputeDiffOverlay(SKBitmap original, SKBitmap generated, SKColor diffColor)
+    {
+        var w = Math.Max(original.Width, generated.Width);
+        var h = Math.Max(original.Height, generated.Height);
+
+        var pixels1 = GetPixels(original, w, h);
+        var pixels2 = GetPixels(generated, w, h);
+
+        var overlayPixels = new SKColor[w * h];
+        var diffCount = 0;
+        for (var i = 0; i < overlayPixels.Length; i++)
+        {
+            if (pixels1[i] != pixels2[i])
+            {
+                overlayPixels[i] = diffColor;
+                diffCount++;
+            }
+            // matching pixels stay transparent (default SKColor is (0,0,0,0))
+        }
+
+        var overlay = new SKBitmap(w, h);
+        overlay.Pixels = overlayPixels;
+        return (overlay, diffCount);
+    }
+
+    public static Bitmap ToAvaloniaBitmap(SKBitmap skBitmap)
+    {
+        using var image = SKImage.FromBitmap(skBitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var ms = new MemoryStream(data.ToArray());
+        return new Bitmap(ms);
+    }
+
+    static SKColor[] GetPixels(SKBitmap src, int w, int h)
+    {
+        if (src.Width == w && src.Height == h) return src.Pixels;
+        // Pad to target size with transparent pixels
+        using var padded = new SKBitmap(w, h);
+        using var canvas = new SKCanvas(padded);
+        canvas.Clear(SKColors.Transparent);
+        canvas.DrawBitmap(src, 0, 0);
+        return padded.Pixels;
+    }
+}

--- a/Tools/Mapsui.Tools.ImageComparison/Services/SettingsService.cs
+++ b/Tools/Mapsui.Tools.ImageComparison/Services/SettingsService.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Mapsui.Tools.ImageComparison.Services;
+
+class SettingsService
+{
+    static readonly string _path = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Mapsui", "ImageComparison", "settings.json");
+
+    record SettingsData(string RootPath);
+
+    public string LoadRootPath()
+    {
+        try
+        {
+            if (!File.Exists(_path)) return Config.RootPath;
+            var data = JsonSerializer.Deserialize<SettingsData>(File.ReadAllText(_path));
+            return data?.RootPath ?? Config.RootPath;
+        }
+        catch
+        {
+            return Config.RootPath;
+        }
+    }
+
+    public void SaveRootPath(string rootPath)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+            File.WriteAllText(_path, JsonSerializer.Serialize(new SettingsData(rootPath)));
+        }
+        catch { /* best effort */ }
+    }
+}

--- a/Tools/Mapsui.Tools.ImageComparison/ViewModels/MainViewModel.cs
+++ b/Tools/Mapsui.Tools.ImageComparison/ViewModels/MainViewModel.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Reactive;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Mapsui.Tools.ImageComparison.Services;
+using ReactiveUI;
+using SkiaSharp;
+
+namespace Mapsui.Tools.ImageComparison.ViewModels;
+
+enum DiffMode { GeneratedOnly = 0, GeneratedWithDiff = 1, DiffOnly = 2 }
+
+sealed record DiffColorOption(string Name, Color Color)
+{
+    public SolidColorBrush Brush { get; } = new(Color);
+}
+
+sealed class MainViewModel : ReactiveObject, IDisposable
+{
+    readonly SettingsService _settings = new();
+    readonly Func<Task<string?>> _pickFolder;
+
+    string _rootPath;
+    TestEntryViewModel? _selectedEntry;
+    Bitmap? _originalBitmap;
+    Bitmap? _diffOverlayBitmap;
+    Bitmap? _generatedBitmap;
+    string? _loadedOrigPath;
+    string? _loadedGenPath;
+    bool _hasGenerated;
+    int _selectedDiffMode = (int)DiffMode.GeneratedWithDiff;
+    DiffColorOption _selectedDiffColorOption = DiffColorPalette[0];
+    string _statusMessage = string.Empty;
+    CancellationTokenSource _thumbCts = new();
+
+    public static IReadOnlyList<DiffColorOption> DiffColorPalette { get; } =
+    [
+        new("Red",     Colors.Red),
+        new("Yellow",  Colors.Yellow),
+        new("Cyan",    Colors.Cyan),
+        new("Magenta", Colors.Magenta),
+        new("White",   Colors.White),
+    ];
+
+    public MainViewModel(Func<Task<string?>> pickFolder)
+    {
+        _pickFolder = pickFolder;
+        _rootPath = _settings.LoadRootPath();
+        TestEntries = [];
+
+        PickRootCommand = ReactiveCommand.CreateFromTask(PickRootAsync);
+        RefreshCommand = ReactiveCommand.CreateFromTask(LoadTestNamesAsync);
+
+        _ = LoadTestNamesAsync();
+    }
+
+    public string RootPath
+    {
+        get => _rootPath;
+        private set => this.RaiseAndSetIfChanged(ref _rootPath, value);
+    }
+
+    public ObservableCollection<TestEntryViewModel> TestEntries { get; }
+
+    public TestEntryViewModel? SelectedEntry
+    {
+        get => _selectedEntry;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _selectedEntry, value);
+            _ = LoadImagesAsync();
+        }
+    }
+
+    public Bitmap? OriginalBitmap
+    {
+        get => _originalBitmap;
+        private set => this.RaiseAndSetIfChanged(ref _originalBitmap, value);
+    }
+
+    public Bitmap? DiffOverlayBitmap
+    {
+        get => _diffOverlayBitmap;
+        private set => this.RaiseAndSetIfChanged(ref _diffOverlayBitmap, value);
+    }
+
+    public int SelectedDiffMode
+    {
+        get => _selectedDiffMode;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _selectedDiffMode, value);
+            this.RaisePropertyChanged(nameof(ShowGeneratedImage));
+            this.RaisePropertyChanged(nameof(ShowDiffOverlay));
+        }
+    }
+
+    public DiffColorOption SelectedDiffColorOption
+    {
+        get => _selectedDiffColorOption;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _selectedDiffColorOption, value);
+            _ = RecomputeOverlayAsync();
+        }
+    }
+
+    public bool ShowGeneratedImage => _hasGenerated && _selectedDiffMode != (int)DiffMode.DiffOnly;
+    public bool ShowDiffOverlay => _hasGenerated && _selectedDiffMode != (int)DiffMode.GeneratedOnly;
+
+    public Bitmap? GeneratedBitmap
+    {
+        get => _generatedBitmap;
+        private set => this.RaiseAndSetIfChanged(ref _generatedBitmap, value);
+    }
+
+    public bool HasGenerated
+    {
+        get => _hasGenerated;
+        private set
+        {
+            this.RaiseAndSetIfChanged(ref _hasGenerated, value);
+            this.RaisePropertyChanged(nameof(ShowGeneratedImage));
+            this.RaisePropertyChanged(nameof(ShowDiffOverlay));
+        }
+    }
+
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        private set => this.RaiseAndSetIfChanged(ref _statusMessage, value);
+    }
+
+    public ReactiveCommand<Unit, Unit> PickRootCommand { get; }
+    public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+
+    async Task PickRootAsync()
+    {
+        var path = await _pickFolder();
+        if (path is null) return;
+        RootPath = path;
+        _settings.SaveRootPath(path);
+        await LoadTestNamesAsync();
+    }
+
+    async Task LoadTestNamesAsync()
+    {
+        var origDir = Path.Combine(RootPath,
+            Config.OriginalRelPath.Replace('/', Path.DirectorySeparatorChar));
+
+        // Cancel any in-progress thumbnail loading
+        await _thumbCts.CancelAsync();
+        _thumbCts.Dispose();
+        _thumbCts = new CancellationTokenSource();
+
+        foreach (var entry in TestEntries) entry.Dispose();
+        TestEntries.Clear();
+        ClearImages();
+
+        if (!Directory.Exists(origDir))
+        {
+            StatusMessage = $"Original folder not found: {origDir}";
+            return;
+        }
+
+        var files = await Task.Run(() =>
+        {
+            var f = Directory.GetFiles(origDir, "*.png");
+            Array.Sort(f);
+            return f;
+        });
+
+        foreach (var f in files)
+            TestEntries.Add(new TestEntryViewModel(Path.GetFileNameWithoutExtension(f)));
+
+        StatusMessage = TestEntries.Count == 0
+            ? $"No PNG files found in: {origDir}"
+            : $"{TestEntries.Count} test images";
+
+        // Auto-select the first image so the comparison is visible immediately
+        if (TestEntries.Count > 0 && SelectedEntry is null)
+            SelectedEntry = TestEntries[0];
+
+        // Load thumbnails in the background with limited parallelism
+        _ = LoadThumbnailsAsync(origDir, [.. TestEntries], _thumbCts.Token);
+    }
+
+    async Task LoadThumbnailsAsync(string origDir, TestEntryViewModel[] entries, CancellationToken ct)
+    {
+        using var semaphore = new SemaphoreSlim(4, 4);
+
+        await Task.WhenAll(entries.Select(async entry =>
+        {
+            await semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (ct.IsCancellationRequested) return;
+                var path = Path.Combine(origDir, entry.Name + ".png");
+                entry.Thumbnail = await Task.Run(() => ImageDiffService.LoadThumbnail(path), ct)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { /* expected on cancellation */ }
+            finally
+            {
+                semaphore.Release();
+            }
+        }));
+    }
+
+    async Task LoadImagesAsync()
+    {
+        if (_selectedEntry is null) return;
+
+        var origDir = Path.Combine(RootPath,
+            Config.OriginalRelPath.Replace('/', Path.DirectorySeparatorChar));
+        var genDir = Path.Combine(RootPath,
+            Config.GenRelPath.Replace('/', Path.DirectorySeparatorChar));
+
+        ClearImages();
+        StatusMessage = "Loading…";
+
+        var origPath = Path.Combine(origDir, _selectedEntry.Name + ".png");
+        var genPath = Path.Combine(genDir, _selectedEntry.Name + ".png");
+
+        var c = _selectedDiffColorOption.Color;
+        var skColor = new SKColor(c.R, c.G, c.B, c.A);
+
+        var (origAva, genAva, overlayAva, diffCount, error) = await Task.Run(() =>
+        {
+            Bitmap? orig = null;
+            Bitmap? gen = null;
+            Bitmap? overlay = null;
+            try
+            {
+                using var origSk = ImageDiffService.LoadSkBitmap(origPath);
+                if (origSk is null)
+                    return ((Bitmap?)null, (Bitmap?)null, (Bitmap?)null, 0,
+                        $"Original image not found: {origPath}");
+
+                orig = ImageDiffService.ToAvaloniaBitmap(origSk);
+
+                using var genSk = ImageDiffService.LoadSkBitmap(genPath);
+                if (genSk is null)
+                    return (orig, (Bitmap?)null, (Bitmap?)null, 0,
+                        $"No generated image — run tests first. Expected: {genPath}");
+
+                gen = ImageDiffService.ToAvaloniaBitmap(genSk);
+                var (overlaySk, count) = ImageDiffService.ComputeDiffOverlay(origSk, genSk, skColor);
+                overlay = ImageDiffService.ToAvaloniaBitmap(overlaySk);
+                overlaySk.Dispose();
+                return (orig, gen, overlay, count, (string?)null);
+            }
+            catch
+            {
+                orig?.Dispose();
+                gen?.Dispose();
+                overlay?.Dispose();
+                throw;
+            }
+        });
+
+        _loadedOrigPath = origPath;
+        _loadedGenPath = genAva is not null ? genPath : null;
+        OriginalBitmap = origAva;
+        GeneratedBitmap = genAva;
+        DiffOverlayBitmap = overlayAva;
+        HasGenerated = genAva is not null;
+
+        StatusMessage = error is not null
+            ? error
+            : diffCount == 0
+                ? "✓ Images match"
+                : $"⚠ {diffCount:N0} pixels differ";
+    }
+
+    void ClearImages()
+    {
+        OriginalBitmap?.Dispose();
+        DiffOverlayBitmap?.Dispose();
+        GeneratedBitmap?.Dispose();
+        OriginalBitmap = null;
+        DiffOverlayBitmap = null;
+        GeneratedBitmap = null;
+        _loadedOrigPath = null;
+        _loadedGenPath = null;
+        HasGenerated = false;
+    }
+
+    async Task RecomputeOverlayAsync()
+    {
+        if (_loadedOrigPath is null || _loadedGenPath is null) return;
+        var c = _selectedDiffColorOption.Color;
+        var skColor = new SKColor(c.R, c.G, c.B, c.A);
+        var (origPath, genPath) = (_loadedOrigPath, _loadedGenPath);
+        var newOverlay = await Task.Run(() =>
+        {
+            using var origSk = ImageDiffService.LoadSkBitmap(origPath);
+            using var genSk = ImageDiffService.LoadSkBitmap(genPath);
+            if (origSk is null || genSk is null) return (Bitmap?)null;
+            var (overlaySk, _) = ImageDiffService.ComputeDiffOverlay(origSk, genSk, skColor);
+            var ava = ImageDiffService.ToAvaloniaBitmap(overlaySk);
+            overlaySk.Dispose();
+            return ava;
+        });
+        if (newOverlay is null) return;
+        DiffOverlayBitmap?.Dispose();
+        DiffOverlayBitmap = newOverlay;
+    }
+
+    public void Dispose()
+    {
+        ClearImages();
+        foreach (var entry in TestEntries) entry.Dispose();
+        _thumbCts.Cancel();
+        _thumbCts.Dispose();
+        PickRootCommand.Dispose();
+        RefreshCommand.Dispose();
+    }
+}

--- a/Tools/Mapsui.Tools.ImageComparison/ViewModels/TestEntryViewModel.cs
+++ b/Tools/Mapsui.Tools.ImageComparison/ViewModels/TestEntryViewModel.cs
@@ -1,0 +1,26 @@
+using System;
+using Avalonia.Media.Imaging;
+using ReactiveUI;
+
+namespace Mapsui.Tools.ImageComparison.ViewModels;
+
+sealed class TestEntryViewModel : ReactiveObject, IDisposable
+{
+    Bitmap? _thumbnail;
+
+    public TestEntryViewModel(string name) => Name = name;
+
+    public string Name { get; }
+
+    public Bitmap? Thumbnail
+    {
+        get => _thumbnail;
+        set
+        {
+            _thumbnail?.Dispose();
+            this.RaiseAndSetIfChanged(ref _thumbnail, value);
+        }
+    }
+
+    public void Dispose() => _thumbnail?.Dispose();
+}

--- a/Tools/Mapsui.Tools.ImageComparison/Views/MainWindow.axaml
+++ b/Tools/Mapsui.Tools.ImageComparison/Views/MainWindow.axaml
@@ -1,0 +1,124 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:Mapsui.Tools.ImageComparison.ViewModels"
+        x:Class="Mapsui.Tools.ImageComparison.Views.MainWindow"
+        x:DataType="vm:MainViewModel"
+        Title="Regression Image Comparison — Mapsui"
+        Width="1400" Height="900"
+        Background="#1E1E1E">
+
+    <DockPanel>
+
+        <!-- Top bar -->
+        <Border DockPanel.Dock="Top" Background="#2D2D2D" Padding="10,6">
+            <StackPanel Orientation="Horizontal" Spacing="10">
+                <TextBlock VerticalAlignment="Center" Text="Root:" Foreground="#AAAAAA" FontSize="12" />
+                <TextBlock VerticalAlignment="Center" Text="{Binding RootPath}" Foreground="White" FontSize="12" />
+                <Button Content="Change…" Command="{Binding PickRootCommand}" Padding="8,3" />
+                <Button Content="Refresh" Command="{Binding RefreshCommand}" Padding="8,3" />
+            </StackPanel>
+        </Border>
+
+        <!-- Bottom status bar -->
+        <Border DockPanel.Dock="Bottom" Background="#2D2D2D" Padding="10,4">
+            <TextBlock Text="{Binding StatusMessage}" Foreground="#CCCCCC" FontSize="12" />
+        </Border>
+
+        <!-- Toolbar: view-mode selector and diff colour picker -->
+        <Border DockPanel.Dock="Bottom" Background="#252526" Padding="10,6"
+                BorderBrush="#3C3C3C" BorderThickness="0,1,0,0">
+            <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                <TextBlock Text="Right panel:" VerticalAlignment="Center"
+                           Foreground="#AAAAAA" FontSize="12" />
+                <ComboBox SelectedIndex="{Binding SelectedDiffMode}" Width="200" VerticalAlignment="Center">
+                    <ComboBoxItem>Generated</ComboBoxItem>
+                    <ComboBoxItem>Generated + Diff</ComboBoxItem>
+                    <ComboBoxItem>Diff Only</ComboBoxItem>
+                </ComboBox>
+                <TextBlock Text="Diff colour:" VerticalAlignment="Center"
+                           Foreground="#AAAAAA" FontSize="12" Margin="12,0,0,0" />
+                <ComboBox ItemsSource="{Binding DiffColorPalette}"
+                          SelectedItem="{Binding SelectedDiffColorOption}"
+                          Width="120" VerticalAlignment="Center">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <Border Width="14" Height="14" Background="{Binding Brush}"
+                                        CornerRadius="2" VerticalAlignment="Center" />
+                                <TextBlock Text="{Binding Name}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </StackPanel>
+        </Border>
+
+        <!-- Left panel: thumbnail filmstrip -->
+        <Border DockPanel.Dock="Left" Width="170"
+                Background="#252526"
+                BorderBrush="#3C3C3C" BorderThickness="0,0,1,0">
+            <DockPanel>
+                <Border DockPanel.Dock="Top" Background="#2D2D2D" Padding="8,4">
+                    <TextBlock Text="Test Images" Foreground="#AAAAAA" FontSize="11" FontWeight="SemiBold" />
+                </Border>
+                <ListBox ItemsSource="{Binding TestEntries}"
+                         SelectedItem="{Binding SelectedEntry}"
+                         Background="Transparent"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                    <ListBox.Styles>
+                        <Style Selector="ListBoxItem">
+                            <Setter Property="Padding" Value="4" />
+                        </Style>
+                    </ListBox.Styles>
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="vm:TestEntryViewModel">
+                            <StackPanel Spacing="3">
+                                <Border Background="#1A1A1A" Height="90" ClipToBounds="True">
+                                    <Image Source="{Binding Thumbnail}" Stretch="Uniform" />
+                                </Border>
+                                <TextBlock Text="{Binding Name}"
+                                           TextWrapping="Wrap" FontSize="10"
+                                           Foreground="#CCCCCC" MaxLines="2" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </DockPanel>
+        </Border>
+
+        <!-- Main comparison area: Original | Generated (with optional diff overlay) -->
+        <Grid ColumnDefinitions="*,*">
+
+            <!-- Original -->
+            <DockPanel Grid.Column="0" Margin="0,0,1,0">
+                <Border DockPanel.Dock="Top" Background="#2D2D2D" Padding="4,4">
+                    <TextBlock Text="Original" HorizontalAlignment="Center"
+                               Foreground="#CCCCCC" FontSize="12" FontWeight="SemiBold" />
+                </Border>
+                <Image Source="{Binding OriginalBitmap}" Stretch="Uniform" />
+            </DockPanel>
+
+            <!-- Generated with overlay -->
+            <DockPanel Grid.Column="1">
+                <Border DockPanel.Dock="Top" Background="#2D2D2D" Padding="4,4">
+                    <TextBlock Text="Generated" HorizontalAlignment="Center"
+                               Foreground="#CCCCCC" FontSize="12" FontWeight="SemiBold" />
+                </Border>
+                <Panel>
+                    <!-- Generated image — hidden in DiffOnly mode -->
+                    <Image IsVisible="{Binding ShowGeneratedImage}"
+                           Source="{Binding GeneratedBitmap}" Stretch="Uniform" />
+                    <!-- Diff overlay — hidden in GeneratedOnly mode -->
+                    <Image IsVisible="{Binding ShowDiffOverlay}"
+                           Source="{Binding DiffOverlayBitmap}" Stretch="Uniform" />
+                    <!-- Placeholder when no generated image exists yet -->
+                    <TextBlock IsVisible="{Binding !HasGenerated}"
+                               Text="Run tests to see generated image"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Foreground="#555555" FontSize="13" />
+                </Panel>
+            </DockPanel>
+
+        </Grid>
+    </DockPanel>
+</Window>

--- a/Tools/Mapsui.Tools.ImageComparison/Views/MainWindow.axaml.cs
+++ b/Tools/Mapsui.Tools.ImageComparison/Views/MainWindow.axaml.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using Mapsui.Tools.ImageComparison.ViewModels;
+
+namespace Mapsui.Tools.ImageComparison.Views;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        AvaloniaXamlLoader.Load(this);
+        DataContext = new MainViewModel(PickFolderAsync);
+    }
+
+    async Task<string?> PickFolderAsync()
+    {
+        var results = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Select root folder (Tests/Mapsui.Rendering.Skia.Tests)",
+            AllowMultiple = false,
+        });
+        return results.FirstOrDefault()?.Path.LocalPath;
+    }
+}

--- a/Tools/Mapsui.Tools.ImageComparison/app.manifest
+++ b/Tools/Mapsui.Tools.ImageComparison/app.manifest
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- This manifest is used on Windows only.
+       Don't remove it as it might cause problems with window transparency and embedded controls.
+       For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
+  <assemblyIdentity version="1.0.0.0" name="Mapsui.Tools.ImageComparison"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
## What

Adds a new developer tool — `Mapsui.Tools.ImageComparison` — for visually comparing rendering regression test images.

The tool is a cross-platform Avalonia desktop app (`net9.0` + `Avalonia.Desktop`) that loads the `OriginalRegression` and `GeneratedRegression` image folders and shows them side by side.

<img width="1393" height="917" alt="image" src="https://github.com/user-attachments/assets/8f297b96-0c11-4257-a31f-58e459476660" />

## Key features

- **Two-column layout** — original always on the left, generated on the right (previously there was a separate third "Diff" column that wasted space and shrunk the images).
- **Three-state view mode** (ComboBox below the images):
  - *Generated* — generated image only
  - *Generated + Diff* (default) — generated image with diff pixels overlaid on top
  - *Diff Only* — only the diff pixels on a transparent/dark background
- **Colour palette** — pick the diff highlight colour (Red, Yellow, Cyan, Magenta, White) from a compact ComboBox with colour swatches. Changing the colour recomputes the overlay immediately without re-selecting the entry.
- **Transparent overlay** — diff pixels use the chosen colour at full opacity; matching pixels are fully transparent, so the generated image shows through cleanly.

## Why

The old layout had a large green panel in the middle for the diff, which made both the original and generated images much smaller. The new overlay approach keeps both images at full size and makes differences immediately obvious without the visual noise of the green background.

## Cross-platform

`OutputType` is `WinExe` (consistent with `Mapsui.Samples.Avalonia12.Desktop`), `TargetFramework` is `net9.0` (not `net9.0-windows`). Works on Windows, Linux, and Mac — `WinExe` only suppresses the console window on Windows; on other platforms it behaves identically to `Exe`.