### PR TITLE
update: Move to SkiaSharp 3.119.4 and prepare for SkiaSharp 4

### DIFF
--- a/.github/workflows/dotnet-validate-nugets.yml
+++ b/.github/workflows/dotnet-validate-nugets.yml
@@ -46,15 +46,26 @@ jobs:
     - name: Restore dependencies (dotnet)
       run: dotnet restore Mapsui.slnx  
     # Release Build
+    # Forks have no release tags, so `git describe --tags` yields an empty version and the pack step
+    # fails with MSB4044. Fall back to a placeholder so this is runnable on a fork; upstream, where
+    # the tags exist, it resolves to the real version exactly as before. This job runs on Windows,
+    # so the step is PowerShell rather than the bash form used in dotnet.yml.
+    - name: Determine package version
+      shell: pwsh
+      run: |
+        $version = git describe --tags 2>$null
+        if ([string]::IsNullOrWhiteSpace($version)) { $version = '0.0.1-fork' }
+        "PACKAGE_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+        $LASTEXITCODE = 0
     - name: Build nuget packages
-      run: dotnet pack Mapsui.slnx --configuration Release /p:Version=$(git describe --tags) -o Artifacts
+      run: dotnet pack Mapsui.slnx --configuration Release /p:Version=$env:PACKAGE_VERSION -o Artifacts
     - name: Cleanup
       run: git clean -fx -d -e Artifacts
     # Change Project References to nuget package references in samples    
     - name: nuget ProjectReferences to PackageReferences
       shell: pwsh
       run: |
-       ./Scripts/SamplesMapsuiNugetReferences.ps1 $(git describe --tags)       
+       ./Scripts/SamplesMapsuiNugetReferences.ps1 $env:PACKAGE_VERSION
     - name: Restore dependencies (dotnet)
       run: dotnet restore Mapsui.slnx  
     # Samples Build 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -93,8 +93,13 @@ jobs:
     - name: Run Mapsui.Rendering.Skia.Tests
       run: dotnet test Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net9.0/Mapsui.Rendering.Skia.Tests.dll --blame-hang-timeout:60s
     # Release Build
+    # Forks have no release tags, so `git describe --tags` yields an empty version and the pack
+    # steps fail with MSB4044. Fall back to a placeholder so CI is green on forks; upstream, where
+    # the tags exist, this resolves to the real version exactly as before.
+    - name: Determine package version
+      run: echo "PACKAGE_VERSION=$(git describe --tags 2>/dev/null || echo 0.0.1-fork)" >> $GITHUB_ENV
     - name: Build Linux packages
-      run: dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=$(git describe --tags) Mapsui.Linux.slnf --output Artifacts
+      run: dotnet pack /p:RestorePackages=true /p:Configuration=Release /p:Version=$PACKAGE_VERSION Mapsui.Linux.slnf --output Artifacts
     - name: Upload packages
       uses: actions/upload-artifact@v4
       with:
@@ -161,26 +166,31 @@ jobs:
     - name: Run Mapsui.Rendering.Skia.Tests
       run: dotnet test Tests/Mapsui.Rendering.Skia.Tests/bin/Debug/net9.0/Mapsui.Rendering.Skia.Tests.dll --blame-hang-timeout:60s
     # Release Build
+    # Forks have no release tags, so `git describe --tags` yields an empty version and the pack
+    # steps fail with MSB4044. Fall back to a placeholder so CI is green on forks; upstream, where
+    # the tags exist, this resolves to the real version exactly as before.
+    - name: Determine package version
+      run: echo "PACKAGE_VERSION=$(git describe --tags 2>/dev/null || echo 0.0.1-fork)" >> $GITHUB_ENV
     - name: Build Mapsui
-      run: dotnet pack --no-restore --configuration Release Mapsui/Mapsui.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui/Mapsui.csproj -o Artifacts -p:PackageVersion=$PACKAGE_VERSION
     - name: Build Mapsui.Rendering.Skia
-      run: dotnet pack --no-restore --configuration Release Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Rendering.Skia/Mapsui.Rendering.Skia.csproj -o Artifacts -p:PackageVersion=$PACKAGE_VERSION
     - name: Build Mapsui.Tiling
-      run: dotnet pack --no-restore --configuration Release Mapsui.Tiling/Mapsui.Tiling.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Tiling/Mapsui.Tiling.csproj -o Artifacts -p:PackageVersion=$PACKAGE_VERSION
     - name: Build Mapsui.Nts
-      run: dotnet pack --no-restore --configuration Release Mapsui.Nts/Mapsui.Nts.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Nts/Mapsui.Nts.csproj -o Artifacts -p:PackageVersion=$PACKAGE_VERSION
     - name: Build Mapsui.ArcGIS
-      run: dotnet pack --no-restore --configuration Release Mapsui.ArcGIS/Mapsui.ArcGIS.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.ArcGIS/Mapsui.ArcGIS.csproj -o Artifacts -p:PackageVersion=$PACKAGE_VERSION
     - name: Build Mapsui.Extensions
-      run: dotnet pack --no-restore --configuration Release Mapsui.Extensions/Mapsui.Extensions.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.Extensions/Mapsui.Extensions.csproj -o Artifacts -p:PackageVersion=$PACKAGE_VERSION
     - name: Build Mapsui.UI.Android
-      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Android/Mapsui.UI.Android.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Android/Mapsui.UI.Android.csproj -o Artifacts -p:PackageVersion=$PACKAGE_VERSION
     - name: Build Mapsui.UI.iOS
-      run: dotnet pack --no-restore --configuration Release Mapsui.UI.iOS/Mapsui.UI.iOS.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.UI.iOS/Mapsui.UI.iOS.csproj -o Artifacts -p:PackageVersion=$PACKAGE_VERSION
     - name: Build Mapsui.UI.Maui
-      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Maui/Mapsui.UI.Maui.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Maui/Mapsui.UI.Maui.csproj -o Artifacts -p:PackageVersion=$PACKAGE_VERSION
     - name: Build Mapsui.UI.Uno.WinUI
-      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj -o Artifacts -p:PackageVersion=$(git describe --tags)
+      run: dotnet pack --no-restore --configuration Release Mapsui.UI.Uno.WinUI/Mapsui.UI.Uno.WinUI.csproj -o Artifacts -p:PackageVersion=$PACKAGE_VERSION
     - name: Upload packages
       uses: actions/upload-artifact@v4
       with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,10 +26,14 @@
     <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
     <MauiVersion>9.0.50</MauiVersion>
     <Maui8Version>8.0.100</Maui8Version>
-    <Avalonia12Version>12.0.2</Avalonia12Version>
-    <!-- Avalonia 12.0.2 requires SkiaSharp 3.119.4-preview.1.1 and HarfBuzzSharp 8.3.1.3 -->
-    <Avalonia12SkiaSharpVersion>3.119.4-preview.1.1</Avalonia12SkiaSharpVersion>
-    <Avalonia12HarfBuzzSharpVersion>8.3.1.3</Avalonia12HarfBuzzSharpVersion>
+    <!-- Last SkiaSharp that still ships net8.0 assets; 3.119.4 and later are net9.0+ only. -->
+    <Maui8SkiaSharpVersion>3.119.2</Maui8SkiaSharpVersion>
+    <Avalonia12Version>12.1.0</Avalonia12Version>
+    <!-- Avalonia 12.1.0 requires SkiaSharp 3.119.4 and HarfBuzzSharp 8.3.1.3, which now match the
+         central versions in Directory.Packages.props. The overrides are kept so a future bump of the
+         central SkiaSharp version does not silently drag Avalonia 12 along with it. -->
+    <Avalonia12SkiaSharpVersion>3.119.4</Avalonia12SkiaSharpVersion>
+    <Avalonia12HarfBuzzSharpVersion>8.3.1.5</Avalonia12HarfBuzzSharpVersion>
     <!-- In Avalonia 12, Avalonia.ReactiveUI was replaced by ReactiveUI.Avalonia -->
     <Avalonia12ReactiveUIVersion>12.0.1</Avalonia12ReactiveUIVersion>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,17 +6,17 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.3.1" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.3.1" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.1" />
-    <PackageVersion Include="Avalonia.Browser" Version="11.3.1" />
-    <PackageVersion Include="Avalonia.Android" Version="11.3.1" />
-    <PackageVersion Include="Avalonia.iOS" Version="11.3.1" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.1" />
-    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.3.1" />
+    <PackageVersion Include="Avalonia" Version="11.3.9" />
+    <PackageVersion Include="Avalonia.Skia" Version="11.3.9" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.9" />
+    <PackageVersion Include="Avalonia.Browser" Version="11.3.9" />
+    <PackageVersion Include="Avalonia.Android" Version="11.3.9" />
+    <PackageVersion Include="Avalonia.iOS" Version="11.3.9" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.9" />
+    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.3.9" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.1" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.9" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.9" />
     <PackageVersion Include="BenchmarkDotNet" Version="[0.13.9,1.0.0)" />
     <PackageVersion Include="BitMiracle.LibTiff.NET" Version="2.4.660" />
     <PackageVersion Include="BruTile" Version="[6.0.0,7.0)" />
@@ -33,8 +33,8 @@
     <PackageVersion Include="Eto.Platform.XamMac2" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.Platform.Gtk" Version="[2.8.0,3.0.0)" />
     <PackageVersion Include="Eto.SkiaDraw" Version="[0.2.0,0.3.0)" />
-    <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.3" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.3" />
+    <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.5" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.5" />
     <PackageVersion Include="IDisposableAnalyzers" Version="[4.0.8,5.0.0)" />
     <PackageVersion Include="Mapsui.Android" Version="5.0.0-beta.8" />
     <PackageVersion Include="Mapsui.ArcGIS" Version="5.0.0-beta.8" />
@@ -65,20 +65,19 @@
     <PackageVersion Include="NetTopologySuite.IO.VectorTiles.Mapbox" Version="1.1.0" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageVersion Include="SkiaSharp" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.Skottie" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.Views" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.Views.Uno" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.Views.WinUI" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.Views.WPF" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.Skottie" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.Views" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.Views.WinUI" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.Views.WPF" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.Views.WindowsForms" Version="3.119.4" />
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
 	<PackageVersion Include="SourceGear.sqlite3" Version="3.50.4.2" />

--- a/Mapsui.Experimental.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/MapRenderer.cs
@@ -30,6 +30,7 @@ namespace Mapsui.Experimental.Rendering.Skia;
 /// </summary>
 public sealed class MapRenderer : IMapRenderer
 {
+    private static readonly SKSamplingOptions _defaultSamplingOptions = new(SKFilterMode.Linear, SKMipmapMode.None);
     private static readonly Dictionary<Type, ISkiaWidgetRenderer> _widgetRenderers = [];
     private static readonly Dictionary<Type, IStyleRenderer> _styleRenderers = [];
 
@@ -124,7 +125,7 @@ public sealed class MapRenderer : IMapRenderer
 
         surface.SKSurface.Canvas.Flush();
         using var snapshot = surface.SKSurface.Snapshot();
-        targetCanvas.DrawImage(snapshot, 0, 0);
+        targetCanvas.DrawImage(snapshot, 0, 0, _defaultSamplingOptions);
     }
 
     // Threshold above which a "partial" update is treated as a full update to avoid the overhead

--- a/Mapsui.Experimental.Rendering.Skia/MapRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/MapRenderer.cs
@@ -30,7 +30,6 @@ namespace Mapsui.Experimental.Rendering.Skia;
 /// </summary>
 public sealed class MapRenderer : IMapRenderer
 {
-    private static readonly SKSamplingOptions _defaultSamplingOptions = new(SKFilterMode.Linear, SKMipmapMode.None);
     private static readonly Dictionary<Type, ISkiaWidgetRenderer> _widgetRenderers = [];
     private static readonly Dictionary<Type, IStyleRenderer> _styleRenderers = [];
 
@@ -125,7 +124,7 @@ public sealed class MapRenderer : IMapRenderer
 
         surface.SKSurface.Canvas.Flush();
         using var snapshot = surface.SKSurface.Snapshot();
-        targetCanvas.DrawImage(snapshot, 0, 0, _defaultSamplingOptions);
+        targetCanvas.DrawImage(snapshot, 0, 0, SKSamplingOptions.Default);
     }
 
     // Threshold above which a "partial" update is treated as a full update to avoid the overhead

--- a/Mapsui.Experimental.Rendering.Skia/Mapsui.Experimental.Rendering.Skia.csproj
+++ b/Mapsui.Experimental.Rendering.Skia/Mapsui.Experimental.Rendering.Skia.csproj
@@ -7,7 +7,7 @@
 		<IsPackable>true</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- For experimental projects suppress: A stable release of a package should not have a prerelease dependency. -->
-    <NoWarn>NU5104</NoWarn>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Mapsui.Experimental.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
@@ -13,7 +13,6 @@ namespace Mapsui.Experimental.Rendering.Skia;
 
 public class CalloutStyleRenderer : ISkiaStyleRenderer
 {
-    private static readonly SKSamplingOptions _defaultSamplingOptions = new(SKFilterMode.Linear, SKMipmapMode.None);
     public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, Styles.IStyle style,
         Mapsui.Rendering.RenderService renderService, long iteration)
     {
@@ -96,7 +95,7 @@ public class CalloutStyleRenderer : ISkiaStyleRenderer
             using var canvas = recorder.BeginRecording(new SKRect(0, 0, image.Width, image.Height));
             using var paint = new SKPaint();
             if (image is BitmapDrawableImage bitmapImage)
-                canvas.DrawImage(bitmapImage.Image, 0, 0, _defaultSamplingOptions, paint);
+                canvas.DrawImage(bitmapImage.Image, 0, 0, SKSamplingOptions.Default, paint);
             else if (image is SvgDrawableImage svgImage)
                 canvas.DrawPicture(svgImage.Picture, paint);
             return recorder.EndRecording();

--- a/Mapsui.Experimental.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
@@ -13,6 +13,7 @@ namespace Mapsui.Experimental.Rendering.Skia;
 
 public class CalloutStyleRenderer : ISkiaStyleRenderer
 {
+    private static readonly SKSamplingOptions _defaultSamplingOptions = new(SKFilterMode.Linear, SKMipmapMode.None);
     public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, Styles.IStyle style,
         Mapsui.Rendering.RenderService renderService, long iteration)
     {
@@ -95,7 +96,7 @@ public class CalloutStyleRenderer : ISkiaStyleRenderer
             using var canvas = recorder.BeginRecording(new SKRect(0, 0, image.Width, image.Height));
             using var paint = new SKPaint();
             if (image is BitmapDrawableImage bitmapImage)
-                canvas.DrawImage(bitmapImage.Image, 0, 0, paint);
+                canvas.DrawImage(bitmapImage.Image, 0, 0, _defaultSamplingOptions, paint);
             else if (image is SvgDrawableImage svgImage)
                 canvas.DrawPicture(svgImage.Picture, paint);
             return recorder.EndRecording();

--- a/Mapsui.Experimental.Rendering.Skia/SkiaStyles/SymbolStyleRenderer.cs
+++ b/Mapsui.Experimental.Rendering.Skia/SkiaStyles/SymbolStyleRenderer.cs
@@ -73,7 +73,7 @@ public class SymbolStyleRenderer : ISkiaStyleRenderer, IFeatureSize
                 TrianglePath(skPath, 0, 0, width);
                 break;
             default: // Invalid value
-                throw new ArgumentException($"Unknown {nameof(SymbolType)} '{nameof(symbolType)}'");
+                throw new ArgumentException($"Unknown {nameof(SymbolType)} '{symbolType}'");
         }
 
         return skPath;

--- a/Mapsui.Experimental.VectorTiles/Mapsui.Experimental.VectorTiles.csproj
+++ b/Mapsui.Experimental.VectorTiles/Mapsui.Experimental.VectorTiles.csproj
@@ -7,8 +7,9 @@
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- For experimental projects suppress: A stable release of a package should not have a prerelease dependency. -->
-    <NoWarn>NU5104</NoWarn>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Mapsui.Experimental.VectorTiles/Rendering/VexTileRenderer.cs
+++ b/Mapsui.Experimental.VectorTiles/Rendering/VexTileRenderer.cs
@@ -111,10 +111,16 @@ public static class VexTileRenderer
 
         foreach (var tileLayer in vectorTile.Layers)
         {
-            if (!categorizedVectorLayers.TryGetValue(tileLayer.Name, out var layerList))
+            // A layer without a name can never be matched against a style layer, and indexing the
+            // dictionary with null would throw.
+            var layerName = tileLayer.Name;
+            if (layerName is null)
+                continue;
+
+            if (!categorizedVectorLayers.TryGetValue(layerName, out var layerList))
             {
                 layerList = new List<VectorTileLayer>();
-                categorizedVectorLayers[tileLayer.Name] = layerList;
+                categorizedVectorLayers[layerName] = layerList;
             }
             layerList.Add(tileLayer);
         }
@@ -147,9 +153,14 @@ public static class VexTileRenderer
                         {
                             attributes.Clear();
                             foreach (var kvp in feature.Attributes)
-                                attributes[kvp.Key] = kvp.Value;
-                            attributes["$type"] = feature.GeometryType;
-                            attributes["$id"] = layer.ID;
+                            {
+                                // The attribute dictionary the style filters read from does not
+                                // accept nulls; a missing key and a null value mean the same here.
+                                if (kvp.Value is not null)
+                                    attributes[kvp.Key] = kvp.Value;
+                            }
+                            attributes["$type"] = feature.GeometryType ?? string.Empty;
+                            attributes["$id"] = layer.ID ?? string.Empty;
                             attributes["$zoom"] = actualZoom;
 
                             if (style.ValidateLayer(layer, actualZoom, attributes))
@@ -168,7 +179,7 @@ public static class VexTileRenderer
                                     VectorTileFeature = feature,
                                     Geometry = feature.Geometry,
                                     Brush = brush,
-                                    LayerId = layer.ID,
+                                    LayerId = layer.ID ?? string.Empty,
                                     SourceName = layer.SourceName,
                                     SourceLayer = layer.SourceLayer,
                                     InsertionOrder = visualLayers.Count,
@@ -272,7 +283,8 @@ public static class VexTileRenderer
             }
             else if (layer.Type == VisualLayerType.Raster)
             {
-                canvas.DrawImage(layer.RasterData, layer.Brush);
+                if (layer.RasterData is not null)
+                    canvas.DrawImage(layer.RasterData, layer.Brush);
             }
         }
 

--- a/Mapsui.Experimental.VectorTiles/VexTileCopies/.editorconfig
+++ b/Mapsui.Experimental.VectorTiles/VexTileCopies/.editorconfig
@@ -1,0 +1,19 @@
+# Vendored copies of upstream VexTile (https://github.com/bertt/VexTile).
+#
+# These files are deliberately kept as close to upstream as possible so they can be re-synced,
+# so their pre-existing nullable-reference debt is not treated as an error here. The project
+# enables TreatWarningsAsErrors, and Mapsui's own code in this project is held to that full bar -
+# this relaxation applies only to the vendored files in this folder.
+#
+# Note: this is scoped via .editorconfig rather than <NoWarn> because NoWarn is an assembly-level
+# compiler switch and cannot be applied to a subset of files.
+
+[*.cs]
+dotnet_diagnostic.CS8600.severity = none  # Converting null literal or possible null value to non-nullable type
+dotnet_diagnostic.CS8601.severity = none  # Possible null reference assignment
+dotnet_diagnostic.CS8602.severity = none  # Dereference of a possibly null reference
+dotnet_diagnostic.CS8603.severity = none  # Possible null reference return
+dotnet_diagnostic.CS8604.severity = none  # Possible null reference argument
+dotnet_diagnostic.CS8605.severity = none  # Unboxing a possibly null value
+dotnet_diagnostic.CS8618.severity = none  # Non-nullable field must contain a non-null value when exiting constructor
+dotnet_diagnostic.CS8625.severity = none  # Cannot convert null literal to non-nullable reference type

--- a/Mapsui.Experimental.VectorTiles/VexTileCopies/SkiaCanvas.cs
+++ b/Mapsui.Experimental.VectorTiles/VexTileCopies/SkiaCanvas.cs
@@ -530,13 +530,17 @@ public sealed class SkiaCanvas : ICanvas, IDisposable
     private static SKTypeface QualifyTypeface(Brush style, SKTypeface typeface)
     {
         // CountGlyphs returns an int directly — no array allocation needed.
-        int glyphCount = typeface.CountGlyphs(style.Text);
+        // Called on SKFont rather than SKTypeface: SkiaSharp 4 obsoletes SKTypeface.CountGlyphs,
+        // and SKFont.CountGlyphs exists in both 3.x and 4.x, so this stays valid on either major.
+        using var font = new SKFont(typeface);
+        int glyphCount = font.CountGlyphs(style.Text);
         if (glyphCount >= style.Text.Length)
             return typeface;
 
         SKFontManager sKFontManager = SKFontManager.Default;
         using var fallbackTypeface = sKFontManager.MatchCharacter(style.Text[glyphCount]);
-        int fallbackGlyphCount = fallbackTypeface.CountGlyphs(style.Text);
+        using var fallbackFont = new SKFont(fallbackTypeface);
+        int fallbackGlyphCount = fallbackFont.CountGlyphs(style.Text);
         if (fallbackGlyphCount < style.Text.Length)
             style.Text = style.Text[..fallbackGlyphCount];
         return typeface;

--- a/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
@@ -13,7 +13,6 @@ namespace Mapsui.Rendering.Skia;
 
 public class CalloutStyleRenderer : ISkiaStyleRenderer
 {
-    private static readonly SKSamplingOptions _defaultSamplingOptions = new(SKFilterMode.Linear, SKMipmapMode.None);
     public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, Styles.IStyle style,
         RenderService renderService, long iteration)
     {
@@ -94,7 +93,7 @@ public class CalloutStyleRenderer : ISkiaStyleRenderer
             using var canvas = recorder.BeginRecording(new SKRect(0, 0, image.Width, image.Height));
             using var paint = new SKPaint();
             if (image is BitmapDrawableImage bitmapImage)
-                canvas.DrawImage(bitmapImage.Image, 0, 0, _defaultSamplingOptions, paint);
+                canvas.DrawImage(bitmapImage.Image, 0, 0, SKSamplingOptions.Default, paint);
             else if (image is SvgDrawableImage svgImage)
                 canvas.DrawPicture(svgImage.Picture, paint);
             return recorder.EndRecording();

--- a/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/CalloutStyleRenderer.cs
@@ -13,6 +13,7 @@ namespace Mapsui.Rendering.Skia;
 
 public class CalloutStyleRenderer : ISkiaStyleRenderer
 {
+    private static readonly SKSamplingOptions _defaultSamplingOptions = new(SKFilterMode.Linear, SKMipmapMode.None);
     public bool Draw(SKCanvas canvas, Viewport viewport, ILayer layer, IFeature feature, Styles.IStyle style,
         RenderService renderService, long iteration)
     {
@@ -93,7 +94,7 @@ public class CalloutStyleRenderer : ISkiaStyleRenderer
             using var canvas = recorder.BeginRecording(new SKRect(0, 0, image.Width, image.Height));
             using var paint = new SKPaint();
             if (image is BitmapDrawableImage bitmapImage)
-                canvas.DrawImage(bitmapImage.Image, 0, 0, paint);
+                canvas.DrawImage(bitmapImage.Image, 0, 0, _defaultSamplingOptions, paint);
             else if (image is SvgDrawableImage svgImage)
                 canvas.DrawPicture(svgImage.Picture, paint);
             return recorder.EndRecording();

--- a/Mapsui.Rendering.Skia/SkiaStyles/SymbolStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/SkiaStyles/SymbolStyleRenderer.cs
@@ -74,7 +74,7 @@ public class SymbolStyleRenderer : ISkiaStyleRenderer, IFeatureSize
                 TrianglePath(skPath, 0, 0, width);
                 break;
             default: // Invalid value
-                throw new ArgumentException($"Unknown {nameof(SymbolType)} '{nameof(symbolType)}'");
+                throw new ArgumentException($"Unknown {nameof(SymbolType)} '{symbolType}'");
         }
 
         return skPath;

--- a/Mapsui.UI.Android/Mapsui.UI.Android.csproj
+++ b/Mapsui.UI.Android/Mapsui.UI.Android.csproj
@@ -4,7 +4,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworks>net8.0-android;net9.0-android</TargetFrameworks>    
+    <TargetFrameworks>net9.0-android</TargetFrameworks>    
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>Mapsui.Android</PackageId>

--- a/Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj
+++ b/Mapsui.UI.Blazor/Mapsui.UI.Blazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <Import Project="Mapsui.Blazor.targets" />
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
 	  <ImplicitUsings>enable</ImplicitUsings>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <DefineConstants>__BLAZOR__</DefineConstants>

--- a/Mapsui.UI.Maui8/Mapsui.UI.Maui8.csproj
+++ b/Mapsui.UI.Maui8/Mapsui.UI.Maui8.csproj
@@ -45,8 +45,16 @@
   </ItemGroup>
  
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls" />
+    <!-- SkiaSharp dropped its net8.0 assets in 3.119.4, so this net8.0-only head stays on 3.119.2,
+         the last version that still ships them. Both are assembly version 3.119.0.0, so the shared
+         Mapsui.Rendering.Skia binary (built against the central version) loads against either. -->
+    <PackageReference Include="SkiaSharp" VersionOverride="$(Maui8SkiaSharpVersion)" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls" VersionOverride="$(Maui8SkiaSharpVersion)" />
+    <!-- Pulled in transitively by SkiaSharp.Views.Maui.Controls. Central package transitive pinning
+         would otherwise force it to the central version, which has no net8.0 assets. Only the
+         android head actually resolves a platform asset for it. -->
+    <PackageReference Include="SkiaSharp.Views" VersionOverride="$(Maui8SkiaSharpVersion)"
+                      Condition="$(TargetFramework.Contains('android'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
+++ b/Mapsui.UI.WinUI/Mapsui.UI.WinUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net9.0-windows10.0.19041.0</TargetFrameworks>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <RootNamespace>Mapsui.UI.WinUI</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>

--- a/Mapsui.UI.WindowsForms/Mapsui.UI.WindowsForms.csproj
+++ b/Mapsui.UI.WindowsForms/Mapsui.UI.WindowsForms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-windows;net9.0-windows</TargetFrameworks>
+    <TargetFrameworks>net9.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Mapsui.UI.Wpf/Mapsui.UI.Wpf.csproj
+++ b/Mapsui.UI.Wpf/Mapsui.UI.Wpf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-windows;net9.0-windows</TargetFrameworks>
+    <TargetFrameworks>net9.0-windows</TargetFrameworks>
     <UseWpf>true</UseWpf>
     <PackageId>Mapsui.Wpf</PackageId>
     <Description>WPF map components based on the Mapsui library</Description>

--- a/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
+++ b/Samples/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI/Mapsui.Samples.WinUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;arm64</Platforms>

--- a/Samples/Mapsui.Samples.WindowsForms/Mapsui.Samples.WindowsForms.csproj
+++ b/Samples/Mapsui.Samples.WindowsForms/Mapsui.Samples.WindowsForms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Tests/Mapsui.Tests/Layers/RasterizingLayerTests.cs
+++ b/Tests/Mapsui.Tests/Layers/RasterizingLayerTests.cs
@@ -11,6 +11,7 @@ using Mapsui.Rendering.Skia;
 using Mapsui.Tiling.Extensions;
 using NetTopologySuite.Geometries;
 using NUnit.Framework;
+using SkiaSharp;
 
 namespace Mapsui.Tests.Layers;
 
@@ -45,7 +46,28 @@ public class RasterizingLayerTests
         Assert.That(features.Count(), Is.EqualTo(1));
         Assert.That(features.First(), Is.TypeOf<RasterFeature>());
         var rasterFeature = features.OfType<RasterFeature>().First();
-        Assert.That(rasterFeature.Raster!.Data.Length, Is.EqualTo(5354));
+
+        // Assert on the decoded image rather than on the length of the encoded bytes. The encoded
+        // size depends on the PNG encoder shipped with the current Skia build, so it changes on a
+        // SkiaSharp upgrade even though nothing is wrong with the rendering.
+        using var bitmap = SKBitmap.Decode(rasterFeature.Raster!.Data);
+        Assert.That(bitmap, Is.Not.Null, "The raster data could not be decoded as an image.");
+        Assert.Multiple(() =>
+        {
+            Assert.That(bitmap.Width, Is.EqualTo(256));
+            Assert.That(bitmap.Height, Is.EqualTo(256));
+        });
+        Assert.That(CountDrawnPixels(bitmap), Is.GreaterThan(0), "The rasterized tile is empty.");
+    }
+
+    private static int CountDrawnPixels(SKBitmap bitmap)
+    {
+        var count = 0;
+        for (var x = 0; x < bitmap.Width; x++)
+            for (var y = 0; y < bitmap.Height; y++)
+                if (bitmap.GetPixel(x, y).Alpha != 0)
+                    count++;
+        return count;
     }
 
     private static Layer CreatePointLayer()


### PR DESCRIPTION
Relates to #3376.

## Approach

Mapsui can't adopt SkiaSharp 4 yet: **no Avalonia release supports it**. The 11.x line is on SkiaSharp 2.88.x, the whole 12.x line on 3.119.4, and [AvaloniaUI/Avalonia#21696](https://github.com/AvaloniaUI/Avalonia/issues/21696) is open, unassigned and unanswered.

So rather than upgrade, this makes Mapsui **loadable on either major**. `Mapsui.Rendering.Skia` is built against SkiaSharp 3.119.4 using only APIs present in both 3.x and 4.x, so it binds to `SkiaSharp 3.119.0.0` and .NET rolls that reference forward when a consumer supplies SkiaSharp 4. Anyone needing SkiaSharp 4 for another component can reference it directly today, and the eventual v4 adoption becomes a mechanical follow-up once Avalonia lands.

Concretely that means keeping the `SKPath` mutators rather than moving to `SKPathBuilder`, which exists in no 3.x release. Two changes are safe now because they exist in 3.x and are the non-obsolete form in 4.x: the `DrawImage` overloads taking `SKSamplingOptions`, and `SKFont.CountGlyphs` instead of `SKTypeface.CountGlyphs`.

**Verified, not assumed:** SkiaSharp 4.150.1 — managed *and* native — swapped into the built test output and the suites re-run. All rendering and core tests pass with the renderer still compiled against 3.x.

## Changes

- SkiaSharp `3.119.2` → `3.119.4`; HarfBuzzSharp `8.3.1.3` → `8.3.1.5` (required by `SkiaSharp.HarfBuzz 3.119.4`)
- Avalonia 12 off its prerelease Skia dependency: `12.0.2` → `12.1.0`, which wants stable `3.119.4` rather than `3.119.4-preview.1.1`
- Avalonia 11 `11.3.1` → `11.3.9` — not `11.3.18`, because `Avalonia.ReactiveUI` stops at `11.3.9`; this keeps all Avalonia 11 packages in lockstep
- **net8.0 dropped from the UI heads.** Not a v4 requirement — `SkiaSharp.Views.*` drops its net8.0 assets at **3.119.4**, so any move past 3.119.2 forces it. `Mapsui.UI.Maui8` is net8.0-only and stays on `3.119.2` via `$(Maui8SkiaSharpVersion)`; both share assembly version `3.119.0.0`, so the shared renderer loads against either
- `TreatWarningsAsErrors` for `Mapsui.Experimental.VectorTiles`, with a folder-scoped `.editorconfig` exempting the vendored `VexTileCopies` files. Fixing the nullable warnings in `VexTileRenderer.cs` included **two behaviour changes**: tile layers with a null `Name` are skipped rather than throwing, and null attribute values are no longer inserted into a non-nullable dictionary
- `RasterizingLayerTests` asserted an exact encoded PNG byte length, which shifts whenever the bundled Skia encoder does; it now decodes the raster and asserts dimensions and non-empty content
- Removes the dead `SkiaSharp.Views.Uno` `PackageVersion` (unreferenced; no release above `2.88.9`)
- CI: pack steps fall back to a placeholder version when no tags are reachable, so forks aren't reported as failing purely because of packaging

## Verification

Green on all three legs. The Windows leg runs the full rendering regression suite — **154 tests, 0 failures** — which Linux and macOS silently skip, since those fixtures are `[Apartment(ApartmentState.STA)]`.