### PR TITLE
refactor: streamline invalid edit cancellation and rename PR skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,7 +104,7 @@ Before opening a pull request, load the done-checklist skill (`.github/skills/do
 | Skill | When to load |
 |---|---|
 | `.github/skills/done-checklist/SKILL.md` | Before opening any PR — runs the full pre-PR checklist |
-| `.github/skills/create-pr/SKILL.md` | When opening a pull request — covers title prefix conventions, PR type label selection, and the correct tool to use |
+| `.github/skills/create-pull-request/SKILL.md` | When opening a pull request — covers title prefix conventions, PR type label selection, and the correct tool to use |
 | `.github/skills/regression-tests/SKILL.md` | When working with rendering regression tests: running, updating references, diagnosing failures, or adding experimental-renderer samples |
 | `.github/skills/richtextkit/SKILL.md` | When implementing text rendering features involving word wrap, BiDi/RTL, emoji, font fallback, or multi-style text blocks |
 

--- a/.github/skills/create-pull-request/SKILL.md
+++ b/.github/skills/create-pull-request/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: create-pr
+name: create-pull-request
 description: Create a GitHub Pull Request for Mapsui — covering title prefix conventions, PR type label selection, and the correct tool to use. Load this skill when you are ready to open a pull request.
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,5 @@ AppPackages/
 /Benchmarks/Mapsui.Rendering.Benchmarks/BenchmarkDotNet.Artifacts/results
 /Benchmarks/Mapsui.Rendering.Benchmarks/BenchmarkDotNet.Artifacts/*.log
 /.playwright-mcp
+/.codex/
 config.local.json
-

--- a/Mapsui.Nts/Editing/EditManager.cs
+++ b/Mapsui.Nts/Editing/EditManager.cs
@@ -45,10 +45,7 @@ public class EditManager
 
             if (_addInfo.Vertices.Count < 2) // If there are not enough vertices, do not add the feature
             {
-                // And reset it back to the previous state.
-                Layer?.TryRemove(_addInfo.Feature);
-                _addInfo.Reset();
-                EditMode = EditMode.AddLine;
+                CancelAdd(EditMode.AddLine);
                 return false;
             }
 
@@ -67,10 +64,7 @@ public class EditManager
 
             if (_addInfo.Vertices.Count < 3) // A polygon ring needs at least 3 distinct points, otherwise LinearRing throws.
             {
-                // And reset it back to the previous state.
-                Layer?.TryRemove(_addInfo.Feature);
-                _addInfo.Reset();
-                EditMode = EditMode.AddPolygon;
+                CancelAdd(EditMode.AddPolygon);
                 return false;
             }
 
@@ -86,6 +80,16 @@ public class EditManager
         }
 
         return false;
+    }
+
+    private void CancelAdd(EditMode nextMode)
+    {
+        if (_addInfo.Feature != null)
+            Layer?.TryRemove(_addInfo.Feature);
+
+        _addInfo.Reset();
+        EditMode = nextMode;
+        Layer?.DataHasChanged();
     }
 
     public void HoveringVertex(MapInfo mapInfo)

--- a/Tests/Mapsui.Nts.Tests/Editing/EditManagerTests.cs
+++ b/Tests/Mapsui.Nts.Tests/Editing/EditManagerTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using Mapsui.Layers;
 using NetTopologySuite.Geometries;
 using NUnit.Framework;
 using Mapsui.Nts.Editing;
@@ -8,13 +10,34 @@ namespace Mapsui.Nts.Tests.Editing;
 public class EditManagerTests
 {
     [Test]
-    public void EndEditShouldNotThrowWhenPolygonHasFewerThanThreePoints()
+    public void EndEditShouldCancelInvalidPolygonAndNotifyLayer()
     {
-        // Arrange
-        var editManager = new EditManager { EditMode = EditMode.AddPolygon };
+        var layer = new WritableLayer();
+        var editManager = new EditManager { EditMode = EditMode.AddPolygon, Layer = layer };
+        var dataChangedCount = 0;
+        layer.DataChanged += (_, _) => dataChangedCount++;
+
         editManager.AddVertex(new Coordinate(0, 0)); // Only one point placed before finishing.
 
-        // Act & Assert
         Assert.DoesNotThrow(() => editManager.EndEdit());
+        Assert.That(editManager.EditMode, Is.EqualTo(EditMode.AddPolygon));
+        Assert.That(layer.GetFeatures().Count(), Is.EqualTo(0));
+        Assert.That(dataChangedCount, Is.EqualTo(2)); // one add, one cancellation
+    }
+
+    [Test]
+    public void EndEditShouldCancelInvalidLineAndNotifyLayer()
+    {
+        var layer = new WritableLayer();
+        var editManager = new EditManager { EditMode = EditMode.AddLine, Layer = layer };
+        var dataChangedCount = 0;
+        layer.DataChanged += (_, _) => dataChangedCount++;
+
+        editManager.AddVertex(new Coordinate(0, 0)); // Only one point placed before finishing.
+
+        Assert.DoesNotThrow(() => editManager.EndEdit());
+        Assert.That(editManager.EditMode, Is.EqualTo(EditMode.AddLine));
+        Assert.That(layer.GetFeatures().Count(), Is.EqualTo(0));
+        Assert.That(dataChangedCount, Is.EqualTo(2)); // one add, one cancellation
     }
 }


### PR DESCRIPTION
## Summary
- streamline cancellation of invalid line and polygon edits in `EditManager`
- strengthen the `EditManager` regression tests to verify cleanup, mode reset, and layer notifications
- rename the pull request skill from `create-pr` to `create-pull-request` and ignore `/.codex/`

## Testing
- `dotnet test Tests/Mapsui.Nts.Tests/Mapsui.Nts.Tests.csproj --no-restore`
