### PR TITLE
feat: add continuous mouse wheel zoom to Navigator

### DIFF
--- a/Mapsui.UI.Avalonia/MapControl.cs
+++ b/Mapsui.UI.Avalonia/MapControl.cs
@@ -54,19 +54,30 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
         RunOnUIThread(InvalidateVisual);
     }
 
-    /// <summary>
-    /// This enables an alternative mouse wheel method where the step size on each mouse wheel event can be configured
-    /// by setting the ContinuousMouseWheelZoomStepSize.
-    /// </summary>
-    public bool UseContinuousMouseWheelZoom { get; set; } = false;
-    /// <summary>
-    /// The size of the mouse wheel steps used when UseContinuousMouseWheelZoom = true. The default is 0.1. A step 
-    /// size of 1 would doubling or halving the scale of the map on each event.    
-    /// </summary>
-    public double ContinuousMouseWheelZoomStepSize { get; set; } = 0.1;
-
     public static readonly DirectProperty<MapControl, Map> MapProperty =
         AvaloniaProperty.RegisterDirect<MapControl, Map>(nameof(Map), o => o.Map, (o, v) => o.Map = v);
+
+    /// <summary>
+    /// When true, each wheel event zooms by a small continuous step instead of snapping to the next
+    /// predefined resolution. Prefer using <see cref="Mapsui.Animations.MouseWheelAnimation.UseContinuousMouseWheelZoom"/>
+    /// via <c>Map.Navigator.MouseWheelAnimation</c> directly. This shortcut will be removed in the next version.
+    /// </summary>
+    public bool UseContinuousMouseWheelZoom
+    {
+        get => Map.Navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom;
+        set => Map.Navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom = value;
+    }
+
+    /// <summary>
+    /// The zoom step per wheel event when <see cref="UseContinuousMouseWheelZoom"/> is true.
+    /// Prefer using <see cref="Mapsui.Animations.MouseWheelAnimation.ContinuousMouseWheelZoomStepSize"/>
+    /// via <c>Map.Navigator.MouseWheelAnimation</c> directly. This shortcut will be removed in the next version.
+    /// </summary>
+    public double ContinuousMouseWheelZoomStepSize
+    {
+        get => Map.Navigator.MouseWheelAnimation.ContinuousMouseWheelZoomStepSize;
+        set => Map.Navigator.MouseWheelAnimation.ContinuousMouseWheelZoomStepSize = value;
+    }
 
     /// <summary> Clears the Touch State. Should only be called if the touch state seems out of sync 
     /// in a certain situation.</summary>
@@ -142,28 +153,29 @@ public partial class MapControl : UserControl, IMapControl, IDisposable
 
     private void MapControl_PointerWheelChanged(object? sender, PointerWheelEventArgs e)
     {
-        if (UseContinuousMouseWheelZoom)
-        {
-            var stepSize = ContinuousMouseWheelZoomStepSize;
-            var scaleFactor = Math.Pow(2, e.Delta.Y > 0 ? -stepSize : stepSize);
-            Map.Navigator.MouseWheelZoomContinuous(scaleFactor, e.GetPosition(this).ToScreenPosition());
-        }
-        else
-        {
-            // In Avalonia the touchpad can trigger the mouse wheel event. In that case there are more events and the Delta.Y is a double value, 
-            // which is usually smaller than 1.0. In the code below the deltas are accumulated until they are larger than 1.0. Only then 
-            // MouseWheelZoom is called.
-            _mouseWheelPos += e.Delta.Y;
-            if (Math.Abs(_mouseWheelPos) < 1.0) return; // Ignore the mouse wheel event if the accumulated delta is still too small
-            int delta = Math.Sign(_mouseWheelPos);
-            _mouseWheelPos -= delta;
-            // Clamp residual to ±1 to prevent runaway accumulation when Delta.Y > 1 (e.g. browser/WASM wheel events).
-            // Without this, prolonged scrolling in one direction builds up a large residual that makes reversing
-            // direction feel stuck.
-            _mouseWheelPos = Math.Clamp(_mouseWheelPos, -1.0, 1.0);
+        var pos = e.GetPosition(this).ToScreenPosition();
 
-            Map.Navigator.MouseWheelZoom(delta, e.GetPosition(this).ToScreenPosition());
+        if (Map.Navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom)
+        {
+            // Use the actual delta magnitude so trackpad gesture velocity influences zoom speed.
+            // Delta.Y > 0 means scroll up (zoom in) → resolution decreases, hence the negative sign.
+            var stepSize = Map.Navigator.MouseWheelAnimation.ContinuousMouseWheelZoomStepSize;
+            var scaleFactor = Math.Pow(2, e.Delta.Y * -stepSize);
+            Map.Navigator.MouseWheelZoomContinuous(scaleFactor, pos);
+            return;
         }
+
+        // In Avalonia the touchpad can trigger the mouse wheel event. In that case there are more events and the Delta.Y is a double value,
+        // which is usually smaller than 1.0. In the code below the deltas are accumulated until they are larger than 1.0. Only then
+        // MouseWheelZoom is called. This prevents trackpad from triggering dozens of full zoom-level jumps per gesture.
+        _mouseWheelPos += e.Delta.Y;
+        if (Math.Abs(_mouseWheelPos) < 1.0) return;
+        int delta = Math.Sign(_mouseWheelPos);
+        _mouseWheelPos -= delta;
+        // Todo: Consider clamping _mouseWheelPos to ±1 here to prevent runaway accumulation
+        // when Delta.Y > 1 (e.g. fast prolonged scrolling). Not yet confirmed to be necessary.
+
+        Map.Navigator.MouseWheelZoom(delta, pos);
     }
 
     private void MapControl_PointerExited(object? sender, PointerEventArgs e)

--- a/Mapsui.UI.Blazor/MapControl.cs
+++ b/Mapsui.UI.Blazor/MapControl.cs
@@ -54,15 +54,26 @@ public partial class MapControl : ComponentBase, IMapControl
     }
 
     /// <summary>
-    /// This enables an alternative mouse wheel method where the step size on each mouse wheel event can be configured
-    /// by setting the ContinuousMouseWheelZoomStepSize.
+    /// When true, each wheel event zooms by a small continuous step instead of snapping to the next
+    /// predefined resolution. Prefer using <see cref="Mapsui.Animations.MouseWheelAnimation.UseContinuousMouseWheelZoom"/>
+    /// via <c>Map.Navigator.MouseWheelAnimation</c> directly. This shortcut will be removed in the next version.
     /// </summary>
-    public bool UseContinuousMouseWheelZoom { get; set; } = false;
+    public bool UseContinuousMouseWheelZoom
+    {
+        get => Map.Navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom;
+        set => Map.Navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom = value;
+    }
+
     /// <summary>
-    /// The size of the mouse wheel steps used when UseContinuousMouseWheelZoom = true. The default is 0.1. A step 
-    /// size of 1 would doubling or halving the scale of the map on each event.    
+    /// The zoom step per wheel event when <see cref="UseContinuousMouseWheelZoom"/> is true.
+    /// Prefer using <see cref="Mapsui.Animations.MouseWheelAnimation.ContinuousMouseWheelZoomStepSize"/>
+    /// via <c>Map.Navigator.MouseWheelAnimation</c> directly. This shortcut will be removed in the next version.
     /// </summary>
-    public double ContinuousMouseWheelZoomStepSize { get; set; } = 0.1;
+    public double ContinuousMouseWheelZoomStepSize
+    {
+        get => Map.Navigator.MouseWheelAnimation.ContinuousMouseWheelZoomStepSize;
+        set => Map.Navigator.MouseWheelAnimation.ContinuousMouseWheelZoomStepSize = value;
+    }
 
     protected override void OnInitialized()
     {
@@ -108,18 +119,9 @@ public partial class MapControl : ComponentBase, IMapControl
 
     protected void OnMouseWheel(WheelEventArgs e)
     {
-        if (UseContinuousMouseWheelZoom)
-        {
-            var stepSize = ContinuousMouseWheelZoomStepSize;
-            var scaleFactor = Math.Pow(2, e.DeltaY > 0 ? stepSize : -stepSize);
-            Map.Navigator.MouseWheelZoomContinuous(scaleFactor, e.ToScreenPosition());
-        }
-        else
-        {
-            var mouseWheelDelta = (int)e.DeltaY * -1; // so that it zooms like on windows
-            var mousePosition = e.ToScreenPosition();
-            Map.Navigator.MouseWheelZoom(mouseWheelDelta, mousePosition);
-        }
+        var mouseWheelDelta = (int)e.DeltaY * -1; // so that it zooms like on windows
+        var mousePosition = e.ToScreenPosition();
+        Map.Navigator.MouseWheelZoom(mouseWheelDelta, mousePosition);
     }
 
     private async Task<BoundingClientRect> BoundingClientRectAsync()

--- a/Mapsui/Animations/MouseWheelAnimation.cs
+++ b/Mapsui/Animations/MouseWheelAnimation.cs
@@ -12,6 +12,20 @@ public class MouseWheelAnimation
     public int Duration { get; set; } = 600;
     public Easing Easing { get; set; } = Easing.QuarticOut;
 
+    /// <summary>
+    /// When true, each mouse wheel event zooms by a small continuous step instead of snapping
+    /// to the next predefined resolution level. This gives a smoother feel, especially on
+    /// platforms where the mouse wheel fires many events (e.g. trackpad pinch on a laptop).
+    /// </summary>
+    public bool UseContinuousMouseWheelZoom { get; set; } = false;
+
+    /// <summary>
+    /// The zoom step applied per wheel event when <see cref="UseContinuousMouseWheelZoom"/> is true.
+    /// The value is an exponent in base-2: a step of 0.1 scales the resolution by 2^0.1 ≈ 1.07 (7%).
+    /// A step of 1.0 would halve or double the resolution in a single event. Default is 0.1.
+    /// </summary>
+    public double ContinuousMouseWheelZoomStepSize { get; set; } = 0.1;
+
     public double GetResolution(int mouseWheelDelta, double currentResolution, MMinMax? zoomBounds, IReadOnlyList<double> resolutions)
     {
         // If an animation is already running don't start from the current resolution, but from the 

--- a/Mapsui/Navigator.cs
+++ b/Mapsui/Navigator.cs
@@ -205,6 +205,17 @@ public class Navigator
         if (PanLock) // Avoid pan by zooming on center
             centerOfZoom = Viewport.WorldToScreen(Viewport.CenterX, Viewport.CenterY);
 
+        if (MouseWheelAnimation.UseContinuousMouseWheelZoom)
+        {
+            // Each event scales the resolution by a fixed small factor. No snapping or animation —
+            // the steps are intentionally small so the motion already feels smooth.
+            var stepSize = MouseWheelAnimation.ContinuousMouseWheelZoomStepSize;
+            // mouseWheelDelta > 0 means zoom in → resolution decreases → exponent is negative.
+            var scaleFactor = Math.Pow(2, mouseWheelDelta > 0 ? -stepSize : stepSize);
+            MouseWheelZoomContinuous(scaleFactor, centerOfZoom);
+            return;
+        }
+
         // It is unexpected that this method uses the MouseWheelAnimation.Animation and Easing. 
         // At the moment this solution allows the user to change these fields, so I don't want
         // them to become hardcoded values in the MapControl. There should be a more general

--- a/Samples/Mapsui.Samples.Blazor/Pages/Index.razor.cs
+++ b/Samples/Mapsui.Samples.Blazor/Pages/Index.razor.cs
@@ -122,7 +122,7 @@ public sealed partial class Index : IDisposable
             if (_mapControl != null)
             {
                 // Enabled to try experimental renderer: _mapControl.SetMapRenderer(new Mapsui.Experimental.Rendering.Skia.MapRenderer());
-                _mapControl.UseContinuousMouseWheelZoom = true;
+                _mapControl.Map.Navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom = true;
             }
         }
     }

--- a/Samples/Mapsui.Samples.Blazor/Pages/Page1.razor.cs
+++ b/Samples/Mapsui.Samples.Blazor/Pages/Page1.razor.cs
@@ -125,7 +125,7 @@ public partial class Page1 : ComponentBase
             FillMap();
             if (_mapControl != null)
             {
-                _mapControl.UseContinuousMouseWheelZoom = true;
+                _mapControl.Map.Navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom = true;
             }
         }
     }

--- a/Tests/Mapsui.Tests/NavigatorTests.cs
+++ b/Tests/Mapsui.Tests/NavigatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using Mapsui.Animations;
 using Mapsui.Extensions;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using Mapsui.Manipulations;
 
@@ -101,6 +102,78 @@ public class NavigatorTests
         Assert.That(previousViewport, Is.EqualTo(previous));
         Assert.That(currentViewport, Is.EqualTo(navigator.Viewport));
         Assert.That(previousViewport, Is.Not.EqualTo(currentViewport));
+    }
+
+    [Test]
+    public void MouseWheelZoom_ContinuousMode_PositiveDelta_DecreasesResolution()
+    {
+        // Arrange
+        var navigator = new Navigator();
+        navigator.SetSize(100, 100);
+        navigator.OverridePanBounds = new MRect(-1000, -1000, 1000, 1000);
+        navigator.CenterOnAndZoomTo(new MPoint(0, 0), 1.0);
+        navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom = true;
+        navigator.MouseWheelAnimation.ContinuousMouseWheelZoomStepSize = 0.1;
+
+        // Act
+        navigator.MouseWheelZoom(1, new ScreenPosition(50, 50));
+
+        // Assert — positive delta means zoom in, resolution decreases by factor 2^-0.1
+        Assert.That(navigator.Viewport.Resolution, Is.EqualTo(Math.Pow(2, -0.1)).Within(1e-10));
+    }
+
+    [Test]
+    public void MouseWheelZoom_ContinuousMode_NegativeDelta_IncreasesResolution()
+    {
+        // Arrange
+        var navigator = new Navigator();
+        navigator.SetSize(100, 100);
+        navigator.OverridePanBounds = new MRect(-1000, -1000, 1000, 1000);
+        navigator.CenterOnAndZoomTo(new MPoint(0, 0), 1.0);
+        navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom = true;
+        navigator.MouseWheelAnimation.ContinuousMouseWheelZoomStepSize = 0.1;
+
+        // Act
+        navigator.MouseWheelZoom(-1, new ScreenPosition(50, 50));
+
+        // Assert — negative delta means zoom out, resolution increases by factor 2^0.1
+        Assert.That(navigator.Viewport.Resolution, Is.EqualTo(Math.Pow(2, 0.1)).Within(1e-10));
+    }
+
+    [Test]
+    public void MouseWheelZoom_ContinuousMode_ZoomLock_DoesNotChangeResolution()
+    {
+        // Arrange
+        var navigator = new Navigator();
+        navigator.SetSize(100, 100);
+        navigator.OverridePanBounds = new MRect(-1000, -1000, 1000, 1000);
+        navigator.CenterOnAndZoomTo(new MPoint(0, 0), 1.0);
+        navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom = true;
+        navigator.ZoomLock = true;
+
+        // Act
+        navigator.MouseWheelZoom(1, new ScreenPosition(50, 50));
+
+        // Assert — ZoomLock prevents any resolution change
+        Assert.That(navigator.Viewport.Resolution, Is.EqualTo(1.0));
+    }
+
+    [Test]
+    public void MouseWheelZoom_ContinuousMode_CustomStepSize_ScalesResolutionCorrectly()
+    {
+        // Arrange
+        var navigator = new Navigator();
+        navigator.SetSize(100, 100);
+        navigator.OverridePanBounds = new MRect(-1000, -1000, 1000, 1000);
+        navigator.CenterOnAndZoomTo(new MPoint(0, 0), 1.0);
+        navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom = true;
+        navigator.MouseWheelAnimation.ContinuousMouseWheelZoomStepSize = 0.5;
+
+        // Act
+        navigator.MouseWheelZoom(1, new ScreenPosition(50, 50));
+
+        // Assert — step of 0.5 means resolution scales by 2^-0.5 ≈ 0.707 per event
+        Assert.That(navigator.Viewport.Resolution, Is.EqualTo(Math.Pow(2, -0.5)).Within(1e-10));
     }
 
     [Test]


### PR DESCRIPTION
## What

Moves the continuous mouse wheel zoom feature from platform-specific `MapControl` classes into the central `Navigator.MouseWheelAnimation`, making it available on all platforms.

### Changes

- **`MouseWheelAnimation`** — two new properties:
  - `UseContinuousMouseWheelZoom` (default `false`) — when true, each wheel event zooms by a small continuous step instead of snapping to the next resolution level.
  - `ContinuousMouseWheelZoomStepSize` (default `0.1`) — the exponent in base-2 per event; `0.1` scales resolution by ~7% per tick.
- **`Navigator.MouseWheelZoom`** — routes to continuous mode internally when `UseContinuousMouseWheelZoom` is true, so all platforms benefit automatically without platform-level changes.
- **Avalonia `MapControl`** — handler updated to pass the actual trackpad delta magnitude to `MouseWheelZoomContinuous`, so trackpad gesture velocity influences zoom speed. Snap-mode accumulator logic preserved unchanged.
- **Blazor `MapControl`** — handler simplified; routing is now handled centrally by `Navigator`.
- **Forwarding properties** — `UseContinuousMouseWheelZoom` and `ContinuousMouseWheelZoomStepSize` kept on Avalonia and Blazor `MapControl` as forwarding properties (no breaking change). Doc comments note they will be removed in the next version.
- **Blazor samples** — updated to use `Map.Navigator.MouseWheelAnimation` directly.
- **Tests** — 4 new unit tests covering positive delta, negative delta, zoom lock, and custom step size in continuous mode.

## Why

Previously the feature only existed on Avalonia and Blazor. Moving it into `Navigator.MouseWheelAnimation` makes it accessible from all platforms via `Map.Navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom = true`, consistent with where other navigation configuration lives.

## How to use

```csharp
// Enable on any platform:
mapControl.Map.Navigator.MouseWheelAnimation.UseContinuousMouseWheelZoom = true;
mapControl.Map.Navigator.MouseWheelAnimation.ContinuousMouseWheelZoomStepSize = 0.1; // optional, default
```