### PR TITLE
docs: Update sponsors in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,14 @@ Made with [contrib.rocks](https://contrib.rocks).
 
 Lots of thanks to our sponsors
 
-<a href="https://github.com/jamesmontemagno"><img src="https://avatars.githubusercontent.com/u/1676321?v=4" width="200px;" alt="Sponsor3" /></a>
-<a href="https://github.com/TAlecksen"><img src="https://avatars.githubusercontent.com/u/26470677?v=4" width="200px;" alt="Sponsor1" /></a>
-<a href="https://github.com/unoplatform"><img src="https://avatars.githubusercontent.com/u/52228309?v=4" width="200px;" alt="Sponsor2" /></a>
+<a href="https://github.com/jamesmontemagno"><img src="https://avatars.githubusercontent.com/u/1676321?v=4" width="200px;" alt="James Montemagno" /></a>
+<a href="https://github.com/TAlecksen"><img src="https://avatars.githubusercontent.com/u/26470677?v=4" width="200px;" alt="Tyler Alecksen" /></a>
+<a href="https://github.com/unoplatform"><img src="https://avatars.githubusercontent.com/u/52228309?v=4" width="200px;" alt="Uno Platform" /></a>
+<a href="https://github.com/Sebastian1989101"><img src="https://avatars.githubusercontent.com/u/25636075?v=4" width="200px;" alt="Sebastian Kruse" /></a>
+<a href="https://github.com/Oblimbo"><img src="https://avatars.githubusercontent.com/u/30815498?v=4" width="200px;" alt="Oblimbo" /></a>
 
 ### Past Sponsors
 <a href="https://github.com/P33tr"><img src="https://avatars.githubusercontent.com/u/44436267?v=4" width="40px;" alt="Sponsor4" /></a>
-<a href="https://github.com/Sebastian1989101"><img src="https://avatars.githubusercontent.com/u/25636075?v=4" width="40px;" alt="Sponsor5" /></a>
 <a href="https://github.com/blwhttngtn"><img src="https://avatars.githubusercontent.com/u/12670350?v=4" width="40px;" alt="Sponsor3" /></a>
 <a href="https://github.com/winkmichael"><img src="https://avatars.githubusercontent.com/u/5185889?v=4" width="40px;" alt="Sponsor5" /></a>
 


### PR DESCRIPTION
## Summary

- recognize the five current Mapsui sponsors in the README
- add Sebastian Kruse and Oblimbo to the current sponsor list
- retain James Montemagno, Tyler Alecksen, and Uno Platform as current sponsors
- remove Sebastian Kruse from the past sponsor list

## Validation

- verified the sponsor links and avatar markup
- ran `git diff --check`