### PR TITLE
fix: guard EndEdit against polygons with fewer than three points

### DIFF
--- a/Mapsui.Nts/Editing/EditManager.cs
+++ b/Mapsui.Nts/Editing/EditManager.cs
@@ -64,6 +64,16 @@ public class EditManager
             if (polygon == null) return false;
 
             _addInfo.Vertices.RemoveAt(_addInfo.Vertices.Count - 1); // Remove the last vertex, because it is the hover vertex
+
+            if (_addInfo.Vertices.Count < 3) // A polygon ring needs at least 3 distinct points, otherwise LinearRing throws.
+            {
+                // And reset it back to the previous state.
+                Layer?.TryRemove(_addInfo.Feature);
+                _addInfo.Reset();
+                EditMode = EditMode.AddPolygon;
+                return false;
+            }
+
             var linearRing = _addInfo.Vertices.ToList();
             linearRing.Add(linearRing[0].Copy()); // Add first coordinate at end to close the ring.
             _addInfo.Feature.Geometry = new Polygon(new LinearRing(linearRing.ToArray()));

--- a/Tests/Mapsui.Nts.Tests/Editing/EditManagerTests.cs
+++ b/Tests/Mapsui.Nts.Tests/Editing/EditManagerTests.cs
@@ -1,0 +1,20 @@
+using NetTopologySuite.Geometries;
+using NUnit.Framework;
+using Mapsui.Nts.Editing;
+
+namespace Mapsui.Nts.Tests.Editing;
+
+[TestFixture]
+public class EditManagerTests
+{
+    [Test]
+    public void EndEditShouldNotThrowWhenPolygonHasFewerThanThreePoints()
+    {
+        // Arrange
+        var editManager = new EditManager { EditMode = EditMode.AddPolygon };
+        editManager.AddVertex(new Coordinate(0, 0)); // Only one point placed before finishing.
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => editManager.EndEdit());
+    }
+}


### PR DESCRIPTION
## What

`EditManager.EndEdit()` now discards the in-progress polygon and resets the edit instead of constructing a `LinearRing` when fewer than three points were placed.

## Why

Finishing an `AddPolygon` edit with one or two points (for example double-clicking right after the first click) reached `new LinearRing(...)` with too few coordinates, which throws `System.ArgumentException: Number of points must be 0 or >=3` from NetTopologySuite and crashed the application. The `DrawingLine` branch already guards against this with a `Count < 2` check, so this mirrors that behaviour for polygons. Fixes #3370.
