### PR TITLE
feat: add VisibilityMargin to BaseLayer

### DIFF
--- a/Mapsui.Experimental/Layers/ObservableCollectionLayer.cs
+++ b/Mapsui.Experimental/Layers/ObservableCollectionLayer.cs
@@ -3,7 +3,6 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using Mapsui.Extensions;
-using Mapsui.Styles;
 using Mapsui.Utilities;
 using System.Collections.Generic;
 using Mapsui.Layers;
@@ -135,9 +134,7 @@ public class ObservableCollectionLayer<T> : BaseLayer
         if (rect == null)
             yield break;
 
-        var biggerRect = rect.Grow(
-                SymbolStyle.DefaultWidth * 2 * resolution,
-                SymbolStyle.DefaultHeight * 2 * resolution);
+        var biggerRect = rect.Grow(VisibilityMargin * resolution);
         foreach (var feature in _shadowCollection.Select(i => i.Feature).ToArray())
         {
             if (feature?.Extent?.Intersects(biggerRect) == true)

--- a/Mapsui/Layers/BaseLayer.cs
+++ b/Mapsui/Layers/BaseLayer.cs
@@ -177,6 +177,14 @@ public abstract class BaseLayer : ILayer
     /// <inheritdoc />
     public HyperlinkWidget Attribution { get; set; } = new();
 
+    /// <summary>
+    /// The extra margin in pixels added around the viewport extent when querying and fetching features.
+    /// Increase this when the layer's style renders visually larger than the feature's geometry
+    /// (e.g. wide lines, large symbols, labels, or custom renderers that overflow the geometry bounds).
+    /// This prevents features from disappearing at the edge of the screen.
+    /// </summary>
+    public double VisibilityMargin { get; set; } = SymbolStyle.DefaultWidth * 2;
+
     /// <inheritdoc />
     public virtual IReadOnlyList<double> Resolutions { get; } = [];
 

--- a/Mapsui/Layers/GenericCollectionLayer.cs
+++ b/Mapsui/Layers/GenericCollectionLayer.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Mapsui.Extensions;
-using Mapsui.Styles;
 
 namespace Mapsui.Layers;
 
@@ -19,9 +18,7 @@ public class GenericCollectionLayer<T> : BaseLayer where T : IEnumerable<IFeatur
         // Safeguard in case BoundingBox is null, most likely due to no features in layer
         if (rect == null) { return new List<IFeature>(); }
 
-        var biggerRect = rect.Grow(
-                SymbolStyle.DefaultWidth * 2 * resolution,
-                SymbolStyle.DefaultHeight * 2 * resolution);
+        var biggerRect = rect.Grow(VisibilityMargin * resolution);
 
         return Features.Where(f => f.Extent?.Intersects(biggerRect) == true);
     }

--- a/Mapsui/Layers/Layer.cs
+++ b/Mapsui/Layers/Layer.cs
@@ -12,7 +12,6 @@ using Mapsui.Fetcher;
 using Mapsui.Layers.AnimatedLayers;
 using Mapsui.Logging;
 using Mapsui.Providers;
-using Mapsui.Styles;
 
 namespace Mapsui.Layers;
 
@@ -135,7 +134,8 @@ public class Layer(string layerName) : BaseLayer(layerName), IFetchableSource, I
     {
         try
         {
-            fetchInfo = fetchInfo.Grow(SymbolStyle.DefaultWidth);
+            var grownExtent = fetchInfo.Extent.Grow(VisibilityMargin * fetchInfo.Resolution);
+            fetchInfo = new FetchInfo(new MSection(grownExtent, fetchInfo.Resolution), fetchInfo.CRS, fetchInfo.ChangeType);
             var features = DataSource != null ? await DataSource.GetFeaturesAsync(fetchInfo).ConfigureAwait(false) : [];
             _cache = features.ToArray();
             _hasAnimatedFeatures = _cache.Any(f => f is IAnimatedFeature);

--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -1,5 +1,4 @@
 using Mapsui.Extensions;
-using Mapsui.Styles;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,9 +47,7 @@ public class MemoryLayer(string layerName) : BaseLayer(layerName)
         if (rect == null)
             yield break;
 
-        var biggerRect = rect.Grow(
-                SymbolStyle.DefaultWidth * 2 * resolution,
-                SymbolStyle.DefaultHeight * 2 * resolution);
+        var biggerRect = rect.Grow(VisibilityMargin * resolution);
         foreach (var feature in _localFeatures)
         {
             if (feature?.Extent?.Intersects(biggerRect) == true)

--- a/Mapsui/Layers/WritableLayer.cs
+++ b/Mapsui/Layers/WritableLayer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Mapsui.Styles;
 using Mapsui.Utilities;
 
 namespace Mapsui.Layers;
@@ -15,7 +14,7 @@ public class WritableLayer : BaseLayer
         // Safeguard in case MRect is null, most likely due to no features in layer
         if (box == null) return new List<IFeature>();
         var cache = _cache;
-        var biggerBox = box.Grow(SymbolStyle.DefaultWidth * 2 * resolution, SymbolStyle.DefaultHeight * 2 * resolution);
+        var biggerBox = box.Grow(VisibilityMargin * resolution);
         var result = cache.Where(f => biggerBox.Intersects(f.Extent));
         return result;
     }

--- a/docs/general/markdown/working-with-layers.md
+++ b/docs/general/markdown/working-with-layers.md
@@ -59,6 +59,7 @@ Every layer exposes a few properties that control whether and how it is drawn:
 - **`Opacity`** — value between 0 and 1.
 - **`MinVisible` / `MaxVisible`** — resolution range in which the layer is drawn. Useful to only show detail layers when zoomed in.
 - **`Style`** — the default style applied to all features in the layer. Set to `null` if you only want per-feature styles.
+- **`VisibilityMargin`** — extra margin in pixels added around the viewport extent when querying and fetching features. The default is 64 px. Increase it when your layer's style renders visually larger than the feature's geometry — for example wide strokes, large point symbols, labels, or custom renderers that overflow the geometry bounds. Without a large enough margin, features near the viewport edge can disappear before their rendered symbol leaves the screen.
 - **`Name`** — used for lookups (`FindLayer`) and for display in things like a legend.
 
 ## Layer groups


### PR DESCRIPTION
## What

Adds a `VisibilityMargin` property to `BaseLayer` that controls how far (in pixels) the query extent is expanded beyond the viewport when fetching and culling features.

## Why

Several `GetFeatures` and `FetchAsync` implementations were hardcoding `SymbolStyle.DefaultWidth * 2 * resolution` as a growth margin. This was not configurable, not discoverable, and asymmetric (width and height were treated separately even though the values were always identical). Layers using large symbols, wide strokes, or labels had no way to increase this margin without subclassing.

## Changes

- `BaseLayer` — new `VisibilityMargin` auto-property (default: `SymbolStyle.DefaultWidth * 2` = 64 px) with XML doc comment
- `MemoryLayer`, `WritableLayer`, `GenericCollectionLayer` — `GetFeatures` uses `VisibilityMargin * resolution` instead of the hardcoded expression
- `ObservableCollectionLayer` (Experimental) — same fix
- `Layer.FetchAsync` — replaces `fetchInfo.Grow(SymbolStyle.DefaultWidth)` (which had a hidden x2 multiplier) with an explicit pixel to world expansion using `VisibilityMargin * fetchInfo.Resolution`, keeping behaviour identical but making the semantics consistent
- `using Mapsui.Styles;` removed from all 5 changed layer files (was only used for the now-removed `SymbolStyle` reference)
- `docs/general/markdown/working-with-layers.md` — `VisibilityMargin` documented in the 'Layer properties that affect drawing' section

## Behaviour

Default behaviour is **unchanged**: all locations still produce 64 px of margin per edge. Users can now increase the margin per layer when needed:

`csharp
var layer = new MemoryLayer { Features = myFeatures };
layer.VisibilityMargin = 128; // e.g. for a layer using large custom symbols
`

## Potential breaking changes

- A custom `BaseLayer` subclass that already defines its own `VisibilityMargin` property will silently shadow the base class property (CS0108).
- The grow was previously asymmetric (separate width/height). It is now uniform. Anyone who had set `SymbolStyle.DefaultWidth` and `SymbolStyle.DefaultHeight` to different values will see a behaviour change.